### PR TITLE
Extend tag validation to check for invalid chars

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -96,10 +96,7 @@ pub trait HashId {
     fn validate_id(&self, id: &str) -> Result<(), String> {
         let generated_id = self.create_id();
         if generated_id != id {
-            return Err(format!(
-                "Invalid ID: expected {}, found {}",
-                generated_id, id
-            ));
+            return Err(format!("Invalid ID: expected {generated_id}, found {id}"));
         }
         Ok(())
     }


### PR DESCRIPTION
This PR adds a list of `INVALID_CHARS`, which forbids the use of `,` and `:` in tag labels.

Fixes #75