### PR TITLE
Bump version in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-app-specs"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky-app-specs"
-version = "0.3.5"
+version = "0.4.0"
 edition = "2021"
 description = "Pubky.app Data Model Specifications"
 homepage = "https://pubky.app"


### PR DESCRIPTION
Reflect the latest published crate version in `Cargo.toml`.