### PR TITLE
Propagate use of URI, path builders

### DIFF
--- a/examples/create_user.rs
+++ b/examples/create_user.rs
@@ -10,10 +10,7 @@ use {
     anyhow::Result,
     pubky::Client,
     pubky::{Keypair, PublicKey},
-    pubky_app_specs::{
-        traits::{HasPath, Validatable},
-        PubkyAppUser, PROTOCOL,
-    },
+    pubky_app_specs::{traits::Validatable, user_uri_builder, PubkyAppUser},
     serde_json::to_vec,
 };
 // Replace this with your actual homeserver public key
@@ -71,12 +68,7 @@ async fn main() -> Result<()> {
     // Step 5: Write the user profile to the homeserver
     println!("\nStep 5: Writing the user profile to the homeserver...");
 
-    let url = format!(
-        "{protocol}{pubky_id}{path}",
-        protocol = PROTOCOL,
-        pubky_id = user_id,
-        path = PubkyAppUser::create_path()
-    );
+    let url = user_uri_builder(user_id);
     let content = to_vec(&user_profile)?;
 
     client

--- a/examples/create_user.rs
+++ b/examples/create_user.rs
@@ -75,7 +75,7 @@ async fn main() -> Result<()> {
         "{protocol}{pubky_id}{path}",
         protocol = PROTOCOL,
         pubky_id = user_id,
-        path = user_profile.create_path()
+        path = PubkyAppUser::create_path()
     );
     let content = to_vec(&user_profile)?;
 

--- a/src/models/blob.rs
+++ b/src/models/blob.rs
@@ -76,7 +76,7 @@ impl HashId for PubkyAppBlob {
 impl HasIdPath for PubkyAppBlob {
     const PATH_SEGMENT: &'static str = "blobs/";
 
-    fn create_path(&self, id: &str) -> String {
+    fn create_path(id: &str) -> String {
         [PUBLIC_PATH, APP_PATH, Self::PATH_SEGMENT, id].concat()
     }
 }

--- a/src/models/blob.rs
+++ b/src/models/blob.rs
@@ -15,8 +15,8 @@ use wasm_bindgen::prelude::*;
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
-/// Represents a file uploaded by the user.
-/// URI: /pub/pubky.app/files/:file_id
+/// Represents a blob, which backs a file uploaded by the user.
+/// URI: /pub/pubky.app/blobs/:blob_id
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 #[derive(Deserialize, Serialize, Debug, Default, Clone)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]

--- a/src/models/bookmark.rs
+++ b/src/models/bookmark.rs
@@ -72,7 +72,7 @@ impl HashId for PubkyAppBookmark {
 impl HasIdPath for PubkyAppBookmark {
     const PATH_SEGMENT: &'static str = "bookmarks/";
 
-    fn create_path(&self, id: &str) -> String {
+    fn create_path(id: &str) -> String {
         [PUBLIC_PATH, APP_PATH, Self::PATH_SEGMENT, id].concat()
     }
 }
@@ -112,7 +112,7 @@ mod tests {
         };
         let expected_id = bookmark.create_id();
         let expected_path = format!("{}{}bookmarks/{}", PUBLIC_PATH, APP_PATH, expected_id);
-        let path = bookmark.create_path(&expected_id);
+        let path = PubkyAppBookmark::create_path(&expected_id);
         assert_eq!(path, expected_path);
     }
 

--- a/src/models/bookmark.rs
+++ b/src/models/bookmark.rs
@@ -96,13 +96,12 @@ mod tests {
     #[test]
     fn test_create_bookmark_id() {
         let bookmark = PubkyAppBookmark {
-            // TODO Valid post URI?
-            uri: "user_id/pub/pubky.app/posts/post_id".to_string(),
+            uri: post_uri_builder("user_id".into(), "post_id".into()),
             created_at: 1627849723,
         };
 
         let bookmark_id = bookmark.create_id();
-        assert_eq!(bookmark_id, "AF7KQ6NEV5XV1EG5DVJ2E74JJ4");
+        assert_eq!(bookmark_id, "2GN0JCHX9NYXPECQDS8KSMSE7M");
     }
 
     #[test]
@@ -129,8 +128,8 @@ mod tests {
 
     #[test]
     fn test_validate_invalid_id() {
-        // TODO Valid post URI?
-        let bookmark = PubkyAppBookmark::new("user_id/pub/pubky.app/posts/post_id".to_string());
+        let post_uri = post_uri_builder("user_id".into(), "post_id".into());
+        let bookmark = PubkyAppBookmark::new(post_uri);
         let invalid_id = "INVALIDID";
         let result = bookmark.validate(Some(invalid_id));
         assert!(result.is_err());
@@ -145,8 +144,7 @@ mod tests {
         }
         "#;
 
-        // TODO Valid post URI?
-        let uri = "user_id/pub/pubky.app/posts/post_id".to_string();
+        let uri = post_uri_builder("user_id".into(), "post_id".into());
         let bookmark = PubkyAppBookmark::new(uri.clone());
         let id = bookmark.create_id();
 

--- a/src/models/bookmark.rs
+++ b/src/models/bookmark.rs
@@ -91,11 +91,12 @@ impl Validatable for PubkyAppBookmark {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::traits::Validatable;
+    use crate::{post_uri_builder, traits::Validatable};
 
     #[test]
     fn test_create_bookmark_id() {
         let bookmark = PubkyAppBookmark {
+            // TODO Valid post URI?
             uri: "user_id/pub/pubky.app/posts/post_id".to_string(),
             created_at: 1627849723,
         };
@@ -106,8 +107,9 @@ mod tests {
 
     #[test]
     fn test_create_path() {
+        let post_uri = post_uri_builder("user_id".into(), "post_id".into());
         let bookmark = PubkyAppBookmark {
-            uri: "pubky://user_id/pub/pubky.app/posts/post_id".to_string(),
+            uri: post_uri,
             created_at: 1627849723,
         };
         let expected_id = bookmark.create_id();
@@ -118,8 +120,8 @@ mod tests {
 
     #[test]
     fn test_validate_valid() {
-        let bookmark =
-            PubkyAppBookmark::new("pubky://user_id/pub/pubky.app/posts/post_id".to_string());
+        let post_uri = post_uri_builder("user_id".into(), "post_id".into());
+        let bookmark = PubkyAppBookmark::new(post_uri);
         let id = bookmark.create_id();
         let result = bookmark.validate(Some(&id));
         assert!(result.is_ok());
@@ -127,6 +129,7 @@ mod tests {
 
     #[test]
     fn test_validate_invalid_id() {
+        // TODO Valid post URI?
         let bookmark = PubkyAppBookmark::new("user_id/pub/pubky.app/posts/post_id".to_string());
         let invalid_id = "INVALIDID";
         let result = bookmark.validate(Some(invalid_id));
@@ -142,6 +145,7 @@ mod tests {
         }
         "#;
 
+        // TODO Valid post URI?
         let uri = "user_id/pub/pubky.app/posts/post_id".to_string();
         let bookmark = PubkyAppBookmark::new(uri.clone());
         let id = bookmark.create_id();

--- a/src/models/feed.rs
+++ b/src/models/feed.rs
@@ -197,7 +197,7 @@ impl HashId for PubkyAppFeed {
 impl HasIdPath for PubkyAppFeed {
     const PATH_SEGMENT: &'static str = "feeds/";
 
-    fn create_path(&self, id: &str) -> String {
+    fn create_path(id: &str) -> String {
         [PUBLIC_PATH, APP_PATH, Self::PATH_SEGMENT, id].concat()
     }
 }

--- a/src/models/file.rs
+++ b/src/models/file.rs
@@ -185,13 +185,13 @@ impl Validatable for PubkyAppFile {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::traits::Validatable;
+    use crate::{blob_uri_builder, traits::Validatable};
 
     #[test]
     fn test_new() {
         let file = PubkyAppFile::new(
             "example.png".to_string(),
-            "pubky://user_id/pub/pubky.app/blobs/id".to_string(),
+            blob_uri_builder("user_id".into(), "id".into()),
             "image/png".to_string(),
             1024,
         );
@@ -208,7 +208,7 @@ mod tests {
     fn test_create_path() {
         let file = PubkyAppFile::new(
             "example.png".to_string(),
-            "pubky://user_id/pub/pubky.app/blobs/id".to_string(),
+            blob_uri_builder("user_id".into(), "id".into()),
             "image/png".to_string(),
             1024,
         );
@@ -227,7 +227,7 @@ mod tests {
     fn test_validate_valid() {
         let file = PubkyAppFile::new(
             "example.png".to_string(),
-            "pubky://user_id/pub/pubky.app/blobs/id".to_string(),
+            blob_uri_builder("user_id".into(), "id".into()),
             "image/png".to_string(),
             1024,
         );
@@ -240,7 +240,7 @@ mod tests {
     fn test_validate_invalid_id() {
         let file = PubkyAppFile::new(
             "example.png".to_string(),
-            "pubky://user_id/pub/pubky.app/blobs/id".to_string(),
+            blob_uri_builder("user_id".into(), "id".into()),
             "image/png".to_string(),
             1024,
         );
@@ -253,7 +253,7 @@ mod tests {
     fn test_validate_invalid_content_type() {
         let file = PubkyAppFile::new(
             "example.png".to_string(),
-            "pubky://user_id/pub/pubky.app/blobs/id".to_string(),
+            blob_uri_builder("user_id".into(), "id".into()),
             "notavalid/content_type".to_string(),
             1024,
         );
@@ -266,7 +266,7 @@ mod tests {
     fn test_validate_invalid_size() {
         let file = PubkyAppFile::new(
             "example.png".to_string(),
-            "pubky://user_id/pub/pubky.app/blobs/id".to_string(),
+            blob_uri_builder("user_id".into(), "id".into()),
             "notavalid/content_type".to_string(),
             MAX_SIZE + 1,
         );
@@ -302,7 +302,7 @@ mod tests {
 
         let file = PubkyAppFile::new(
             "example.png".to_string(),
-            "pubky://user_id/pub/pubky.app/blobs/id".to_string(),
+            blob_uri_builder("user_id".into(), "id".into()),
             "image/png".to_string(),
             1024,
         );

--- a/src/models/file.rs
+++ b/src/models/file.rs
@@ -109,7 +109,7 @@ impl TimestampId for PubkyAppFile {}
 impl HasIdPath for PubkyAppFile {
     const PATH_SEGMENT: &'static str = "files/";
 
-    fn create_path(&self, id: &str) -> String {
+    fn create_path(id: &str) -> String {
         [PUBLIC_PATH, APP_PATH, Self::PATH_SEGMENT, id].concat()
     }
 }
@@ -213,7 +213,7 @@ mod tests {
             1024,
         );
         let file_id = file.create_id();
-        let path = file.create_path(&file_id);
+        let path = PubkyAppFile::create_path(&file_id);
 
         // Check if the path starts with the expected prefix
         let prefix = format!("{}{}files/", PUBLIC_PATH, APP_PATH);

--- a/src/models/follow.rs
+++ b/src/models/follow.rs
@@ -72,7 +72,7 @@ impl Validatable for PubkyAppFollow {
 impl HasIdPath for PubkyAppFollow {
     const PATH_SEGMENT: &'static str = "follows/";
 
-    fn create_path(&self, pubky_id: &str) -> String {
+    fn create_path(pubky_id: &str) -> String {
         [PUBLIC_PATH, APP_PATH, Self::PATH_SEGMENT, pubky_id].concat()
     }
 }
@@ -93,8 +93,7 @@ mod tests {
 
     #[test]
     fn test_create_path_with_id() {
-        let mute = PubkyAppFollow::new();
-        let path = mute.create_path("user_id123");
+        let path = PubkyAppFollow::create_path("user_id123");
         assert_eq!(path, "/pub/pubky.app/follows/user_id123");
     }
 

--- a/src/models/last_read.rs
+++ b/src/models/last_read.rs
@@ -60,7 +60,7 @@ impl Validatable for PubkyAppLastRead {
 impl HasPath for PubkyAppLastRead {
     const PATH_SEGMENT: &'static str = "last_read";
 
-    fn create_path(&self) -> String {
+    fn create_path() -> String {
         [PUBLIC_PATH, APP_PATH, Self::PATH_SEGMENT].concat()
     }
 }
@@ -80,8 +80,7 @@ mod tests {
 
     #[test]
     fn test_create_path() {
-        let last_read = PubkyAppLastRead::new();
-        let path = last_read.create_path();
+        let path = PubkyAppLastRead::create_path();
         assert_eq!(path, format!("{}{}last_read", PUBLIC_PATH, APP_PATH));
     }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -92,6 +92,8 @@ impl PubkyAppObject {
 
 #[cfg(test)]
 mod tests {
+    use crate::user_uri_builder;
+
     use super::*;
 
     // These tests assume that the respective try_from implementations for each model
@@ -99,7 +101,7 @@ mod tests {
 
     #[test]
     fn test_import_user() {
-        let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/profile.json";
+        let uri = user_uri_builder("operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into());
         let user_json = r#"{
             "name": "Alice",
             "bio": "Hello, I am Alice",
@@ -107,7 +109,7 @@ mod tests {
             "links": null,
             "status": "active"
         }"#;
-        let result = PubkyAppObject::from_uri(uri, user_json.as_bytes());
+        let result = PubkyAppObject::from_uri(&uri, user_json.as_bytes());
         assert!(
             result.is_ok(),
             "Expected a successful import for user, got error: {:?}",

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -92,7 +92,7 @@ impl PubkyAppObject {
 
 #[cfg(test)]
 mod tests {
-    use crate::{follow_uri_builder, post_uri_builder, user_uri_builder};
+    use crate::{follow_uri_builder, mute_uri_builder, post_uri_builder, user_uri_builder};
 
     use super::*;
 
@@ -180,11 +180,14 @@ mod tests {
 
     #[test]
     fn test_import_mute() {
-        let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/mutes/pxnu33x7jtpx9ar1ytsi4yxbp6a5o36gwhffs8zoxmbuptici1jy";
+        let uri = mute_uri_builder(
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+            "pxnu33x7jtpx9ar1ytsi4yxbp6a5o36gwhffs8zoxmbuptici1jy".into(),
+        );
         let mute_json = r#"{
             "created_at": 1627849724
         }"#;
-        let result = PubkyAppObject::from_uri(uri, mute_json.as_bytes());
+        let result = PubkyAppObject::from_uri(&uri, mute_json.as_bytes());
         assert!(
             result.is_ok(),
             "Expected a successful import for mute, got error: {:?}",

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -320,7 +320,10 @@ mod tests {
 
     #[test]
     fn test_import_feed() {
-        let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/feeds/5F2NDB2HJGJ2HJBY6MPQ0H5R0G";
+        let uri = feed_uri_builder(
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+            "5F2NDB2HJGJ2HJBY6MPQ0H5R0G".into(),
+        );
         let feed_json = r#"{
             "feed": {
                 "tags": [],

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -34,8 +34,8 @@ pub enum PubkyAppObject {
 impl PubkyAppObject {
     /// Given a URI and a blob (raw data from the homeserver),
     /// this function returns the fully formed PubkyAppObject.
-    pub fn from_uri(uri: &str, blob: &[u8]) -> Result<Self, String> {
-        let parsed_uri = ParsedUri::try_from(uri)?;
+    pub fn from_uri<S: AsRef<str>>(uri: S, blob: &[u8]) -> Result<Self, String> {
+        let parsed_uri = ParsedUri::try_from(uri.as_ref())?;
         Self::from_resource(&parsed_uri.resource, blob)
     }
 
@@ -109,7 +109,7 @@ mod tests {
             "links": null,
             "status": "active"
         }"#;
-        let result = PubkyAppObject::from_uri(&uri, user_json.as_bytes());
+        let result = PubkyAppObject::from_uri(uri, user_json.as_bytes());
         assert!(
             result.is_ok(),
             "Expected a successful import for user, got error: {:?}",
@@ -141,7 +141,7 @@ mod tests {
             "embed": null,
             "attachments": null
         }"#;
-        let result = PubkyAppObject::from_uri(uri.as_str(), post_json.as_bytes());
+        let result = PubkyAppObject::from_uri(uri, post_json.as_bytes());
         assert!(
             result.is_ok(),
             "Expected a successful import for post, got error: {:?}",
@@ -164,7 +164,7 @@ mod tests {
         let follow_json = r#"{
             "created_at": 1627849723
         }"#;
-        let result = PubkyAppObject::from_uri(&uri, follow_json.as_bytes());
+        let result = PubkyAppObject::from_uri(uri, follow_json.as_bytes());
         assert!(
             result.is_ok(),
             "Expected a successful import for follow, got error: {:?}",
@@ -187,7 +187,7 @@ mod tests {
         let mute_json = r#"{
             "created_at": 1627849724
         }"#;
-        let result = PubkyAppObject::from_uri(&uri, mute_json.as_bytes());
+        let result = PubkyAppObject::from_uri(uri, mute_json.as_bytes());
         assert!(
             result.is_ok(),
             "Expected a successful import for mute, got error: {:?}",
@@ -218,7 +218,7 @@ mod tests {
                 "created_at": 1627849725
             }}"#
         );
-        let result = PubkyAppObject::from_uri(&uri, bookmark_json.as_bytes());
+        let result = PubkyAppObject::from_uri(uri, bookmark_json.as_bytes());
         assert!(
             result.is_ok(),
             "Expected a successful import for bookmark, got error: {:?}",
@@ -250,7 +250,7 @@ mod tests {
             "created_at": 1627849726
         }}"#
         );
-        let result = PubkyAppObject::from_uri(&uri, tag_json.as_bytes());
+        let result = PubkyAppObject::from_uri(uri, tag_json.as_bytes());
         assert!(
             result.is_ok(),
             "Expected a successful import for tag, got error: {:?}",
@@ -277,7 +277,7 @@ mod tests {
             "content_type": "image/png",
             "size": 1024
         }"#;
-        let result = PubkyAppObject::from_uri(uri.as_str(), file_json.as_bytes());
+        let result = PubkyAppObject::from_uri(uri, file_json.as_bytes());
         assert!(
             result.is_ok(),
             "Expected a successful import for file, got error: {:?}",

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -266,7 +266,10 @@ mod tests {
 
     #[test]
     fn test_import_file() {
-        let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/files/0032SSN7Q4EVG";
+        let uri = file_uri_builder(
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+            "0032SSN7Q4EVG".into(),
+        );
         let file_json = r#"{
             "name": "example.png",
             "created_at": 1627849727,
@@ -274,7 +277,7 @@ mod tests {
             "content_type": "image/png",
             "size": 1024
         }"#;
-        let result = PubkyAppObject::from_uri(uri, file_json.as_bytes());
+        let result = PubkyAppObject::from_uri(uri.as_str(), file_json.as_bytes());
         assert!(
             result.is_ok(),
             "Expected a successful import for file, got error: {:?}",

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -92,7 +92,7 @@ impl PubkyAppObject {
 
 #[cfg(test)]
 mod tests {
-    use crate::user_uri_builder;
+    use crate::{post_uri_builder, user_uri_builder};
 
     use super::*;
 
@@ -130,7 +130,10 @@ mod tests {
 
     #[test]
     fn test_import_post() {
-        let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/posts/0032SSN7Q4EVG";
+        let uri = post_uri_builder(
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+            "0032SSN7Q4EVG".into(),
+        );
         let post_json = r#"{
             "content": "Hello World!",
             "kind": "short",
@@ -138,7 +141,7 @@ mod tests {
             "embed": null,
             "attachments": null
         }"#;
-        let result = PubkyAppObject::from_uri(uri, post_json.as_bytes());
+        let result = PubkyAppObject::from_uri(uri.as_str(), post_json.as_bytes());
         assert!(
             result.is_ok(),
             "Expected a successful import for post, got error: {:?}",
@@ -194,11 +197,18 @@ mod tests {
 
     #[test]
     fn test_import_bookmark() {
+        let post_uri = post_uri_builder(
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+            "0032SSN7Q4EVG".into(),
+        );
+
         let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/bookmarks/8Z8CWH8NVYQY39ZEBFGKQWWEKG";
-        let bookmark_json = r#"{
-            "uri": "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/posts/0032SSN7Q4EVG",
-            "created_at": 1627849725
-        }"#;
+        let bookmark_json = format!(
+            r#"{{
+                "uri": "{post_uri}",
+                "created_at": 1627849725
+            }}"#
+        );
         let result = PubkyAppObject::from_uri(uri, bookmark_json.as_bytes());
         assert!(
             result.is_ok(),
@@ -207,11 +217,7 @@ mod tests {
         );
         match result.unwrap() {
             PubkyAppObject::Bookmark(bookmark) => {
-                assert_eq!(
-                    bookmark.uri,
-                    "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/posts/0032SSN7Q4EVG",
-                    "Bookmark URI mismatch"
-                );
+                assert_eq!(bookmark.uri, post_uri, "Bookmark URI mismatch");
             }
             other => panic!("Expected a Bookmark object, got {:?}", other),
         }
@@ -219,12 +225,19 @@ mod tests {
 
     #[test]
     fn test_import_tag() {
+        let post_uri = post_uri_builder(
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+            "0032SSN7Q4EVG".into(),
+        );
+
         let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/tags/86805FC1CSFZD4W6HZ09S24QWG";
-        let tag_json = r#"{
-            "uri": "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/posts/0032SSN7Q4EVG",
+        let tag_json = format!(
+            r#"{{
+            "uri": "{post_uri}",
             "label": "cool",
             "created_at": 1627849726
-        }"#;
+        }}"#
+        );
         let result = PubkyAppObject::from_uri(uri, tag_json.as_bytes());
         assert!(
             result.is_ok(),

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -92,7 +92,7 @@ impl PubkyAppObject {
 
 #[cfg(test)]
 mod tests {
-    use crate::{follow_uri_builder, mute_uri_builder, post_uri_builder, user_uri_builder};
+    use crate::utils::*;
 
     use super::*;
 
@@ -208,14 +208,17 @@ mod tests {
             "0032SSN7Q4EVG".into(),
         );
 
-        let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/bookmarks/8Z8CWH8NVYQY39ZEBFGKQWWEKG";
+        let uri = bookmark_uri_builder(
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+            "8Z8CWH8NVYQY39ZEBFGKQWWEKG".into(),
+        );
         let bookmark_json = format!(
             r#"{{
                 "uri": "{post_uri}",
                 "created_at": 1627849725
             }}"#
         );
-        let result = PubkyAppObject::from_uri(uri, bookmark_json.as_bytes());
+        let result = PubkyAppObject::from_uri(&uri, bookmark_json.as_bytes());
         assert!(
             result.is_ok(),
             "Expected a successful import for bookmark, got error: {:?}",

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -297,7 +297,10 @@ mod tests {
 
     #[test]
     fn test_import_blob() {
-        let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/blobs/CDW1T5RM4PHP64QT0P6RE4PNT0";
+        let uri = blob_uri_builder(
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+            "CDW1T5RM4PHP64QT0P6RE4PNT0".into(),
+        );
         // For a blob, assume the JSON is an array of numbers representing the data.
         let blob: Vec<u8> = vec![1, 2, 3, 4];
         let result = PubkyAppObject::from_uri(uri, &blob);

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -92,7 +92,7 @@ impl PubkyAppObject {
 
 #[cfg(test)]
 mod tests {
-    use crate::{post_uri_builder, user_uri_builder};
+    use crate::{follow_uri_builder, post_uri_builder, user_uri_builder};
 
     use super::*;
 
@@ -157,11 +157,14 @@ mod tests {
 
     #[test]
     fn test_import_follow() {
-        let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/follows/pxnu33x7jtpx9ar1ytsi4yxbp6a5o36gwhffs8zoxmbuptici1jy";
+        let uri = follow_uri_builder(
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+            "pxnu33x7jtpx9ar1ytsi4yxbp6a5o36gwhffs8zoxmbuptici1jy".into(),
+        );
         let follow_json = r#"{
             "created_at": 1627849723
         }"#;
-        let result = PubkyAppObject::from_uri(uri, follow_json.as_bytes());
+        let result = PubkyAppObject::from_uri(&uri, follow_json.as_bytes());
         assert!(
             result.is_ok(),
             "Expected a successful import for follow, got error: {:?}",

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -239,7 +239,10 @@ mod tests {
             "0032SSN7Q4EVG".into(),
         );
 
-        let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/tags/86805FC1CSFZD4W6HZ09S24QWG";
+        let uri = tag_uri_builder(
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+            "86805FC1CSFZD4W6HZ09S24QWG".into(),
+        );
         let tag_json = format!(
             r#"{{
             "uri": "{post_uri}",
@@ -247,7 +250,7 @@ mod tests {
             "created_at": 1627849726
         }}"#
         );
-        let result = PubkyAppObject::from_uri(uri, tag_json.as_bytes());
+        let result = PubkyAppObject::from_uri(&uri, tag_json.as_bytes());
         assert!(
             result.is_ok(),
             "Expected a successful import for tag, got error: {:?}",

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -352,7 +352,7 @@ mod tests {
     #[test]
     fn test_import_last_read() {
         let uri =
-            "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/last_read";
+            last_read_uri_builder("operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into());
         let last_read_json = r#"{
             "timestamp": 1627849729
         }"#;

--- a/src/models/mute.rs
+++ b/src/models/mute.rs
@@ -66,7 +66,7 @@ impl Validatable for PubkyAppMute {
 impl HasIdPath for PubkyAppMute {
     const PATH_SEGMENT: &'static str = "mutes/";
 
-    fn create_path(&self, pubky_id: &str) -> String {
+    fn create_path(pubky_id: &str) -> String {
         [PUBLIC_PATH, APP_PATH, Self::PATH_SEGMENT, pubky_id].concat()
     }
 }
@@ -88,8 +88,8 @@ mod tests {
 
     #[test]
     fn test_create_path_with_id() {
-        let mute = PubkyAppMute::new();
-        let path = mute.create_path("operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo");
+        let path =
+            PubkyAppMute::create_path("operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo");
         assert_eq!(
             path,
             "/pub/pubky.app/mutes/operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo"

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -182,7 +182,7 @@ impl TimestampId for PubkyAppPost {}
 impl HasIdPath for PubkyAppPost {
     const PATH_SEGMENT: &'static str = "posts/";
 
-    fn create_path(&self, id: &str) -> String {
+    fn create_path(id: &str) -> String {
         [PUBLIC_PATH, APP_PATH, Self::PATH_SEGMENT, id].concat()
     }
 }
@@ -319,7 +319,7 @@ mod tests {
         );
 
         let post_id = post.create_id();
-        let path = post.create_path(&post_id);
+        let path = PubkyAppPost::create_path(&post_id);
 
         // Check if the path starts with the expected prefix
         let prefix = format!("{}{}posts/", PUBLIC_PATH, APP_PATH);

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -276,7 +276,7 @@ impl Validatable for PubkyAppPost {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{traits::Validatable, PUBLIC_PATH};
+    use crate::{post_path_builder, traits::Validatable, APP_PATH, PUBLIC_PATH};
 
     #[test]
     fn test_create_id() {
@@ -319,7 +319,7 @@ mod tests {
         );
 
         let post_id = post.create_id();
-        let path = PubkyAppPost::create_path(&post_id);
+        let path = post_path_builder(&post_id);
 
         // Check if the path starts with the expected prefix
         let prefix = format!("{}{}posts/", PUBLIC_PATH, APP_PATH);

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -276,7 +276,7 @@ impl Validatable for PubkyAppPost {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{post_path_builder, traits::Validatable, APP_PATH, PUBLIC_PATH};
+    use crate::{traits::Validatable, APP_PATH, PUBLIC_PATH};
 
     #[test]
     fn test_create_id() {
@@ -319,7 +319,7 @@ mod tests {
         );
 
         let post_id = post.create_id();
-        let path = post_path_builder(&post_id);
+        let path = PubkyAppPost::create_path(&post_id);
 
         // Check if the path starts with the expected prefix
         let prefix = format!("{}{}posts/", PUBLIC_PATH, APP_PATH);

--- a/src/models/tag.rs
+++ b/src/models/tag.rs
@@ -30,6 +30,7 @@ use utoipa::ToSchema;
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct PubkyAppTag {
+    /// The resource this is a tag on
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
     pub uri: String,
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
@@ -158,7 +159,7 @@ impl Validatable for PubkyAppTag {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{traits::Validatable, APP_PATH};
+    use crate::{traits::Validatable, user_uri_builder, APP_PATH};
 
     #[test]
     fn test_label_id() {
@@ -290,23 +291,22 @@ mod tests {
 
     #[test]
     fn test_try_from_valid() {
-        let tag_json = r#"
-        {
-            "uri": "pubky://user_pubky_id/pub/pubky.app/profile.json",
-            "label": "Cool Tag",
-            "created_at": 1627849723000
-        }
-        "#;
+        let user_uri = user_uri_builder("user_pubky_id".into());
+        let tag_json = format!(
+            r#"
+            {{
+                "uri": "{user_uri}",
+                "label": "Cool Tag",
+                "created_at": 1627849723000
+            }}
+        "#
+        );
 
-        let id = PubkyAppTag::new(
-            "pubky://user_pubky_id/pub/pubky.app/profile.json".to_string(),
-            "Cool Tag".to_string(),
-        )
-        .create_id();
+        let id = PubkyAppTag::new(user_uri.clone(), "Cool Tag".to_string()).create_id();
 
         let blob = tag_json.as_bytes();
         let tag = <PubkyAppTag as Validatable>::try_from(blob, &id).unwrap();
-        assert_eq!(tag.uri, "pubky://user_pubky_id/pub/pubky.app/profile.json");
+        assert_eq!(tag.uri, user_uri);
         assert_eq!(tag.label, "cooltag"); // After sanitization
     }
 

--- a/src/models/tag.rs
+++ b/src/models/tag.rs
@@ -82,7 +82,7 @@ impl Json for PubkyAppTag {}
 impl HasIdPath for PubkyAppTag {
     const PATH_SEGMENT: &'static str = "tags/";
 
-    fn create_path(&self, id: &str) -> String {
+    fn create_path(id: &str) -> String {
         [PUBLIC_PATH, APP_PATH, Self::PATH_SEGMENT, id].concat()
     }
 }
@@ -227,7 +227,7 @@ mod tests {
 
         let expected_id = tag.create_id();
         let expected_path = format!("{}{}tags/{}", PUBLIC_PATH, APP_PATH, expected_id);
-        let path = tag.create_path(&expected_id);
+        let path = PubkyAppTag::create_path(&expected_id);
 
         assert_eq!(path, expected_path);
     }

--- a/src/models/tag.rs
+++ b/src/models/tag.rs
@@ -159,15 +159,16 @@ impl Validatable for PubkyAppTag {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{traits::Validatable, user_uri_builder, APP_PATH};
+    use crate::{post_uri_builder, traits::Validatable, user_uri_builder, APP_PATH};
 
     #[test]
     fn test_label_id() {
+        let post_uri = post_uri_builder("user_id".into(), "post_id".into());
         // Precomputed earlier
         let tag_id = "CBYS8P6VJPHC5XXT4WDW26662W";
         // Create new tag
         let tag = PubkyAppTag {
-            uri: "pubky://user_id/pub/pubky.app/posts/post_id".to_string(),
+            uri: post_uri.clone(),
             created_at: 1627849723,
             label: "cool".to_string(),
         };
@@ -179,7 +180,7 @@ mod tests {
         assert_eq!(new_tag_id, tag_id);
 
         let wrong_tag = PubkyAppTag {
-            uri: "pubky://user_id/pub/pubky.app/posts/post_id".to_string(),
+            uri: post_uri,
             created_at: 1627849723,
             label: "co0l".to_string(),
         };
@@ -220,8 +221,12 @@ mod tests {
 
     #[test]
     fn test_create_path() {
+        let post_uri = post_uri_builder(
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+            "0032FNCGXE3R0".into(),
+        );
         let tag = PubkyAppTag {
-            uri: "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/posts/0032FNCGXE3R0".to_string(),
+            uri: post_uri,
             created_at: 1627849723000,
             label: "cool".to_string(),
         };
@@ -235,8 +240,9 @@ mod tests {
 
     #[test]
     fn test_sanitize() {
+        let ppst_uri = post_uri_builder("user_id".into(), "0000000000000".into());
         let tag = PubkyAppTag {
-            uri: "pubky://user_id/pub/pubky.app/posts/0000000000000".to_string(),
+            uri: ppst_uri,
             label: "   CoOl  ".to_string(),
             created_at: 1627849723000,
         };
@@ -247,8 +253,9 @@ mod tests {
 
     #[test]
     fn test_validate_valid() {
+        let post_uri = post_uri_builder("user_id".into(), "0000000000000".into());
         let tag = PubkyAppTag {
-            uri: "pubky://user_id/pub/pubky.app/posts/0000000000000".to_string(),
+            uri: post_uri,
             label: "cool".to_string(),
             created_at: 1627849723000,
         };
@@ -260,8 +267,9 @@ mod tests {
 
     #[test]
     fn test_validate_invalid_label_length() {
+        let post_uri = post_uri_builder("user_id".into(), "0000000000000".into());
         let tag = PubkyAppTag {
-            uri: "pubky://user_id/pub/pubky.app/posts/0000000000000".to_string(),
+            uri: post_uri,
             label: "a".repeat(MAX_TAG_LABEL_LENGTH + 1),
             created_at: 1627849723000,
         };
@@ -277,8 +285,9 @@ mod tests {
 
     #[test]
     fn test_validate_invalid_id() {
+        let post_uri = post_uri_builder("user_id".into(), "0000000000000".into());
         let tag = PubkyAppTag {
-            uri: "pubky://user_id/pub/pubky.app/posts/0000000000000".to_string(),
+            uri: post_uri,
             label: "cool".to_string(),
             created_at: 1627849723000,
         };
@@ -333,6 +342,7 @@ mod tests {
     #[test]
     fn test_incorrect_label() {
         let tag = PubkyAppTag {
+            // TODO Valid post URI?
             uri: "user_id/pub/pubky.app/posts/post_id".to_string(),
             created_at: 1627849723,
             label: "cool".to_string(),
@@ -348,7 +358,7 @@ mod tests {
         };
 
         let tag = PubkyAppTag {
-            uri: "pubky://user_id/pub/pubky.app/posts/post_id".to_string(),
+            uri: post_uri_builder("user_id".into(), "post_id".into()),
             created_at: 1627849723,
             label: "coolc00lcolaca0g00llooll".to_string(),
         };
@@ -371,7 +381,7 @@ mod tests {
         let label = "cool";
 
         let leading_whitespace = PubkyAppTag {
-            uri: "pubky://user_id/pub/pubky.app/posts/post_id".to_string(),
+            uri: post_uri_builder("user_id".into(), "post_id".into()),
             created_at: 1627849723,
             label: " cool".to_string(),
         };
@@ -379,7 +389,7 @@ mod tests {
         assert_eq!(sanitazed_label.label, label);
 
         let trailing_whitespace = PubkyAppTag {
-            uri: "pubky://user_id/pub/pubky.app/posts/post_id".to_string(),
+            uri: post_uri_builder("user_id".into(), "post_id".into()),
             created_at: 1627849723,
             label: " cool".to_string(),
         };
@@ -387,7 +397,7 @@ mod tests {
         assert_eq!(sanitazed_label.label, label);
 
         let space_between = PubkyAppTag {
-            uri: "pubky://user_id/pub/pubky.app/posts/post_id".to_string(),
+            uri: post_uri_builder("user_id".into(), "post_id".into()),
             created_at: 1627849723,
             label: "   co ol ".to_string(),
         };

--- a/src/models/tag.rs
+++ b/src/models/tag.rs
@@ -240,9 +240,9 @@ mod tests {
 
     #[test]
     fn test_sanitize() {
-        let ppst_uri = post_uri_builder("user_id".into(), "0000000000000".into());
+        let post_uri = post_uri_builder("user_id".into(), "0000000000000".into());
         let tag = PubkyAppTag {
-            uri: ppst_uri,
+            uri: post_uri,
             label: "   CoOl  ".to_string(),
             created_at: 1627849723000,
         };

--- a/src/models/tag.rs
+++ b/src/models/tag.rs
@@ -342,8 +342,7 @@ mod tests {
     #[test]
     fn test_incorrect_label() {
         let tag = PubkyAppTag {
-            // TODO Valid post URI?
-            uri: "user_id/pub/pubky.app/posts/post_id".to_string(),
+            uri: post_uri_builder("user_id".into(), "post_id".into()),
             created_at: 1627849723,
             label: "cool".to_string(),
         };

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -143,7 +143,7 @@ impl PubkyAppUser {
 impl HasPath for PubkyAppUser {
     const PATH_SEGMENT: &'static str = "profile.json";
 
-    fn create_path(&self) -> String {
+    fn create_path() -> String {
         [PUBLIC_PATH, APP_PATH, Self::PATH_SEGMENT].concat()
     }
 }
@@ -342,8 +342,7 @@ mod tests {
 
     #[test]
     fn test_create_path() {
-        let user = PubkyAppUser::default();
-        let path = user.create_path();
+        let path = PubkyAppUser::create_path();
         assert_eq!(path, format!("{}{}profile.json", PUBLIC_PATH, APP_PATH));
     }
 

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -308,7 +308,7 @@ impl Validatable for PubkyAppUserLink {
 mod tests {
     use super::*;
     use crate::traits::Validatable;
-    use crate::{APP_PATH, PUBLIC_PATH};
+    use crate::{user_path_builder, APP_PATH, PUBLIC_PATH};
 
     #[test]
     fn test_new() {
@@ -342,7 +342,7 @@ mod tests {
 
     #[test]
     fn test_create_path() {
-        let path = PubkyAppUser::create_path();
+        let path = user_path_builder();
         assert_eq!(path, format!("{}{}profile.json", PUBLIC_PATH, APP_PATH));
     }
 

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -308,7 +308,7 @@ impl Validatable for PubkyAppUserLink {
 mod tests {
     use super::*;
     use crate::traits::Validatable;
-    use crate::{user_path_builder, APP_PATH, PUBLIC_PATH};
+    use crate::{APP_PATH, PUBLIC_PATH};
 
     #[test]
     fn test_new() {
@@ -342,7 +342,7 @@ mod tests {
 
     #[test]
     fn test_create_path() {
-        let path = user_path_builder();
+        let path = PubkyAppUser::create_path();
         assert_eq!(path, format!("{}{}profile.json", PUBLIC_PATH, APP_PATH));
     }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -127,7 +127,7 @@ pub trait HasPath {
 
 pub trait HasIdPath {
     const PATH_SEGMENT: &'static str;
-    fn create_path(&self, id: &str) -> String;
+    fn create_path(id: &str) -> String;
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -122,7 +122,7 @@ pub trait Validatable: Sized + DeserializeOwned {
 
 pub trait HasPath {
     const PATH_SEGMENT: &'static str;
-    fn create_path(&self) -> String;
+    fn create_path() -> String;
 }
 
 pub trait HasIdPath {

--- a/src/uri_parser.rs
+++ b/src/uri_parser.rs
@@ -238,7 +238,6 @@ mod tests {
     #[test]
     fn test_valid_follow_uri() {
         // A valid follow URI.
-        // TODO Is this a valid Follow URI, where the author follows themselves?
         let uri = follow_uri_builder(
             "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
             "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),

--- a/src/uri_parser.rs
+++ b/src/uri_parser.rs
@@ -147,6 +147,14 @@ impl TryFrom<&str> for ParsedUri {
     }
 }
 
+impl TryFrom<String> for ParsedUri {
+    type Error = String;
+
+    fn try_from(uri: String) -> Result<Self, Self::Error> {
+        ParsedUri::try_from(uri.as_str())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::utils::*;
@@ -161,7 +169,7 @@ mod tests {
             "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
             "".into(),
         );
-        let parsed_uri = ParsedUri::try_from(uri.as_str()).unwrap_or_default();
+        let parsed_uri = ParsedUri::try_from(uri).unwrap_or_default();
         assert_eq!(
             parsed_uri.resource,
             Resource::Unknown,
@@ -175,7 +183,7 @@ mod tests {
             "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
             "00".into(),
         );
-        let parsed_uri = ParsedUri::try_from(uri.as_str()).unwrap_or_default();
+        let parsed_uri = ParsedUri::try_from(uri).unwrap_or_default();
         assert_eq!(
             parsed_uri.resource,
             Resource::Bookmark("00".to_string()),
@@ -186,7 +194,7 @@ mod tests {
     #[test]
     fn test_user() {
         let uri = user_uri_builder("operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into());
-        let parsed_uri = ParsedUri::try_from(uri.as_str()).unwrap_or_default();
+        let parsed_uri = ParsedUri::try_from(uri).unwrap_or_default();
         assert_eq!(
             parsed_uri.resource,
             Resource::User,
@@ -200,7 +208,7 @@ mod tests {
     fn test_valid_user_uri() {
         // A valid user URI ends with profile.json.
         let uri = user_uri_builder("operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into());
-        let parsed = ParsedUri::try_from(uri.as_str()).expect("Failed to parse valid user URI");
+        let parsed = ParsedUri::try_from(uri).expect("Failed to parse valid user URI");
         assert_eq!(parsed.user_id, PubkyId::try_from(USER_ID).unwrap());
         assert_eq!(parsed.resource, Resource::User);
     }
@@ -222,7 +230,7 @@ mod tests {
             "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
             "0032SSN7Q4EVG".into(),
         );
-        let parsed = ParsedUri::try_from(uri.as_str()).expect("Failed to parse valid post URI");
+        let parsed = ParsedUri::try_from(uri).expect("Failed to parse valid post URI");
         assert_eq!(parsed.user_id, PubkyId::try_from(USER_ID).unwrap());
         assert_eq!(parsed.resource, Resource::Post("0032SSN7Q4EVG".to_string()));
     }
@@ -235,7 +243,7 @@ mod tests {
             "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
             "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
         );
-        let parsed = ParsedUri::try_from(uri.as_str()).expect("Failed to parse valid follow URI");
+        let parsed = ParsedUri::try_from(uri).expect("Failed to parse valid follow URI");
         assert_eq!(parsed.user_id, PubkyId::try_from(USER_ID).unwrap());
         // Assuming PubkyId::try_from("def456") returns a PubkyId that equals PubkyId::try_from("def456")
         assert_eq!(
@@ -251,7 +259,7 @@ mod tests {
             "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
             bookmark_id.into(),
         );
-        let parsed = ParsedUri::try_from(uri.as_str()).expect("Failed to parse valid bookmark URI");
+        let parsed = ParsedUri::try_from(uri).expect("Failed to parse valid bookmark URI");
         assert_eq!(parsed.user_id, PubkyId::try_from(USER_ID).unwrap());
         assert_eq!(parsed.resource, Resource::Bookmark(bookmark_id.to_string()));
     }
@@ -262,7 +270,7 @@ mod tests {
             "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
             "8Z8CWH8NVYQY39ZEBFGKQWWEKG".into(),
         );
-        let parsed = ParsedUri::try_from(uri.as_str()).expect("Failed to parse valid tag URI");
+        let parsed = ParsedUri::try_from(uri).expect("Failed to parse valid tag URI");
         assert_eq!(parsed.user_id, PubkyId::try_from(USER_ID).unwrap());
         assert_eq!(
             parsed.resource,

--- a/src/uri_parser.rs
+++ b/src/uri_parser.rs
@@ -150,6 +150,8 @@ impl TryFrom<&str> for ParsedUri {
 #[cfg(test)]
 mod tests {
 
+    use crate::user_uri_builder;
+
     use super::*;
 
     const USER_ID: &str = "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo";
@@ -180,9 +182,8 @@ mod tests {
 
     #[test]
     fn test_user() {
-        let uri =
-            "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/profile.json";
-        let parsed_uri = ParsedUri::try_from(uri).unwrap_or_default();
+        let uri = user_uri_builder("operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into());
+        let parsed_uri = ParsedUri::try_from(uri.as_str()).unwrap_or_default();
         assert_eq!(
             parsed_uri.resource,
             Resource::User,
@@ -195,8 +196,8 @@ mod tests {
     #[test]
     fn test_valid_user_uri() {
         // A valid user URI ends with profile.json.
-        let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/profile.json";
-        let parsed = ParsedUri::try_from(uri).expect("Failed to parse valid user URI");
+        let uri = user_uri_builder("operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into());
+        let parsed = ParsedUri::try_from(uri.as_str()).expect("Failed to parse valid user URI");
         assert_eq!(parsed.user_id, PubkyId::try_from(USER_ID).unwrap());
         assert_eq!(parsed.resource, Resource::User);
     }

--- a/src/uri_parser.rs
+++ b/src/uri_parser.rs
@@ -291,7 +291,10 @@ mod tests {
 
     #[test]
     fn test_valid_blob_uri() {
-        let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/blobs/8Z8CWH8NVYQY39ZEBFGKQWWEKG";
+        let uri = blob_uri_builder(
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+            "8Z8CWH8NVYQY39ZEBFGKQWWEKG".into(),
+        );
         let parsed = ParsedUri::try_from(uri).expect("Failed to parse valid blob URI");
         assert_eq!(parsed.user_id, PubkyId::try_from(USER_ID).unwrap());
         assert_eq!(

--- a/src/uri_parser.rs
+++ b/src/uri_parser.rs
@@ -150,7 +150,7 @@ impl TryFrom<&str> for ParsedUri {
 #[cfg(test)]
 mod tests {
 
-    use crate::user_uri_builder;
+    use crate::{post_uri_builder, user_uri_builder};
 
     use super::*;
 
@@ -215,8 +215,11 @@ mod tests {
     #[test]
     fn test_valid_post_uri() {
         // A valid post URI includes the posts/ segment followed by an identifier.
-        let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/posts/0032SSN7Q4EVG";
-        let parsed = ParsedUri::try_from(uri).expect("Failed to parse valid post URI");
+        let uri = post_uri_builder(
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+            "0032SSN7Q4EVG".into(),
+        );
+        let parsed = ParsedUri::try_from(uri.as_str()).expect("Failed to parse valid post URI");
         assert_eq!(parsed.user_id, PubkyId::try_from(USER_ID).unwrap());
         assert_eq!(parsed.resource, Resource::Post("0032SSN7Q4EVG".to_string()));
     }

--- a/src/uri_parser.rs
+++ b/src/uri_parser.rs
@@ -150,7 +150,7 @@ impl TryFrom<&str> for ParsedUri {
 #[cfg(test)]
 mod tests {
 
-    use crate::{post_uri_builder, user_uri_builder};
+    use crate::{follow_uri_builder, post_uri_builder, user_uri_builder};
 
     use super::*;
 
@@ -227,8 +227,12 @@ mod tests {
     #[test]
     fn test_valid_follow_uri() {
         // A valid follow URI.
-        let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/follows/operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo";
-        let parsed = ParsedUri::try_from(uri).expect("Failed to parse valid follow URI");
+        // TODO Is this a valid Follow URI, where the author follows themselves?
+        let uri = follow_uri_builder(
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+        );
+        let parsed = ParsedUri::try_from(uri.as_str()).expect("Failed to parse valid follow URI");
         assert_eq!(parsed.user_id, PubkyId::try_from(USER_ID).unwrap());
         // Assuming PubkyId::try_from("def456") returns a PubkyId that equals PubkyId::try_from("def456")
         assert_eq!(

--- a/src/uri_parser.rs
+++ b/src/uri_parser.rs
@@ -258,8 +258,11 @@ mod tests {
 
     #[test]
     fn test_valid_tag_uri() {
-        let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/tags/8Z8CWH8NVYQY39ZEBFGKQWWEKG";
-        let parsed = ParsedUri::try_from(uri).expect("Failed to parse valid tag URI");
+        let uri = tag_uri_builder(
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+            "8Z8CWH8NVYQY39ZEBFGKQWWEKG".into(),
+        );
+        let parsed = ParsedUri::try_from(uri.as_str()).expect("Failed to parse valid tag URI");
         assert_eq!(parsed.user_id, PubkyId::try_from(USER_ID).unwrap());
         assert_eq!(
             parsed.resource,

--- a/src/uri_parser.rs
+++ b/src/uri_parser.rs
@@ -280,7 +280,10 @@ mod tests {
 
     #[test]
     fn test_valid_file_uri() {
-        let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/files/file003";
+        let uri = file_uri_builder(
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+            "file003".into(),
+        );
         let parsed = ParsedUri::try_from(uri).expect("Failed to parse valid file URI");
         assert_eq!(parsed.user_id, PubkyId::try_from(USER_ID).unwrap());
         assert_eq!(parsed.resource, Resource::File("file003".to_string()));

--- a/src/uri_parser.rs
+++ b/src/uri_parser.rs
@@ -217,7 +217,7 @@ mod tests {
     fn test_valid_last_read_uri() {
         // A valid last_read URI ends with last_read.
         let uri =
-            "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/last_read";
+            last_read_uri_builder("operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into());
         let parsed = ParsedUri::try_from(uri).expect("Failed to parse valid last_read URI");
         assert_eq!(parsed.user_id, PubkyId::try_from(USER_ID).unwrap());
         assert_eq!(parsed.resource, Resource::LastRead);

--- a/src/uri_parser.rs
+++ b/src/uri_parser.rs
@@ -149,8 +149,7 @@ impl TryFrom<&str> for ParsedUri {
 
 #[cfg(test)]
 mod tests {
-
-    use crate::{follow_uri_builder, post_uri_builder, user_uri_builder};
+    use crate::utils::*;
 
     use super::*;
 
@@ -158,9 +157,11 @@ mod tests {
 
     #[test]
     fn test_empty_bookmark_uri() {
-        let uri =
-            "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/bookmarks/";
-        let parsed_uri = ParsedUri::try_from(uri).unwrap_or_default();
+        let uri = bookmark_uri_builder(
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+            "".into(),
+        );
+        let parsed_uri = ParsedUri::try_from(uri.as_str()).unwrap_or_default();
         assert_eq!(
             parsed_uri.resource,
             Resource::Unknown,
@@ -170,9 +171,11 @@ mod tests {
 
     #[test]
     fn test_some_bookmark_uri() {
-        let uri =
-            "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/bookmarks/00";
-        let parsed_uri = ParsedUri::try_from(uri).unwrap_or_default();
+        let uri = bookmark_uri_builder(
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+            "00".into(),
+        );
+        let parsed_uri = ParsedUri::try_from(uri.as_str()).unwrap_or_default();
         assert_eq!(
             parsed_uri.resource,
             Resource::Bookmark("00".to_string()),
@@ -243,13 +246,14 @@ mod tests {
 
     #[test]
     fn test_valid_bookmark_uri() {
-        let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/bookmarks/8Z8CWH8NVYQY39ZEBFGKQWWEKG";
-        let parsed = ParsedUri::try_from(uri).expect("Failed to parse valid bookmark URI");
-        assert_eq!(parsed.user_id, PubkyId::try_from(USER_ID).unwrap());
-        assert_eq!(
-            parsed.resource,
-            Resource::Bookmark("8Z8CWH8NVYQY39ZEBFGKQWWEKG".to_string())
+        let bookmark_id = "8Z8CWH8NVYQY39ZEBFGKQWWEKG";
+        let uri = bookmark_uri_builder(
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+            bookmark_id.into(),
         );
+        let parsed = ParsedUri::try_from(uri.as_str()).expect("Failed to parse valid bookmark URI");
+        assert_eq!(parsed.user_id, PubkyId::try_from(USER_ID).unwrap());
+        assert_eq!(parsed.resource, Resource::Bookmark(bookmark_id.to_string()));
     }
 
     #[test]

--- a/src/uri_parser.rs
+++ b/src/uri_parser.rs
@@ -305,7 +305,10 @@ mod tests {
 
     #[test]
     fn test_valid_feed_uri() {
-        let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/feeds/8Z8CWH8NVYQY39ZEBFGKQWWEKG";
+        let uri = feed_uri_builder(
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+            "8Z8CWH8NVYQY39ZEBFGKQWWEKG".into(),
+        );
         let parsed = ParsedUri::try_from(uri).expect("Failed to parse valid feed URI");
         assert_eq!(parsed.user_id, PubkyId::try_from(USER_ID).unwrap());
         assert_eq!(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,8 @@
 use crate::{
     common::*,
     traits::{HasIdPath, HasPath},
-    PubkyAppBookmark, PubkyAppFollow, PubkyAppMute, PubkyAppPost, PubkyAppTag, PubkyAppUser,
+    PubkyAppBookmark, PubkyAppFile, PubkyAppFollow, PubkyAppMute, PubkyAppPost, PubkyAppTag,
+    PubkyAppUser,
 };
 
 #[cfg(target_arch = "wasm32")]
@@ -88,4 +89,17 @@ pub fn tag_path_builder(id: &str) -> String {
 pub fn tag_uri_builder(author_id: String, tag_id: String) -> String {
     let tag_path = tag_path_builder(&tag_id);
     [PROTOCOL, &author_id, &tag_path].concat()
+}
+
+/// Builds a File Path of the form "/pub/pubky.app/files/<file_id>"
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = filePathBuilder))]
+pub fn file_path_builder(id: &str) -> String {
+    PubkyAppFile::create_path(id)
+}
+
+/// Builds a File URI of the form "pubky://<author_id>/pub/pubky.app/files/<file_id>"
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fileUriBuilder))]
+pub fn file_uri_builder(author_id: String, file_id: String) -> String {
+    let file_path = file_path_builder(&file_id);
+    [PROTOCOL, &author_id, &file_path].concat()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::*,
     traits::{HasIdPath, HasPath},
-    PubkyAppFollow, PubkyAppMute, PubkyAppPost, PubkyAppUser,
+    PubkyAppBookmark, PubkyAppFollow, PubkyAppMute, PubkyAppPost, PubkyAppUser,
 };
 
 #[cfg(target_arch = "wasm32")]
@@ -62,4 +62,17 @@ pub fn mute_path_builder(id: &str) -> String {
 pub fn mute_uri_builder(author_id: String, mute_id: String) -> String {
     let mute_path = mute_path_builder(&mute_id);
     [PROTOCOL, &author_id, &mute_path].concat()
+}
+
+/// Builds a Bookmark Path of the form "/pub/pubky.app/bookmarks/<bookmark_id>"
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = bookmarkPathBuilder))]
+pub fn bookmark_path_builder(id: &str) -> String {
+    PubkyAppBookmark::create_path(id)
+}
+
+/// Builds a Bookmark URI of the form "pubky://<author_id>/pub/pubky.app/bookmarks/<bookmark_id>"
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = bookmarkUriBuilder))]
+pub fn bookmark_uri_builder(author_id: String, bookmark_id: String) -> String {
+    let bookmark_path = bookmark_path_builder(&bookmark_id);
+    [PROTOCOL, &author_id, &bookmark_path].concat()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,8 @@
 use crate::{
     common::*,
     traits::{HasIdPath, HasPath},
-    PubkyAppBlob, PubkyAppBookmark, PubkyAppFile, PubkyAppFollow, PubkyAppMute, PubkyAppPost,
-    PubkyAppTag, PubkyAppUser,
+    PubkyAppBlob, PubkyAppBookmark, PubkyAppFeed, PubkyAppFile, PubkyAppFollow, PubkyAppMute,
+    PubkyAppPost, PubkyAppTag, PubkyAppUser,
 };
 
 #[cfg(target_arch = "wasm32")]
@@ -115,4 +115,17 @@ pub fn blob_path_builder(id: &str) -> String {
 pub fn blob_uri_builder(author_id: String, blob_id: String) -> String {
     let blob_path = blob_path_builder(&blob_id);
     [PROTOCOL, &author_id, &blob_path].concat()
+}
+
+/// Builds a Feed Path of the form "/pub/pubky.app/feeds/<feed_id>"
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = feedPathBuilder))]
+pub fn feed_path_builder(id: &str) -> String {
+    PubkyAppFeed::create_path(id)
+}
+
+/// Builds a Feed URI of the form "pubky://<author_id>/pub/pubky.app/feeds/<feed_id>"
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = feedUriBuilder))]
+pub fn feed_uri_builder(author_id: String, feed_id: String) -> String {
+    let feed_path = feed_path_builder(&feed_id);
+    [PROTOCOL, &author_id, &feed_path].concat()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,8 @@
 use crate::{
     common::*,
     traits::{HasIdPath, HasPath},
-    PubkyAppBookmark, PubkyAppFile, PubkyAppFollow, PubkyAppMute, PubkyAppPost, PubkyAppTag,
-    PubkyAppUser,
+    PubkyAppBlob, PubkyAppBookmark, PubkyAppFile, PubkyAppFollow, PubkyAppMute, PubkyAppPost,
+    PubkyAppTag, PubkyAppUser,
 };
 
 #[cfg(target_arch = "wasm32")]
@@ -102,4 +102,17 @@ pub fn file_path_builder(id: &str) -> String {
 pub fn file_uri_builder(author_id: String, file_id: String) -> String {
     let file_path = file_path_builder(&file_id);
     [PROTOCOL, &author_id, &file_path].concat()
+}
+
+/// Builds a Blob Path of the form "/pub/pubky.app/blobs/<blob_id>"
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = blobPathBuilder))]
+pub fn blob_path_builder(id: &str) -> String {
+    PubkyAppBlob::create_path(id)
+}
+
+/// Builds a Blob URI of the form "pubky://<author_id>/pub/pubky.app/blobs/<blob_id>"
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = blobUriBuilder))]
+pub fn blob_uri_builder(author_id: String, blob_id: String) -> String {
+    let blob_path = blob_path_builder(&blob_id);
+    [PROTOCOL, &author_id, &blob_path].concat()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::*,
     traits::{HasIdPath, HasPath},
-    PubkyAppPost, PubkyAppUser,
+    PubkyAppFollow, PubkyAppPost, PubkyAppUser,
 };
 
 #[cfg(target_arch = "wasm32")]
@@ -36,4 +36,17 @@ pub fn post_path_builder(id: &str) -> String {
 pub fn post_uri_builder(author_id: String, post_id: String) -> String {
     let post_path = post_path_builder(&post_id);
     [PROTOCOL, &author_id, &post_path].concat()
+}
+
+/// Builds a Follow Path of the form "/pub/pubky.app/follows/<follow_id>"
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = followPathBuilder))]
+pub fn follow_path_builder(id: &str) -> String {
+    PubkyAppFollow::create_path(id)
+}
+
+/// Builds a Follow URI of the form "pubky://<author_id>/pub/pubky.app/follows/<follow_id>"
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = followUriBuilder))]
+pub fn follow_uri_builder(author_id: String, follow_id: String) -> String {
+    let follow_path = follow_path_builder(&follow_id);
+    [PROTOCOL, &author_id, &follow_path].concat()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,8 @@
-use crate::{common::*, traits::HasPath, PubkyAppUser};
+use crate::{
+    common::*,
+    traits::{HasIdPath, HasPath},
+    PubkyAppPost, PubkyAppUser,
+};
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
@@ -11,13 +15,13 @@ pub fn base_uri_builder(user_id: String) -> String {
 /// Builds an User URI of the form "pubky://<user_pubky_id>/pub/pubky.app/profile.json"
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = userUriBuilder))]
 pub fn user_uri_builder(user_id: String) -> String {
-    format!("{}{}{}", PROTOCOL, user_id, PubkyAppUser::create_path())
+    let user_path = PubkyAppUser::create_path();
+    format!("{PROTOCOL}{user_id}{user_path}")
 }
 
+/// Builds a Post URI of the form "pubky://<author_id>/pub/pubky.app/posts/<post_id>"
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = postUriBuilder))]
 pub fn post_uri_builder(author_id: String, post_id: String) -> String {
-    format!(
-        "{}{}{}{}posts/{}",
-        PROTOCOL, author_id, PUBLIC_PATH, APP_PATH, post_id
-    )
+    let post_path = PubkyAppPost::create_path(&post_id);
+    format!("{PROTOCOL}{author_id}{post_path}")
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -129,3 +129,16 @@ pub fn feed_uri_builder(author_id: String, feed_id: String) -> String {
     let feed_path = feed_path_builder(&feed_id);
     [PROTOCOL, &author_id, &feed_path].concat()
 }
+
+/// Builds a LastRead Path of the form "/pub/pubky.app/last_read"
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = lastReadPathBuilder))]
+pub fn last_read_path_builder() -> String {
+    [PUBLIC_PATH, APP_PATH, "last_read"].concat()
+}
+
+/// Builds a LastRead URI of the form "pubky://<author_id>/pub/pubky.app/last_read"
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = lastReadUriBuilder))]
+pub fn last_read_uri_builder(author_id: String) -> String {
+    let last_read_path = last_read_path_builder();
+    [PROTOCOL, &author_id, &last_read_path].concat()
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -12,16 +12,28 @@ pub fn base_uri_builder(user_id: String) -> String {
     format!("{}{}{}{}", PROTOCOL, user_id, PUBLIC_PATH, APP_PATH)
 }
 
+/// Builds an User Path of the form "/pub/pubky.app/profile.json"
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = userPathBuilder))]
+pub fn user_path_builder() -> String {
+    PubkyAppUser::create_path()
+}
+
 /// Builds an User URI of the form "pubky://<user_pubky_id>/pub/pubky.app/profile.json"
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = userUriBuilder))]
 pub fn user_uri_builder(user_id: String) -> String {
-    let user_path = PubkyAppUser::create_path();
-    format!("{PROTOCOL}{user_id}{user_path}")
+    let user_path = user_path_builder();
+    [PROTOCOL, &user_id, &user_path].concat()
+}
+
+/// Builds a Post Path of the form "/pub/pubky.app/posts/<post_id>"
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = postPathBuilder))]
+pub fn post_path_builder(id: &str) -> String {
+    PubkyAppPost::create_path(id)
 }
 
 /// Builds a Post URI of the form "pubky://<author_id>/pub/pubky.app/posts/<post_id>"
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = postUriBuilder))]
 pub fn post_uri_builder(author_id: String, post_id: String) -> String {
-    let post_path = PubkyAppPost::create_path(&post_id);
-    format!("{PROTOCOL}{author_id}{post_path}")
+    let post_path = post_path_builder(&post_id);
+    [PROTOCOL, &author_id, &post_path].concat()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use crate::common::*;
+use crate::{common::*, traits::HasPath, PubkyAppUser};
 
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
@@ -8,12 +8,10 @@ pub fn base_uri_builder(user_id: String) -> String {
     format!("{}{}{}{}", PROTOCOL, user_id, PUBLIC_PATH, APP_PATH)
 }
 
+/// Builds an User URI of the form "pubky://<user_pubky_id>/pub/pubky.app/profile.json"
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = userUriBuilder))]
 pub fn user_uri_builder(user_id: String) -> String {
-    format!(
-        "{}{}{}{}profile.json",
-        PROTOCOL, user_id, PUBLIC_PATH, APP_PATH
-    )
+    format!("{}{}{}", PROTOCOL, user_id, PubkyAppUser::create_path())
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = postUriBuilder))]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,132 +13,72 @@ pub fn base_uri_builder(user_id: String) -> String {
     format!("{}{}{}{}", PROTOCOL, user_id, PUBLIC_PATH, APP_PATH)
 }
 
-/// Builds an User Path of the form "/pub/pubky.app/profile.json"
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = userPathBuilder))]
-pub fn user_path_builder() -> String {
-    PubkyAppUser::create_path()
-}
-
 /// Builds an User URI of the form "pubky://<user_pubky_id>/pub/pubky.app/profile.json"
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = userUriBuilder))]
 pub fn user_uri_builder(user_id: String) -> String {
-    let user_path = user_path_builder();
+    let user_path = PubkyAppUser::create_path();
     [PROTOCOL, &user_id, &user_path].concat()
-}
-
-/// Builds a Post Path of the form "/pub/pubky.app/posts/<post_id>"
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = postPathBuilder))]
-pub fn post_path_builder(id: &str) -> String {
-    PubkyAppPost::create_path(id)
 }
 
 /// Builds a Post URI of the form "pubky://<author_id>/pub/pubky.app/posts/<post_id>"
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = postUriBuilder))]
 pub fn post_uri_builder(author_id: String, post_id: String) -> String {
-    let post_path = post_path_builder(&post_id);
+    let post_path = PubkyAppPost::create_path(&post_id);
     [PROTOCOL, &author_id, &post_path].concat()
-}
-
-/// Builds a Follow Path of the form "/pub/pubky.app/follows/<follow_id>"
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = followPathBuilder))]
-pub fn follow_path_builder(id: &str) -> String {
-    PubkyAppFollow::create_path(id)
 }
 
 /// Builds a Follow URI of the form "pubky://<author_id>/pub/pubky.app/follows/<follow_id>"
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = followUriBuilder))]
 pub fn follow_uri_builder(author_id: String, follow_id: String) -> String {
-    let follow_path = follow_path_builder(&follow_id);
+    let follow_path = PubkyAppFollow::create_path(&follow_id);
     [PROTOCOL, &author_id, &follow_path].concat()
-}
-
-/// Builds a Mute Path of the form "/pub/pubky.app/mutes/<mute_id>"
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = mutePathBuilder))]
-pub fn mute_path_builder(id: &str) -> String {
-    PubkyAppMute::create_path(id)
 }
 
 /// Builds a Mute URI of the form "pubky://<author_id>/pub/pubky.app/mutes/<mute_id>"
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = muteUriBuilder))]
 pub fn mute_uri_builder(author_id: String, mute_id: String) -> String {
-    let mute_path = mute_path_builder(&mute_id);
+    let mute_path = PubkyAppMute::create_path(&mute_id);
     [PROTOCOL, &author_id, &mute_path].concat()
-}
-
-/// Builds a Bookmark Path of the form "/pub/pubky.app/bookmarks/<bookmark_id>"
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = bookmarkPathBuilder))]
-pub fn bookmark_path_builder(id: &str) -> String {
-    PubkyAppBookmark::create_path(id)
 }
 
 /// Builds a Bookmark URI of the form "pubky://<author_id>/pub/pubky.app/bookmarks/<bookmark_id>"
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = bookmarkUriBuilder))]
 pub fn bookmark_uri_builder(author_id: String, bookmark_id: String) -> String {
-    let bookmark_path = bookmark_path_builder(&bookmark_id);
+    let bookmark_path = PubkyAppBookmark::create_path(&bookmark_id);
     [PROTOCOL, &author_id, &bookmark_path].concat()
-}
-
-/// Builds a Tag Path of the form "/pub/pubky.app/tags/<tag_id>"
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = tagPathBuilder))]
-pub fn tag_path_builder(id: &str) -> String {
-    PubkyAppTag::create_path(id)
 }
 
 /// Builds a Tag URI of the form "pubky://<author_id>/pub/pubky.app/tags/<tag_id>"
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = tagUriBuilder))]
 pub fn tag_uri_builder(author_id: String, tag_id: String) -> String {
-    let tag_path = tag_path_builder(&tag_id);
+    let tag_path = PubkyAppTag::create_path(&tag_id);
     [PROTOCOL, &author_id, &tag_path].concat()
-}
-
-/// Builds a File Path of the form "/pub/pubky.app/files/<file_id>"
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = filePathBuilder))]
-pub fn file_path_builder(id: &str) -> String {
-    PubkyAppFile::create_path(id)
 }
 
 /// Builds a File URI of the form "pubky://<author_id>/pub/pubky.app/files/<file_id>"
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fileUriBuilder))]
 pub fn file_uri_builder(author_id: String, file_id: String) -> String {
-    let file_path = file_path_builder(&file_id);
+    let file_path = PubkyAppFile::create_path(&file_id);
     [PROTOCOL, &author_id, &file_path].concat()
-}
-
-/// Builds a Blob Path of the form "/pub/pubky.app/blobs/<blob_id>"
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = blobPathBuilder))]
-pub fn blob_path_builder(id: &str) -> String {
-    PubkyAppBlob::create_path(id)
 }
 
 /// Builds a Blob URI of the form "pubky://<author_id>/pub/pubky.app/blobs/<blob_id>"
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = blobUriBuilder))]
 pub fn blob_uri_builder(author_id: String, blob_id: String) -> String {
-    let blob_path = blob_path_builder(&blob_id);
+    let blob_path = PubkyAppBlob::create_path(&blob_id);
     [PROTOCOL, &author_id, &blob_path].concat()
-}
-
-/// Builds a Feed Path of the form "/pub/pubky.app/feeds/<feed_id>"
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = feedPathBuilder))]
-pub fn feed_path_builder(id: &str) -> String {
-    PubkyAppFeed::create_path(id)
 }
 
 /// Builds a Feed URI of the form "pubky://<author_id>/pub/pubky.app/feeds/<feed_id>"
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = feedUriBuilder))]
 pub fn feed_uri_builder(author_id: String, feed_id: String) -> String {
-    let feed_path = feed_path_builder(&feed_id);
+    let feed_path = PubkyAppFeed::create_path(&feed_id);
     [PROTOCOL, &author_id, &feed_path].concat()
-}
-
-/// Builds a LastRead Path of the form "/pub/pubky.app/last_read"
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = lastReadPathBuilder))]
-pub fn last_read_path_builder() -> String {
-    [PUBLIC_PATH, APP_PATH, "last_read"].concat()
 }
 
 /// Builds a LastRead URI of the form "pubky://<author_id>/pub/pubky.app/last_read"
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = lastReadUriBuilder))]
 pub fn last_read_uri_builder(author_id: String) -> String {
-    let last_read_path = last_read_path_builder();
+    let last_read_path = [PUBLIC_PATH, APP_PATH, "last_read"].concat();
     [PROTOCOL, &author_id, &last_read_path].concat()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::*,
     traits::{HasIdPath, HasPath},
-    PubkyAppBookmark, PubkyAppFollow, PubkyAppMute, PubkyAppPost, PubkyAppUser,
+    PubkyAppBookmark, PubkyAppFollow, PubkyAppMute, PubkyAppPost, PubkyAppTag, PubkyAppUser,
 };
 
 #[cfg(target_arch = "wasm32")]
@@ -75,4 +75,17 @@ pub fn bookmark_path_builder(id: &str) -> String {
 pub fn bookmark_uri_builder(author_id: String, bookmark_id: String) -> String {
     let bookmark_path = bookmark_path_builder(&bookmark_id);
     [PROTOCOL, &author_id, &bookmark_path].concat()
+}
+
+/// Builds a Tag Path of the form "/pub/pubky.app/tags/<tag_id>"
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = tagPathBuilder))]
+pub fn tag_path_builder(id: &str) -> String {
+    PubkyAppTag::create_path(id)
+}
+
+/// Builds a Tag URI of the form "pubky://<author_id>/pub/pubky.app/tags/<tag_id>"
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = tagUriBuilder))]
+pub fn tag_uri_builder(author_id: String, tag_id: String) -> String {
+    let tag_path = tag_path_builder(&tag_id);
+    [PROTOCOL, &author_id, &tag_path].concat()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 use crate::{
     common::*,
     traits::{HasIdPath, HasPath},
-    PubkyAppFollow, PubkyAppPost, PubkyAppUser,
+    PubkyAppFollow, PubkyAppMute, PubkyAppPost, PubkyAppUser,
 };
 
 #[cfg(target_arch = "wasm32")]
@@ -49,4 +49,17 @@ pub fn follow_path_builder(id: &str) -> String {
 pub fn follow_uri_builder(author_id: String, follow_id: String) -> String {
     let follow_path = follow_path_builder(&follow_id);
     [PROTOCOL, &author_id, &follow_path].concat()
+}
+
+/// Builds a Mute Path of the form "/pub/pubky.app/mutes/<mute_id>"
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = mutePathBuilder))]
+pub fn mute_path_builder(id: &str) -> String {
+    PubkyAppMute::create_path(id)
+}
+
+/// Builds a Mute URI of the form "pubky://<author_id>/pub/pubky.app/mutes/<mute_id>"
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = muteUriBuilder))]
+pub fn mute_uri_builder(author_id: String, mute_id: String) -> String {
+    let mute_path = mute_path_builder(&mute_id);
+    [PROTOCOL, &author_id, &mute_path].concat()
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -77,11 +77,11 @@ pub struct PubkySpecsBuilder {
 /// It also generates getters for both fields.
 ///
 /// # Usage
-/// ```rust
+/// ```ignore
 /// result_struct!(PostResult, post, PubkyAppPost);
 /// ```
 /// Expands to:
-/// ```rust
+/// ```ignore
 /// #[wasm_bindgen]
 /// pub struct PostResult {
 ///     post: PubkyAppPost,
@@ -165,7 +165,7 @@ impl PubkySpecsBuilder {
         user.validate(None)?; // No ID-based validation for user
 
         // 3) Create the path and meta
-        let path = user.create_path();
+        let path = user_path_builder();
         let meta = Meta::from_object(None, self.pubky_id.clone(), path);
 
         // 4) Return a typed struct containing both
@@ -207,7 +207,7 @@ impl PubkySpecsBuilder {
         let feed_id = feed.create_id();
         feed.validate(Some(&feed_id))?;
 
-        let path = feed.create_path(&feed_id);
+        let path = PubkyAppFeed::create_path(&feed_id);
         let meta = Meta::from_object(Some(&feed_id), self.pubky_id.clone(), path);
 
         Ok(FeedResult { feed, meta })
@@ -229,7 +229,7 @@ impl PubkySpecsBuilder {
         let file_id = file.create_id();
         file.validate(Some(&file_id))?;
 
-        let path = file.create_path(&file_id);
+        let path = PubkyAppFile::create_path(&file_id);
         let meta = Meta::from_object(Some(&file_id), self.pubky_id.clone(), path);
 
         Ok(FileResult { file, meta })
@@ -252,7 +252,7 @@ impl PubkySpecsBuilder {
         let post_id = post.create_id();
         post.validate(Some(&post_id))?;
 
-        let path = post.create_path(&post_id);
+        let path = post_path_builder(&post_id);
         let meta = Meta::from_object(Some(&post_id), self.pubky_id.clone(), path);
 
         Ok(PostResult { post, meta })
@@ -275,7 +275,7 @@ impl PubkySpecsBuilder {
         post.validate(Some(&post_id))?;
 
         // Recreate the path and meta using the unchanged ID.
-        let path = [PUBLIC_PATH, APP_PATH, PubkyAppPost::PATH_SEGMENT, &post_id].concat();
+        let path = post_path_builder(&post_id);
         let meta = Meta::from_object(Some(&post_id), self.pubky_id.clone(), path);
 
         Ok(PostResult { post, meta })
@@ -291,7 +291,7 @@ impl PubkySpecsBuilder {
         let tag_id = tag.create_id();
         tag.validate(Some(&tag_id))?;
 
-        let path = tag.create_path(&tag_id);
+        let path = PubkyAppTag::create_path(&tag_id);
         let meta = Meta::from_object(Some(&tag_id), self.pubky_id.clone(), path);
 
         Ok(TagResult { tag, meta })
@@ -307,7 +307,7 @@ impl PubkySpecsBuilder {
         let bookmark_id = bookmark.create_id();
         bookmark.validate(Some(&bookmark_id))?;
 
-        let path = bookmark.create_path(&bookmark_id);
+        let path = PubkyAppBookmark::create_path(&bookmark_id);
         let meta = Meta::from_object(Some(&bookmark_id), self.pubky_id.clone(), path);
 
         Ok(BookmarkResult { bookmark, meta })
@@ -323,7 +323,7 @@ impl PubkySpecsBuilder {
         follow.validate(Some(&followee_id))?; // No ID in follow, so we pass user ID or empty
 
         // Path requires the user ID
-        let path = follow.create_path(&followee_id);
+        let path = PubkyAppFollow::create_path(&followee_id);
         let meta = Meta::from_object(Some(&followee_id), self.pubky_id.clone(), path);
 
         Ok(FollowResult { follow, meta })
@@ -338,7 +338,7 @@ impl PubkySpecsBuilder {
         let mute = PubkyAppMute::new();
         mute.validate(Some(&mutee_id))?;
 
-        let path = mute.create_path(&mutee_id);
+        let path = PubkyAppMute::create_path(&mutee_id);
         let meta = Meta::from_object(Some(&mutee_id), self.pubky_id.clone(), path);
 
         Ok(MuteResult { mute, meta })
@@ -353,7 +353,7 @@ impl PubkySpecsBuilder {
         let last_read = PubkyAppLastRead::new();
         last_read.validate(None)?;
 
-        let path = last_read.create_path();
+        let path = PubkyAppLastRead::create_path();
         let meta = Meta::from_object(None, self.pubky_id.clone(), path);
 
         Ok(LastReadResult { last_read, meta })
@@ -375,7 +375,7 @@ impl PubkySpecsBuilder {
         let id = blob.create_id();
         blob.validate(Some(&id))?;
 
-        let path = blob.create_path(&id);
+        let path = PubkyAppBlob::create_path(&id);
         let meta = Meta::from_object(Some(&id), self.pubky_id.clone(), path);
 
         Ok(BlobResult { blob, meta })

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -165,7 +165,7 @@ impl PubkySpecsBuilder {
         user.validate(None)?; // No ID-based validation for user
 
         // 3) Create the path and meta
-        let path = user_path_builder();
+        let path = PubkyAppUser::create_path();
         let meta = Meta::from_object(None, self.pubky_id.clone(), path);
 
         // 4) Return a typed struct containing both
@@ -252,7 +252,7 @@ impl PubkySpecsBuilder {
         let post_id = post.create_id();
         post.validate(Some(&post_id))?;
 
-        let path = post_path_builder(&post_id);
+        let path = PubkyAppPost::create_path(&post_id);
         let meta = Meta::from_object(Some(&post_id), self.pubky_id.clone(), path);
 
         Ok(PostResult { post, meta })
@@ -275,7 +275,7 @@ impl PubkySpecsBuilder {
         post.validate(Some(&post_id))?;
 
         // Recreate the path and meta using the unchanged ID.
-        let path = post_path_builder(&post_id);
+        let path = PubkyAppPost::create_path(&post_id);
         let meta = Meta::from_object(Some(&post_id), self.pubky_id.clone(), path);
 
         Ok(PostResult { post, meta })

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -3,7 +3,8 @@
 extern crate wasm_bindgen_test;
 use js_sys::Array;
 use pubky_app_specs::{
-    parse_uri, PubkyAppPost, PubkyAppPostKind, PubkyAppUserLink, PubkySpecsBuilder,
+    parse_uri, post_uri_builder, PubkyAppPost, PubkyAppPostKind, PubkyAppUserLink,
+    PubkySpecsBuilder,
 };
 use serde_wasm_bindgen::to_value;
 use wasm_bindgen::JsValue;
@@ -173,7 +174,10 @@ fn test_post_from_json() {
 #[wasm_bindgen_test]
 fn test_parse_uri() {
     // A valid URI for a post resource.
-    let uri = "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/posts/0032SSN7Q4EVG";
+    let uri = post_uri_builder(
+        "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+        "0032SSN7Q4EVG".into(),
+    );
 
     // Call the wasm-exposed parse_uri function.
     let parsed = parse_uri(uri).expect("Expected valid URI parsing");

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -3,8 +3,8 @@
 extern crate wasm_bindgen_test;
 use js_sys::Array;
 use pubky_app_specs::{
-    parse_uri, post_uri_builder, PubkyAppPost, PubkyAppPostKind, PubkyAppUserLink,
-    PubkySpecsBuilder,
+    parse_uri, post_uri_builder, user_path_builder, user_uri_builder, PubkyAppPost,
+    PubkyAppPostKind, PubkyAppUserLink, PubkySpecsBuilder,
 };
 use serde_wasm_bindgen::to_value;
 use wasm_bindgen::JsValue;
@@ -79,7 +79,7 @@ fn test_create_user_rust_api() {
     let user = result.user();
 
     // Validate the meta object
-    assert_eq!(meta.path(), PubkyAppUser::create_path());
+    assert_eq!(meta.path(), user_path_builder());
     assert_eq!(
         meta.url(),
         user_uri_builder("operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into())
@@ -133,7 +133,7 @@ fn test_create_user_with_minimal_data() {
     let user = result.user();
 
     // Validate the meta object
-    assert_eq!(meta.path(), PubkyAppUser::create_path());
+    assert_eq!(meta.path(), user_path_builder());
     assert_eq!(
         meta.url(),
         user_uri_builder("operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into())
@@ -180,7 +180,7 @@ fn test_parse_uri() {
     );
 
     // Call the wasm-exposed parse_uri function.
-    let parsed = parse_uri(uri).expect("Expected valid URI parsing");
+    let parsed = parse_uri(&uri).expect("Expected valid URI parsing");
 
     // Verify the user ID is correctly parsed.
     assert_eq!(

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -2,9 +2,10 @@
 
 extern crate wasm_bindgen_test;
 use js_sys::Array;
+use pubky_app_specs::traits::{HasIdPath, HasPath};
 use pubky_app_specs::{
-    follow_path_builder, follow_uri_builder, parse_uri, post_uri_builder, user_path_builder,
-    user_uri_builder, PubkyAppPost, PubkyAppPostKind, PubkyAppUserLink, PubkySpecsBuilder,
+    follow_uri_builder, parse_uri, post_uri_builder, user_uri_builder, PubkyAppFollow,
+    PubkyAppPost, PubkyAppPostKind, PubkyAppUser, PubkyAppUserLink, PubkySpecsBuilder,
 };
 use serde_wasm_bindgen::to_value;
 use wasm_bindgen::JsValue;
@@ -27,7 +28,7 @@ fn test_create_follow() {
     // Now we can call the Rust getter methods directly:
     assert_eq!(
         meta.path(),
-        follow_path_builder("operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into())
+        PubkyAppFollow::create_path("operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into())
     );
     assert_eq!(
         meta.url(),
@@ -82,7 +83,7 @@ fn test_create_user_rust_api() {
     let user = result.user();
 
     // Validate the meta object
-    assert_eq!(meta.path(), user_path_builder());
+    assert_eq!(meta.path(), PubkyAppUser::create_path());
     assert_eq!(
         meta.url(),
         user_uri_builder("operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into())
@@ -136,7 +137,7 @@ fn test_create_user_with_minimal_data() {
     let user = result.user();
 
     // Validate the meta object
-    assert_eq!(meta.path(), user_path_builder());
+    assert_eq!(meta.path(), PubkyAppUser::create_path());
     assert_eq!(
         meta.url(),
         user_uri_builder("operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into())

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -78,10 +78,10 @@ fn test_create_user_rust_api() {
     let user = result.user();
 
     // Validate the meta object
-    assert_eq!(meta.path(), "/pub/pubky.app/profile.json");
+    assert_eq!(meta.path(), PubkyAppUser::create_path());
     assert_eq!(
         meta.url(),
-        "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/profile.json"
+        user_uri_builder("operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into())
     );
     assert_eq!(meta.id(), "");
 
@@ -132,10 +132,10 @@ fn test_create_user_with_minimal_data() {
     let user = result.user();
 
     // Validate the meta object
-    assert_eq!(meta.path(), "/pub/pubky.app/profile.json");
+    assert_eq!(meta.path(), PubkyAppUser::create_path());
     assert_eq!(
         meta.url(),
-        "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/profile.json"
+        user_uri_builder("operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into())
     );
     assert_eq!(meta.id(), "");
 

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -3,8 +3,8 @@
 extern crate wasm_bindgen_test;
 use js_sys::Array;
 use pubky_app_specs::{
-    parse_uri, post_uri_builder, user_path_builder, user_uri_builder, PubkyAppPost,
-    PubkyAppPostKind, PubkyAppUserLink, PubkySpecsBuilder,
+    follow_path_builder, follow_uri_builder, parse_uri, post_uri_builder, user_path_builder,
+    user_uri_builder, PubkyAppPost, PubkyAppPostKind, PubkyAppUserLink, PubkySpecsBuilder,
 };
 use serde_wasm_bindgen::to_value;
 use wasm_bindgen::JsValue;
@@ -27,11 +27,14 @@ fn test_create_follow() {
     // Now we can call the Rust getter methods directly:
     assert_eq!(
         meta.path(),
-        "/pub/pubky.app/follows/operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo"
+        follow_path_builder("operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into())
     );
     assert_eq!(
         meta.url(),
-        "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/follows/operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo"
+        follow_uri_builder(
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into(),
+            "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".into()
+        )
     );
     assert_eq!(
         meta.id(),


### PR DESCRIPTION
This PR re-uses URI builder utils where possible:
- `user_uri_builder`
- `post_uri_builder`
- `follow_uri_builder`
- `mute_uri_builder`
- `bookmark_uri_builder`
- `tag_uri_builder`
- `file_uri_builder`
- `blob_uri_builder`
- `feed_uri_builder`
- `last_read_uri_builder`

The PR also updated `HasPath`, `HasIdPath` traits to remove the unused `&self` reference in their `create_path()`.