### PR TITLE
Add `PubkyId` to `PublicKey` conversion

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -21,5 +21,8 @@ jobs:
         with:
           tool: cargo-nextest
 
+      - name: Check OpenAPI feature
+        run: cargo check --features openapi
+
       - name: Run native tests
         run: cargo nextest run --no-fail-fast

--- a/examples/create_user.rs
+++ b/examples/create_user.rs
@@ -8,7 +8,7 @@ fn main() {
 #[cfg(not(target_arch = "wasm32"))]
 use {
     anyhow::Result,
-    pubky::{Keypair, PublicKey, Pubky},
+    pubky::{Keypair, Pubky, PublicKey},
     pubky_app_specs::{traits::HasPath, traits::Validatable, PubkyAppUser},
     serde_json::to_vec,
 };

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,3 @@
-#[cfg(target_arch = "wasm32")]
 use base32::{decode, Alphabet};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
@@ -31,8 +30,7 @@ impl PartialSchema for PubkyId {
 impl ToSchema for PubkyId {}
 
 impl PubkyId {
-    #[cfg(target_arch = "wasm32")]
-    pub fn try_from(s: &str) -> Result<Self, String> {
+    fn validate(s: &str) -> Result<(), String> {
         // Validate string is a valid Pkarr public key
         // Should closely resemble the behavior of pkarr::PublicKey::try_from(&str) for the case of 52 chars
         // https://github.com/pubky/pkarr/blob/72fe80c271c1c1d2293e6a6800f227c570e8d4f5/pkarr/src/keys.rs#L142-L214
@@ -42,15 +40,22 @@ impl PubkyId {
         }
 
         match decode(Alphabet::Z, s) {
-            Some(_) => (),
-            None => return Err("Validation Error: invalid public key encoding".to_string()),
-        };
+            Some(_) => Ok(()),
+            None => Err("Validation Error: invalid public key encoding".to_string()),
+        }
+    }
 
+    #[cfg(target_arch = "wasm32")]
+    pub fn try_from(s: &str) -> Result<Self, String> {
+        Self::validate(s)?;
         Ok(Self { z32: s.to_string() })
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     pub fn try_from(s: &str) -> Result<Self, String> {
+        // Include the stricter wasm32-specific validation for consistency
+        Self::validate(s)?;
+
         let public_key =
             pubky::PublicKey::try_from(s).map_err(|e| format!("Validation Error: {e}"))?;
 
@@ -153,8 +158,6 @@ mod tests {
         let invalid_key = "short";
         let result = PubkyId::try_from(invalid_key);
         assert!(result.is_err());
-
-        #[cfg(target_arch = "wasm32")]
         assert_eq!(
             result.unwrap_err(),
             "Validation Error: the string is not 52 utf chars"
@@ -167,8 +170,6 @@ mod tests {
         let invalid_key = "0perrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rd0";
         let result = PubkyId::try_from(invalid_key);
         assert!(result.is_err());
-
-        #[cfg(target_arch = "wasm32")]
         assert_eq!(
             result.unwrap_err(),
             "Validation Error: invalid public key encoding"

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,6 @@
+#[cfg(target_arch = "wasm32")]
 use base32::{decode, Alphabet};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 
 #[cfg(target_arch = "wasm32")]
@@ -12,26 +13,41 @@ use crate::{ParsedUri, Resource};
 
 /// Represents user data with name, bio, image, links, and status.
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
-pub struct PubkyId(String);
+pub struct PubkyId {
+    z32: String,
+    #[cfg(not(target_arch = "wasm32"))]
+    public_key: pubky::PublicKey,
+}
 
 impl PubkyId {
     pub fn try_from(s: &str) -> Result<Self, String> {
-        // Validate string is a valid Pkarr public key
-        // Should closely resemble the behavior of pkarr::PublicKey::try_from(&str) for the case of 52 chars
-        // https://github.com/pubky/pkarr/blob/72fe80c271c1c1d2293e6a6800f227c570e8d4f5/pkarr/src/keys.rs#L142-L214
-        // We avoid pkarr as a dependency by doing writing our own validation instead.
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let public_key = pubky::PublicKey::try_from(s)
+                .map_err(|e| format!("Validation Error: {e}"))?;
+
+            return Ok(Self {
+                z32: public_key.to_z32(),
+                public_key,
+            });
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        // Validate string is a valid Pkarr public key.
         if s.len() != 52 {
             return Err("Validation Error: the string is not 52 utf chars".to_string());
         }
 
+        #[cfg(target_arch = "wasm32")]
         match decode(Alphabet::Z, s) {
             Some(_) => (),
             None => return Err("Validation Error: invalid public key encoding".to_string()),
         };
 
-        Ok(PubkyId(s.to_string()))
+        #[cfg(target_arch = "wasm32")]
+        return Ok(Self { z32: s.to_string() });
     }
 
     pub fn to_uri(&self) -> ParsedUri {
@@ -40,12 +56,20 @@ impl PubkyId {
             resource: Resource::User,
         }
     }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn to_public_key(&self) -> pubky::PublicKey {
+        self.public_key.clone()
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 impl From<pubky::PublicKey> for PubkyId {
     fn from(pk: pubky::PublicKey) -> Self {
-        Self(pk.to_z32())
+        Self {
+            z32: pk.to_z32(),
+            public_key: pk,
+        }
     }
 }
 
@@ -58,7 +82,7 @@ impl From<pubky::Keypair> for PubkyId {
 
 impl fmt::Display for PubkyId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.z32)
     }
 }
 
@@ -66,13 +90,32 @@ impl std::ops::Deref for PubkyId {
     type Target = String;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.z32
     }
 }
 
 impl AsRef<str> for PubkyId {
     fn as_ref(&self) -> &str {
-        &self.0
+        &self.z32
+    }
+}
+
+impl Serialize for PubkyId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.z32)
+    }
+}
+
+impl<'de> Deserialize<'de> for PubkyId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        PubkyId::try_from(&s).map_err(serde::de::Error::custom)
     }
 }
 
@@ -96,10 +139,6 @@ mod tests {
         let invalid_key = "short";
         let result = PubkyId::try_from(invalid_key);
         assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err(),
-            "Validation Error: the string is not 52 utf chars"
-        );
     }
 
     #[test]
@@ -108,10 +147,6 @@ mod tests {
         let invalid_key = "0perrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rd0";
         let result = PubkyId::try_from(invalid_key);
         assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err(),
-            "Validation Error: invalid public key encoding"
-        );
     }
 
     #[test]
@@ -193,5 +228,17 @@ mod tests {
         // Both should produce the same PubkyId
         assert_eq!(pubky_id_from_keypair, pubky_id_from_public_key);
         assert_eq!(pubky_id_from_keypair.as_ref(), expected_z32);
+    }
+
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    fn test_to_public_key_is_infallible_for_valid_pubky_id() {
+        let keypair = Keypair::random();
+        let expected_public_key = keypair.public_key();
+        let pubky_id = PubkyId::from(expected_public_key.clone());
+
+        let converted_public_key = pubky_id.to_public_key();
+
+        assert_eq!(converted_public_key, expected_public_key);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -144,6 +144,12 @@ mod tests {
         let invalid_key = "short";
         let result = PubkyId::try_from(invalid_key);
         assert!(result.is_err());
+
+        #[cfg(target_arch = "wasm32")]
+        assert_eq!(
+            result.unwrap_err(),
+            "Validation Error: the string is not 52 utf chars"
+        );
     }
 
     #[test]
@@ -152,6 +158,12 @@ mod tests {
         let invalid_key = "0perrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rd0";
         let result = PubkyId::try_from(invalid_key);
         assert!(result.is_err());
+
+        #[cfg(target_arch = "wasm32")]
+        assert_eq!(
+            result.unwrap_err(),
+            "Validation Error: invalid public key encoding"
+        );
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -58,6 +58,10 @@ impl PubkyId {
         }
     }
 
+    /// Returns the cached public key.
+    ///
+    /// This is infallible on native targets because the key was validated
+    /// during `PubkyId` construction and cached.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn to_public_key(&self) -> pubky::PublicKey {
         self.public_key.clone()

--- a/src/types.rs
+++ b/src/types.rs
@@ -268,4 +268,67 @@ mod tests {
 
         assert_eq!(converted_public_key, expected_public_key);
     }
+
+    #[test]
+    fn test_serialization() {
+        let valid_key = "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo";
+        let pubky_id = PubkyId::try_from(valid_key).unwrap();
+
+        let json = serde_json::to_string(&pubky_id).unwrap();
+        // Serde serializes the inner String, so it should be a quoted JSON string
+        assert_eq!(json, format!("\"{}\"", valid_key));
+    }
+
+    #[test]
+    fn test_deserialization() {
+        let valid_key = "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo";
+        // Deserialize from a JSON string (quoted)
+        let json = format!("\"{}\"", valid_key);
+        let pubky_id: PubkyId = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(pubky_id.as_ref(), valid_key);
+    }
+
+    #[test]
+    fn test_deserialization_from_slice() {
+        let valid_key = "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo";
+        // Deserialize from a JSON byte slice
+        let json_str = format!("\"{}\"", valid_key);
+        let pubky_id: PubkyId = serde_json::from_slice(json_str.as_bytes()).unwrap();
+
+        assert_eq!(pubky_id.as_ref(), valid_key);
+    }
+
+    #[test]
+    fn test_deserialization_invalid_length() {
+        let json = "\"short\"";
+        let result: Result<PubkyId, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_deserialization_invalid_length_from_slice() {
+        let json = "\"short\"";
+        let result: Result<PubkyId, _> = serde_json::from_slice(json.as_bytes());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_deserialization_invalid_encoding() {
+        // 52 chars but contains invalid z-base-32 character '0'
+        let json = "\"0perrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rd0\"";
+        let result: Result<PubkyId, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let valid_key = "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo";
+        let original = PubkyId::try_from(valid_key).unwrap();
+
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: PubkyId = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(original, deserialized);
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,19 +7,28 @@ use std::fmt;
 use wasm_bindgen::prelude::*;
 
 #[cfg(feature = "openapi")]
-use utoipa::ToSchema;
+use utoipa::{PartialSchema, ToSchema};
 
 use crate::{ParsedUri, Resource};
 
 /// Represents user data with name, bio, image, links, and status.
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct PubkyId {
     z32: String,
     #[cfg(not(target_arch = "wasm32"))]
     public_key: pubky::PublicKey,
 }
+
+#[cfg(feature = "openapi")]
+impl PartialSchema for PubkyId {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        String::schema()
+    }
+}
+
+#[cfg(feature = "openapi")]
+impl ToSchema for PubkyId {}
 
 impl PubkyId {
     #[cfg(target_arch = "wasm32")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -42,7 +42,8 @@ impl PubkyId {
 
     #[cfg(not(target_arch = "wasm32"))]
     pub fn try_from(s: &str) -> Result<Self, String> {
-        let public_key = pubky::PublicKey::try_from(s).map_err(|e| format!("Validation Error: {e}"))?;
+        let public_key =
+            pubky::PublicKey::try_from(s).map_err(|e| format!("Validation Error: {e}"))?;
 
         Ok(Self {
             z32: public_key.to_z32(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -22,32 +22,32 @@ pub struct PubkyId {
 }
 
 impl PubkyId {
+    #[cfg(target_arch = "wasm32")]
     pub fn try_from(s: &str) -> Result<Self, String> {
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let public_key = pubky::PublicKey::try_from(s)
-                .map_err(|e| format!("Validation Error: {e}"))?;
-
-            return Ok(Self {
-                z32: public_key.to_z32(),
-                public_key,
-            });
-        }
-
-        #[cfg(target_arch = "wasm32")]
-        // Validate string is a valid Pkarr public key.
+        // Validate string is a valid Pkarr public key
+        // Should closely resemble the behavior of pkarr::PublicKey::try_from(&str) for the case of 52 chars
+        // https://github.com/pubky/pkarr/blob/72fe80c271c1c1d2293e6a6800f227c570e8d4f5/pkarr/src/keys.rs#L142-L214
+        // We avoid pkarr as a dependency by doing writing our own validation instead.
         if s.len() != 52 {
             return Err("Validation Error: the string is not 52 utf chars".to_string());
         }
 
-        #[cfg(target_arch = "wasm32")]
         match decode(Alphabet::Z, s) {
             Some(_) => (),
             None => return Err("Validation Error: invalid public key encoding".to_string()),
         };
 
-        #[cfg(target_arch = "wasm32")]
-        return Ok(Self { z32: s.to_string() });
+        Ok(Self { z32: s.to_string() })
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn try_from(s: &str) -> Result<Self, String> {
+        let public_key = pubky::PublicKey::try_from(s).map_err(|e| format!("Validation Error: {e}"))?;
+
+        Ok(Self {
+            z32: public_key.to_z32(),
+            public_key,
+        })
     }
 
     pub fn to_uri(&self) -> ParsedUri {

--- a/src/uri_parser.rs
+++ b/src/uri_parser.rs
@@ -190,7 +190,8 @@ mod tests {
     #[test]
     fn test_empty_bookmark_uri() {
         let uri = bookmark_uri_builder(USER_ID.into(), "".into());
-        let parsed_uri = ParsedUri::try_from(uri).expect("empty bookmark id should parse to Unknown");
+        let parsed_uri =
+            ParsedUri::try_from(uri).expect("empty bookmark id should parse to Unknown");
         assert_eq!(
             parsed_uri.resource,
             Resource::Unknown,

--- a/src/uri_parser.rs
+++ b/src/uri_parser.rs
@@ -65,7 +65,7 @@ impl Resource {
     }
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ParsedUri {
     pub user_id: PubkyId,
     pub resource: Resource,
@@ -190,7 +190,7 @@ mod tests {
     #[test]
     fn test_empty_bookmark_uri() {
         let uri = bookmark_uri_builder(USER_ID.into(), "".into());
-        let parsed_uri = ParsedUri::try_from(uri).unwrap_or_default();
+        let parsed_uri = ParsedUri::try_from(uri).expect("empty bookmark id should parse to Unknown");
         assert_eq!(
             parsed_uri.resource,
             Resource::Unknown,
@@ -201,7 +201,7 @@ mod tests {
     #[test]
     fn test_some_bookmark_uri() {
         let uri = bookmark_uri_builder(USER_ID.into(), "00".into());
-        let parsed_uri = ParsedUri::try_from(uri).unwrap_or_default();
+        let parsed_uri = ParsedUri::try_from(uri).expect("bookmark id should parse");
         assert_eq!(
             parsed_uri.resource,
             Resource::Bookmark("00".to_string()),
@@ -212,7 +212,7 @@ mod tests {
     #[test]
     fn test_user() {
         let uri = user_uri_builder(USER_ID.into());
-        let parsed_uri = ParsedUri::try_from(uri).unwrap_or_default();
+        let parsed_uri = ParsedUri::try_from(uri).expect("user uri should parse");
         assert_eq!(
             parsed_uri.resource,
             Resource::User,


### PR DESCRIPTION
This PR refactors `PubkyId` so native builds can convert it back to a `PublicKey` infallibly, while keeping wasm behavior unchanged (lightweight and dependency-safe).

- `PubkyId` was changed from a tuple string wrapper to a structured type storing:
  - canonical z32 text (`z32`)
  - cached `pubky::PublicKey` on non-wasm targets. 
- `PubkyId::try_from` is now split by target:
  - wasm32 uses the prior manual z-base-32 validation logic/comments.
  - non-wasm32 uses `pubky::PublicKey::try_from` and stores both parsed key + canonical z32. 
- `to_public_key()` on non-wasm now returns the cached key directly (no fallible conversion path at call site). 
- Custom serde was added so `PubkyId` still serializes/deserializes as a single string while validating on deserialize. 
- `ParsedUri` no longer derives `Default` (since `PubkyId` no longer does), and URI parsing tests were tightened to use explicit `expect(...)` instead of `unwrap_or_default()`. 
- Added/kept test coverage for native round-trip key conversion (`PublicKey` -> `PubkyId` -> `PublicKey`) and full suite remains green on native. 

---

TLDR: with this PR, for native (non-wasm) targets, it's possible to convert
- `PubkyId` -> `PublicKey` via `PubkyId::to_public_key` infallibly

The reverse direction (`PublicKey` -> `PubkyId`) is already possible via `PubkyId::from(PublicKey)` since #80