### PR TITLE
set MSRV to 1.89 and add MSRV check job

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -34,6 +34,6 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - name: Check MSRV compatibility (native)
-        run: cargo check --all-features
+        run: cargo check --locked --all-features
       - name: Check MSRV compatibility (wasm32)
-        run: cargo check --all-features --target wasm32-unknown-unknown
+        run: cargo check --locked --all-features --target wasm32-unknown-unknown

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -30,6 +30,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.89
+        with:
+          targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
-      - name: Check MSRV compatibility
+      - name: Check MSRV compatibility (native)
         run: cargo check --all-features
+      - name: Check MSRV compatibility (wasm32)
+        run: cargo check --all-features --target wasm32-unknown-unknown

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -23,3 +23,13 @@ jobs:
 
       - name: Run native tests
         run: cargo nextest run --no-fail-fast
+
+  msrv:
+    name: MSRV (1.89)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.89
+      - uses: Swatinem/rust-cache@v2
+      - name: Check MSRV compatibility
+        run: cargo check --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pubky-app-specs"
 version = "0.4.4"
 edition = "2021"
+rust-version = "1.89"
 description = "Pubky.app Data Model Specifications"
 homepage = "https://pubky.app"
 repository = "https://github.com/pubky/pubky-app-specs"


### PR DESCRIPTION
## Summary
- Set `rust-version = "1.89"` in `Cargo.toml` — minimum version required by the `pubky` 0.7 dependency.
- Add an `msrv` job to `.github/workflows/native.yml` pinned to Rust 1.89, following the org's standard CI pattern. Verifies MSRV against both the native and wasm target.