### PR TITLE
return string slice from Deref

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -106,7 +106,7 @@ impl fmt::Display for PubkyId {
 }
 
 impl std::ops::Deref for PubkyId {
-    type Target = String;
+    type Target = str;
 
     fn deref(&self) -> &Self::Target {
         &self.z32


### PR DESCRIPTION
It's more ergonomic and `&String` adds a little value over `&str`.

With this change downstream consumers can more easily convert generic containers

Before:
```
  PostViewDetailed::get_by_id(
      &author_id, &post_id,                                                                                                                                                                                                                             
      query.viewer_id.as_ref().map(|v| v.as_ref()),                                                                                                                                                                                                     
      ...                                                                                                                                                                                                                                               
  )         
```                                                                                                                                                                                                                                            

After:                                                                                                                                                                                                                                             
```                            
  PostViewDetailed::get_by_id(
      &author_id, &post_id,                                                                                                                                                                                                                             
      query.viewer_id.as_deref(),
      ...
  )
```


