### PR TITLE
chore: Delete trailing slash in user profile links

### DIFF
--- a/src/user.rs
+++ b/src/user.rs
@@ -179,10 +179,11 @@ impl Validatable for PubkyAppUserLink {
             .chars()
             .take(MAX_LINK_TITLE_LENGTH)
             .collect::<String>();
-
+        
         let url = match Url::parse(self.url.trim()) {
             Ok(parsed_url) => {
-                let sanitized_url = parsed_url.to_string();
+                // Avoid trailing slash in authority-based URLs
+                let sanitized_url = parsed_url.to_string().trim_end_matches('/').to_string();
                 sanitized_url
                     .chars()
                     .take(MAX_LINK_URL_LENGTH)
@@ -244,6 +245,8 @@ mod tests {
         );
         assert!(user.links.is_some());
         assert_eq!(user.links.as_ref().unwrap().len(), 2);
+        // Ensure that the root URL does not include a trailing slash
+        assert_eq!(user.links.unwrap()[1].url, "https://alice.dev");
     }
 
     #[test]


### PR DESCRIPTION
User profile __link sanitation__ was getting `https://synonym.to/` instead of `https://synonym.to` after parsing the URL and converting it back to a string. The reason of that was due to how the _Url_ crate normalizes URLs. Specifically, the `Url::parse` function ensures the URL conforms to the URL specification(RFC 3986).

### Trailing Slash for Authority-Based URLs:

URLs with an authority component (like `https://synonym.to`, which has a scheme and a host) are treated as "authority-based URLs". According to the URL specification, an authority-based URL implicitly refers to the root path (/) if no specific path is provided. 
Therefore, `https://synonym.to` was normalized to `https://synonym.to/` because it explicitly added the root path.