### PR TITLE
Fix blob import, improve blob hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,8 +2025,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utoipa"
-version = "5.3.0"
-source = "git+https://github.com/juhaku/utoipa?rev=d522f744259dc4fde5f45d187983fb68c8167029#d522f744259dc4fde5f45d187983fb68c8167029"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435c6f69ef38c9017b4b4eea965dfb91e71e53d869e896db40d1cf2441dd75c0"
 dependencies = [
  "indexmap",
  "serde",
@@ -2036,8 +2037,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "5.3.0"
-source = "git+https://github.com/juhaku/utoipa?rev=d522f744259dc4fde5f45d187983fb68c8167029#d522f744259dc4fde5f45d187983fb68c8167029"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77d306bc75294fd52f3e99b13ece67c02c1a2789190a6f31d32f736624326f7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/pkg/package.json
+++ b/pkg/package.json
@@ -2,7 +2,7 @@
   "name": "pubky-app-specs",
   "type": "module",
   "description": "Pubky.app Data Model Specifications",
-  "version": "0.3.0-rc6",
+  "version": "0.3.0-rc7",
   "license": "MIT",
   "collaborators": [
     "SHAcollision"

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -267,10 +267,10 @@ mod tests {
 
     #[test]
     fn test_import_blob() {
-        let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/blobs/8FACA7A6XMYH0GD9KBXMQ373PR";
+        let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/blobs/CDW1T5RM4PHP64QT0P6RE4PNT0";
         // For a blob, assume the JSON is an array of numbers representing the data.
-        let blob_json = r#"[1,2,3,4]"#;
-        let result = PubkyAppObject::from_uri(uri, blob_json.as_bytes());
+        let blob: Vec<u8> = vec![1, 2, 3, 4];
+        let result = PubkyAppObject::from_uri(uri, &blob);
         assert!(
             result.is_ok(),
             "Expected a successful import for blob, got error: {:?}",


### PR DESCRIPTION
This PR changes the way Blob hash ids is computed. Must be updated at the same time in app and Nexus for validation to work in both sides.