### PR TITLE
Add `Collection` post kind + `PubkyAppCollectionContent` envelope (v0.5.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-app-specs"
-version = "0.4.5"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky-app-specs"
-version = "0.4.5"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.89"
 description = "Pubky.app Data Model Specifications"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,5 +1,5 @@
 // Application version
-pub static VERSION: &str = "0.4.5";
+pub static VERSION: &str = "0.5.0";
 
 // Path constants
 pub static PUBLIC_PATH: &str = "/pub/";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,9 @@ pub use models::file::{PubkyAppFile, VALID_MIME_TYPES};
 pub use models::follow::PubkyAppFollow;
 pub use models::last_read::PubkyAppLastRead;
 pub use models::mute::PubkyAppMute;
-pub use models::post::{PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind};
+pub use models::post::{
+    PubkyAppCollectionContent, PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind,
+};
 pub use models::tag::PubkyAppTag;
 pub use models::user::{PubkyAppUser, PubkyAppUserLink};
 pub use models::PubkyAppObject;

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -57,6 +57,12 @@ pub struct ValidationLimits {
     pub post_attachment_url_max_length: usize,
     /// Allowed protocols for attachment URLs.
     pub post_allowed_attachment_protocols: &'static [&'static str],
+    /// Maximum character count for the JSON envelope content of a Collection post.
+    pub collection_content_max_length: usize,
+    /// Maximum number of items (attachment URIs) per Collection.
+    pub collection_items_max_count: usize,
+    /// Maximum character count for a single Collection item URI.
+    pub collection_item_uri_max_length: usize,
     /// Minimum file name length in characters.
     pub file_name_min_length: usize,
     /// Maximum file name length in characters.
@@ -87,6 +93,9 @@ pub const VALIDATION_LIMITS: ValidationLimits = ValidationLimits {
     post_attachments_max_count: 4,
     post_attachment_url_max_length: 200,
     post_allowed_attachment_protocols: &["pubky", "http", "https"],
+    collection_content_max_length: 2_000,
+    collection_items_max_count: 100,
+    collection_item_uri_max_length: 300,
     file_name_min_length: 1,
     file_name_max_length: 255,
     file_src_max_length: 1024,

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -57,7 +57,10 @@ pub struct ValidationLimits {
     pub post_attachment_url_max_length: usize,
     /// Allowed protocols for attachment URLs.
     pub post_allowed_attachment_protocols: &'static [&'static str],
-    /// Maximum character count for the JSON envelope content of a Collection post.
+    /// Maximum scalar count (`chars().count()`, not bytes) for the JSON
+    /// envelope content of a Collection post. Sized to hold a
+    /// max-population envelope: 100 items × 300 chars + name + description
+    /// + JSON overhead + headroom for additive future fields.
     pub collection_content_max_length: usize,
     /// Minimum character count for a Collection name. The validator rejects
     /// whitespace-only names separately, then counts the full string length.
@@ -101,7 +104,7 @@ pub const VALIDATION_LIMITS: ValidationLimits = ValidationLimits {
     post_attachments_max_count: 4,
     post_attachment_url_max_length: 200,
     post_allowed_attachment_protocols: &["pubky", "http", "https"],
-    collection_content_max_length: 2_000,
+    collection_content_max_length: 40_000,
     collection_name_min_length: 1,
     collection_name_max_length: 100,
     collection_description_max_length: 500,

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -59,6 +59,12 @@ pub struct ValidationLimits {
     pub post_allowed_attachment_protocols: &'static [&'static str],
     /// Maximum character count for the JSON envelope content of a Collection post.
     pub collection_content_max_length: usize,
+    /// Minimum character count for a Collection name (after trim).
+    pub collection_name_min_length: usize,
+    /// Maximum character count for a Collection name (after trim).
+    pub collection_name_max_length: usize,
+    /// Maximum character count for a Collection description.
+    pub collection_description_max_length: usize,
     /// Maximum number of items (attachment URIs) per Collection.
     pub collection_items_max_count: usize,
     /// Maximum character count for a single Collection item URI.
@@ -94,6 +100,9 @@ pub const VALIDATION_LIMITS: ValidationLimits = ValidationLimits {
     post_attachment_url_max_length: 200,
     post_allowed_attachment_protocols: &["pubky", "http", "https"],
     collection_content_max_length: 2_000,
+    collection_name_min_length: 1,
+    collection_name_max_length: 100,
+    collection_description_max_length: 500,
     collection_items_max_count: 100,
     collection_item_uri_max_length: 300,
     file_name_min_length: 1,

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -59,9 +59,11 @@ pub struct ValidationLimits {
     pub post_allowed_attachment_protocols: &'static [&'static str],
     /// Maximum character count for the JSON envelope content of a Collection post.
     pub collection_content_max_length: usize,
-    /// Minimum character count for a Collection name (after trim).
+    /// Minimum character count for a Collection name. The validator rejects
+    /// whitespace-only names separately, then counts the full string length.
     pub collection_name_min_length: usize,
-    /// Maximum character count for a Collection name (after trim).
+    /// Maximum character count for a Collection name. Leading/trailing
+    /// whitespace counts toward the total (the validator does not trim).
     pub collection_name_max_length: usize,
     /// Maximum character count for a Collection description.
     pub collection_description_max_length: usize,

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -120,7 +120,7 @@ impl PubkyAppPostEmbed {
 
 /// Typed JSON envelope stored in `PubkyAppPost::content` when `kind == Collection`.
 ///
-/// A collection post curates an ordered list of other posts (URIs in `attachments`)
+/// A collection post curates an ordered list of URIs (via `attachments`)
 /// under a `name` and optional `description`. The envelope is parsed and validated
 /// by the spec but never re-serialized as a top-level homeserver object.
 ///
@@ -311,11 +311,11 @@ impl Validatable for PubkyAppPost {
         // `Unknown` is a serde catch-all for forwards-compat: older binaries can
         // deserialize events from newer clients without panicking, but such posts
         // must never pass spec validation. Same reasoning for `embed.kind`.
-        if matches!(self.kind, PubkyAppPostKind::Unknown) {
+        if !self.kind.is_known() {
             return Err("Validation Error: post kind is unknown".into());
         }
         if let Some(ref embed) = self.embed {
-            if matches!(embed.kind, PubkyAppPostKind::Unknown) {
+            if !embed.kind.is_known() {
                 return Err("Validation Error: embed kind is unknown".into());
             }
         }
@@ -342,7 +342,16 @@ impl Validatable for PubkyAppPost {
                         e
                     )
                 })?;
-            let name_chars = envelope.name.trim().chars().count();
+            // Whitespace-only names are not meaningful; reject them explicitly
+            // so the length check below can count the full string (matching
+            // description's no-trim behavior).
+            if envelope.name.trim().is_empty() {
+                return Err(
+                    "Validation Error: Collection name must contain non-whitespace characters"
+                        .into(),
+                );
+            }
+            let name_chars = envelope.name.chars().count();
             let name_min = VALIDATION_LIMITS.collection_name_min_length;
             let name_max = VALIDATION_LIMITS.collection_name_max_length;
             if !(name_min..=name_max).contains(&name_chars) {
@@ -373,15 +382,8 @@ impl Validatable for PubkyAppPost {
                             VALIDATION_LIMITS.collection_item_uri_max_length
                         ));
                     }
-                    // TODO(pubky-sdk-absolute-uris): `Url::parse` rejects the
-                    // shortened pubky-sdk absolute URI form
-                    // `pubky<pubkey>/pub/<app>/<path>` (no `://` separator),
-                    // even though pubky-core / pubky-sdk treat that form as a
-                    // valid pubky resource. This rejection is systemic across
-                    // pubky-app-specs (tag.rs, bookmark.rs, user.rs, file.rs,
-                    // common.rs, uri_parser.rs all do `Url::parse` the same
-                    // way). Open a follow-up issue to add a normalization
-                    // shim that accepts both forms once Collections lands.
+                    // Note: rejects pubky-sdk short-form URIs `pubky<pubkey>/pub/...`
+                    // (no `://`). Systemic across spec; tracked as a follow-up issue.
                     let parsed = Url::parse(uri).map_err(|_| {
                         format!("Validation Error: Invalid attachment URL: {}", uri)
                     })?;
@@ -1307,6 +1309,41 @@ mod tests {
         let post = make_collection_post(&exactly_100, None, None);
         let id = post.create_id();
         assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_collection_post_rejects_whitespace_only_name() {
+        // Whitespace-only names pass `min_length=1` purely by char count, so
+        // we reject them with a dedicated guard. Without that guard, a name
+        // of `"    "` would be a 4-char valid name with no meaningful content.
+        let post = make_collection_post("    ", None, None);
+        let id = post.create_id();
+        let err = post
+            .validate(Some(&id))
+            .expect_err("whitespace-only name must fail validation");
+        assert!(
+            err.contains("whitespace"),
+            "error should mention whitespace, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_collection_post_counts_whitespace_in_name_length() {
+        // Regression guard: the validator does NOT trim before counting. A
+        // 99-char name padded with one space on each side is 101 chars and
+        // must fail max=100. With the previous trim-then-count behavior this
+        // would have been 99 chars and passed.
+        let padded = format!(" {} ", "a".repeat(99));
+        assert_eq!(padded.chars().count(), 101);
+        let post = make_collection_post(&padded, None, None);
+        let id = post.create_id();
+        let err = post
+            .validate(Some(&id))
+            .expect_err("101-char padded name must fail max length");
+        assert!(
+            err.contains("1..=100"),
+            "error should report the length range, got: {err}"
+        );
     }
 
     #[test]

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -1297,6 +1297,47 @@ mod tests {
     }
 
     #[test]
+    fn test_collection_post_accepts_empty_description() {
+        // Explicit empty-string description is valid (the field is optional and
+        // 0..=500 chars allowed).
+        let post = make_collection_post("X", Some(""), None);
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_collection_post_accepts_max_description() {
+        let exactly_500 = "a".repeat(500);
+        assert_eq!(exactly_500.chars().count(), 500);
+        let post = make_collection_post("X", Some(&exactly_500), None);
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_collection_post_rejects_missing_name() {
+        // Envelope JSON without a `name` field at all (description-only).
+        // Distinct from `test_collection_post_rejects_empty_name`, which sends
+        // an empty string; this sends a missing key entirely.
+        let envelope = r#"{ "description": "no name here" }"#.to_string();
+        let post = PubkyAppPost::new(
+            envelope,
+            PubkyAppPostKind::Collection,
+            None,
+            None,
+            None,
+        );
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("name") || err.to_lowercase().contains("missing"),
+            "expected name-required error, got: {err}"
+        );
+    }
+
+    #[test]
     fn test_collection_post_rejects_parent() {
         let post = PubkyAppPost::new(
             collection_envelope_json("X", None),
@@ -1427,6 +1468,39 @@ mod tests {
     fn test_collection_post_rejects_disallowed_attachment_protocol() {
         let post =
             make_collection_post("X", None, Some(vec!["ftp://example.com/file".to_string()]));
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Disallowed attachment protocol"));
+    }
+
+    #[test]
+    fn test_collection_post_rejects_javascript_protocol() {
+        // XSS-vector defense: never accept `javascript:` URIs as attachments,
+        // even though they technically parse as URLs.
+        let post = make_collection_post(
+            "X",
+            None,
+            Some(vec!["javascript:alert(1)".to_string()]),
+        );
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Disallowed attachment protocol"));
+    }
+
+    #[test]
+    fn test_collection_post_rejects_data_uri_protocol() {
+        // Same XSS-vector defense for `data:` URIs.
+        let post = make_collection_post(
+            "X",
+            None,
+            Some(vec!["data:text/plain,hello".to_string()]),
+        );
         let id = post.create_id();
         let result = post.validate(Some(&id));
         assert!(result.is_err());

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -110,8 +110,6 @@ impl PubkyAppPostEmbed {
             PubkyAppPostKind::Collection => "Collection".to_string(),
             PubkyAppPostKind::Unknown => "Unknown".to_string(),
         }
-        // pub fn kind(&self) -> PubkyAppPostKind {
-        //     self.kind.clone()
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
@@ -185,8 +183,6 @@ impl PubkyAppPost {
             PubkyAppPostKind::Collection => "Collection".to_string(),
             PubkyAppPostKind::Unknown => "Unknown".to_string(),
         }
-        // pub fn kind(&self) -> PubkyAppPostKind {
-        //     self.kind.clone()
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -1343,13 +1343,7 @@ mod tests {
         // Distinct from `test_collection_post_rejects_empty_name`, which sends
         // an empty string; this sends a missing key entirely.
         let envelope = r#"{ "description": "no name here" }"#.to_string();
-        let post = PubkyAppPost::new(
-            envelope,
-            PubkyAppPostKind::Collection,
-            None,
-            None,
-            None,
-        );
+        let post = PubkyAppPost::new(envelope, PubkyAppPostKind::Collection, None, None, None);
         let id = post.create_id();
         let result = post.validate(Some(&id));
         assert!(result.is_err());
@@ -1503,11 +1497,7 @@ mod tests {
     fn test_collection_post_rejects_javascript_protocol() {
         // XSS-vector defense: never accept `javascript:` URIs as attachments,
         // even though they technically parse as URLs.
-        let post = make_collection_post(
-            "X",
-            None,
-            Some(vec!["javascript:alert(1)".to_string()]),
-        );
+        let post = make_collection_post("X", None, Some(vec!["javascript:alert(1)".to_string()]));
         let id = post.create_id();
         let result = post.validate(Some(&id));
         assert!(result.is_err());
@@ -1519,11 +1509,7 @@ mod tests {
     #[test]
     fn test_collection_post_rejects_data_uri_protocol() {
         // Same XSS-vector defense for `data:` URIs.
-        let post = make_collection_post(
-            "X",
-            None,
-            Some(vec!["data:text/plain,hello".to_string()]),
-        );
+        let post = make_collection_post("X", None, Some(vec!["data:text/plain,hello".to_string()]));
         let id = post.create_id();
         let result = post.validate(Some(&id));
         assert!(result.is_err());

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -33,6 +33,7 @@ pub enum PubkyAppPostKind {
     Video,
     Link,
     File,
+    Collection,
     #[serde(other)]
     Unknown,
 }
@@ -58,6 +59,7 @@ impl FromStr for PubkyAppPostKind {
             "video" => Ok(PubkyAppPostKind::Video),
             "link" => Ok(PubkyAppPostKind::Link),
             "file" => Ok(PubkyAppPostKind::File),
+            "collection" => Ok(PubkyAppPostKind::Collection),
             _ => Err(format!("Invalid content kind: {}", s)),
         }
     }
@@ -91,6 +93,7 @@ impl PubkyAppPostEmbed {
             PubkyAppPostKind::Video => "Video".to_string(),
             PubkyAppPostKind::Link => "Link".to_string(),
             PubkyAppPostKind::File => "File".to_string(),
+            PubkyAppPostKind::Collection => "Collection".to_string(),
             PubkyAppPostKind::Unknown => "Unknown".to_string(),
         }
         // pub fn kind(&self) -> PubkyAppPostKind {
@@ -101,6 +104,25 @@ impl PubkyAppPostEmbed {
     pub fn uri(&self) -> String {
         self.uri.clone()
     }
+}
+
+/// Typed JSON envelope stored in `PubkyAppPost::content` when `kind == Collection`.
+///
+/// A collection post curates an ordered list of other posts (URIs in `attachments`)
+/// under a `name` and optional `description`. The envelope is parsed and validated
+/// by the spec but never re-serialized as a top-level homeserver object.
+///
+/// Forward-compat: `#[serde(deny_unknown_fields)]` is intentionally NOT used so
+/// future minor versions can add fields (e.g. `cover_image`) without breaking
+/// older parsers. New fields must be additive and ignorable.
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub struct PubkyAppCollectionContent {
+    /// Display name of the collection (1..=100 unicode scalars after trim).
+    pub name: String,
+    /// Optional human-readable description (..=500 unicode scalars).
+    pub description: Option<String>,
 }
 
 /// Represents raw post in homeserver with content and kind
@@ -143,6 +165,7 @@ impl PubkyAppPost {
             PubkyAppPostKind::Video => "Video".to_string(),
             PubkyAppPostKind::Link => "Link".to_string(),
             PubkyAppPostKind::File => "File".to_string(),
+            PubkyAppPostKind::Collection => "Collection".to_string(),
             PubkyAppPostKind::Unknown => "Unknown".to_string(),
         }
         // pub fn kind(&self) -> PubkyAppPostKind {
@@ -276,6 +299,72 @@ impl Validatable for PubkyAppPost {
             }
         }
 
+        // Collection posts use a typed JSON envelope in `content` and lift the
+        // attachment caps. They forbid `parent` and `embed`. Branch out before the
+        // legacy kind-switch so the existing per-kind tuple stays untouched.
+        if matches!(self.kind, PubkyAppPostKind::Collection) {
+            if self.parent.is_some() || self.embed.is_some() {
+                return Err(
+                    "Validation Error: Collection posts cannot have parent or embed".into(),
+                );
+            }
+            if self.content.chars().count() > VALIDATION_LIMITS.collection_content_max_length {
+                return Err(format!(
+                    "Validation Error: Collection content exceeds max length {}",
+                    VALIDATION_LIMITS.collection_content_max_length
+                ));
+            }
+            let envelope: PubkyAppCollectionContent = serde_json::from_str(&self.content)
+                .map_err(|e| {
+                    format!(
+                        "Validation Error: Collection content must be a valid JSON envelope: {}",
+                        e
+                    )
+                })?;
+            let name_chars = envelope.name.trim().chars().count();
+            if !(1..=100).contains(&name_chars) {
+                return Err(
+                    "Validation Error: Collection name must be 1..=100 characters".into(),
+                );
+            }
+            if let Some(desc) = &envelope.description {
+                if desc.chars().count() > 500 {
+                    return Err(
+                        "Validation Error: Collection description exceeds 500 characters".into(),
+                    );
+                }
+            }
+            if let Some(attachments) = &self.attachments {
+                if attachments.len() > VALIDATION_LIMITS.collection_items_max_count {
+                    return Err(format!(
+                        "Validation Error: Collection cannot have more than {} items",
+                        VALIDATION_LIMITS.collection_items_max_count
+                    ));
+                }
+                for uri in attachments {
+                    if uri.chars().count() > VALIDATION_LIMITS.collection_item_uri_max_length {
+                        return Err(format!(
+                            "Validation Error: Collection item URI exceeds {} characters",
+                            VALIDATION_LIMITS.collection_item_uri_max_length
+                        ));
+                    }
+                    let parsed = Url::parse(uri).map_err(|_| {
+                        format!("Validation Error: Invalid attachment URL: {}", uri)
+                    })?;
+                    if !VALIDATION_LIMITS
+                        .post_allowed_attachment_protocols
+                        .contains(&parsed.scheme())
+                    {
+                        return Err(format!(
+                            "Validation Error: Disallowed attachment protocol: {}",
+                            parsed.scheme()
+                        ));
+                    }
+                }
+            }
+            return Ok(());
+        }
+
         // Validate content length based on post kind
         let (max_length, kind_name) = match self.kind {
             PubkyAppPostKind::Short => (VALIDATION_LIMITS.post_short_content_max_length, "Short"),
@@ -287,7 +376,9 @@ impl Validatable for PubkyAppPost {
                 VALIDATION_LIMITS.post_short_content_max_length,
                 "Image/Video/Link/File",
             ),
-            PubkyAppPostKind::Unknown => unreachable!("guarded by early-return above"),
+            PubkyAppPostKind::Collection | PubkyAppPostKind::Unknown => {
+                unreachable!("guarded by early-return above")
+            }
         };
 
         if self.content.chars().count() > max_length {
@@ -1007,7 +1098,7 @@ mod tests {
         // FromStr stays strict: it does NOT produce Unknown for arbitrary input.
         // Unknown is exclusively a serde catch-all.
         assert!(PubkyAppPostKind::from_str("foobar").is_err());
-        assert!(PubkyAppPostKind::from_str("collection").is_err());
+        assert!(PubkyAppPostKind::from_str("totally-new-kind").is_err());
     }
 
     #[test]
@@ -1064,5 +1155,281 @@ mod tests {
             attachments: None,
         };
         assert_eq!(post.kind(), "Unknown");
+    }
+
+    // ----- v0.5.0 Collection variant + PubkyAppCollectionContent envelope -----
+
+    fn collection_envelope_json(name: &str, description: Option<&str>) -> String {
+        match description {
+            Some(d) => serde_json::to_string(&PubkyAppCollectionContent {
+                name: name.to_string(),
+                description: Some(d.to_string()),
+            })
+            .unwrap(),
+            None => serde_json::to_string(&PubkyAppCollectionContent {
+                name: name.to_string(),
+                description: None,
+            })
+            .unwrap(),
+        }
+    }
+
+    fn make_collection_post(
+        name: &str,
+        description: Option<&str>,
+        attachments: Option<Vec<String>>,
+    ) -> PubkyAppPost {
+        PubkyAppPost::new(
+            collection_envelope_json(name, description),
+            PubkyAppPostKind::Collection,
+            None,
+            None,
+            attachments,
+        )
+    }
+
+    #[test]
+    fn test_collection_post_roundtrip_valid() {
+        let post = make_collection_post(
+            "AI papers",
+            Some("Best stuff"),
+            Some(vec![
+                "pubky://userA/pub/pubky.app/posts/0034A0X7NJ52A".to_string(),
+                "pubky://userB/pub/pubky.app/posts/0034A0X7NJ52B".to_string(),
+                "pubky://userC/pub/pubky.app/posts/0034A0X7NJ52C".to_string(),
+            ]),
+        );
+        let id = post.create_id();
+        let blob = serde_json::to_vec(&post).unwrap();
+        let parsed = <PubkyAppPost as Validatable>::try_from(&blob, &id).unwrap();
+        assert_eq!(parsed.kind, PubkyAppPostKind::Collection);
+        assert_eq!(parsed.attachments.as_ref().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn test_collection_post_rejects_malformed_envelope() {
+        let post = PubkyAppPost::new(
+            "this is not JSON".to_string(),
+            PubkyAppPostKind::Collection,
+            None,
+            None,
+            None,
+        );
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("JSON envelope"),
+            "expected JSON envelope error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_collection_post_rejects_empty_name() {
+        let post = make_collection_post("", None, None);
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("name"));
+    }
+
+    #[test]
+    fn test_collection_post_rejects_oversized_name() {
+        // 101 grapheme-ish chars; mix in emoji to confirm we count by unicode scalars, not bytes.
+        let oversized = "a".repeat(99) + "🚀🚀";
+        assert_eq!(oversized.chars().count(), 101);
+        let post = make_collection_post(&oversized, None, None);
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("name"));
+    }
+
+    #[test]
+    fn test_collection_post_accepts_max_name() {
+        let exactly_100 = "a".repeat(100);
+        assert_eq!(exactly_100.chars().count(), 100);
+        let post = make_collection_post(&exactly_100, None, None);
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_collection_post_rejects_oversized_description() {
+        let too_long = "a".repeat(501);
+        let post = make_collection_post("X", Some(&too_long), None);
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("description"));
+    }
+
+    #[test]
+    fn test_collection_post_rejects_parent() {
+        let post = PubkyAppPost::new(
+            collection_envelope_json("X", None),
+            PubkyAppPostKind::Collection,
+            Some("pubky://userA/pub/pubky.app/posts/0034A0X7NJ52A".to_string()),
+            None,
+            None,
+        );
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("parent or embed"),
+            "expected parent-or-embed error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_collection_post_rejects_embed() {
+        let post = PubkyAppPost::new(
+            collection_envelope_json("X", None),
+            PubkyAppPostKind::Collection,
+            None,
+            Some(PubkyAppPostEmbed {
+                kind: PubkyAppPostKind::Short,
+                uri: "pubky://userA/pub/pubky.app/posts/0034A0X7NJ52A".to_string(),
+            }),
+            None,
+        );
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("parent or embed"));
+    }
+
+    #[test]
+    fn test_collection_post_accepts_100_attachments() {
+        let attachments: Vec<String> = (0..100)
+            .map(|i| format!("pubky://userA/pub/pubky.app/posts/{:013}", i))
+            .collect();
+        let post = make_collection_post("Big list", None, Some(attachments));
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_collection_post_rejects_101_attachments() {
+        let attachments: Vec<String> = (0..101)
+            .map(|i| format!("pubky://userA/pub/pubky.app/posts/{:013}", i))
+            .collect();
+        let post = make_collection_post("Too big", None, Some(attachments));
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("100 items"));
+    }
+
+    #[test]
+    fn test_collection_post_accepts_300_char_uri() {
+        // Build a pubky URI with the user host + a long path filling out to exactly 300 chars.
+        let prefix = "pubky://userA/pub/pubky.app/posts/";
+        let pad = "x".repeat(300 - prefix.chars().count());
+        let uri = format!("{}{}", prefix, pad);
+        assert_eq!(uri.chars().count(), 300);
+        let post = make_collection_post("X", None, Some(vec![uri]));
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_collection_post_rejects_301_char_uri() {
+        let prefix = "pubky://userA/pub/pubky.app/posts/";
+        let pad = "x".repeat(301 - prefix.chars().count());
+        let uri = format!("{}{}", prefix, pad);
+        assert_eq!(uri.chars().count(), 301);
+        let post = make_collection_post("X", None, Some(vec![uri]));
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("URI exceeds"));
+    }
+
+    #[test]
+    fn test_postkind_collection_display_lowercase() {
+        assert_eq!(PubkyAppPostKind::Collection.to_string(), "collection");
+    }
+
+    #[test]
+    fn test_postkind_fromstr_collection() {
+        assert_eq!(
+            PubkyAppPostKind::from_str("collection").unwrap(),
+            PubkyAppPostKind::Collection
+        );
+    }
+
+    #[test]
+    fn test_collection_post_accepts_zero_items() {
+        // Curators may create a draft and add items later via edits.
+        let post = make_collection_post("Drafts", None, None);
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_collection_envelope_tolerates_extra_fields() {
+        // Forward-compat: the envelope intentionally does NOT use deny_unknown_fields,
+        // so future minor versions can add fields like `cover_image` without breaking
+        // older parsers. This test locks in that behavior.
+        let envelope_json = r#"{"name":"X","description":"Y","cover_image":"https://example.com/x.png"}"#;
+        let post = PubkyAppPost::new(
+            envelope_json.to_string(),
+            PubkyAppPostKind::Collection,
+            None,
+            None,
+            None,
+        );
+        let id = post.create_id();
+        assert!(
+            post.validate(Some(&id)).is_ok(),
+            "extra envelope fields must be tolerated"
+        );
+    }
+
+    #[test]
+    fn test_collection_post_rejects_disallowed_attachment_protocol() {
+        let post = make_collection_post(
+            "X",
+            None,
+            Some(vec!["ftp://example.com/file".to_string()]),
+        );
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Disallowed attachment protocol"));
+    }
+
+    #[test]
+    fn test_existing_post_kinds_unchanged_with_collection() {
+        // Regression: each of the six legacy lowercase kinds still round-trips after
+        // adding Collection. Catches accidental ordering / serde changes.
+        for s in ["short", "long", "image", "video", "link", "file"] {
+            let json = format!(
+                r#"{{"content":"x","kind":"{}","parent":null,"embed":null,"attachments":null}}"#,
+                s
+            );
+            let post: PubkyAppPost = serde_json::from_str(&json).unwrap();
+            let re = serde_json::to_value(&post.kind).unwrap();
+            assert_eq!(re.as_str(), Some(s), "kind={} did not round-trip", s);
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn test_postkind_collection_wasm_getter() {
+        let post = PubkyAppPost {
+            content: collection_envelope_json("X", None),
+            kind: PubkyAppPostKind::Collection,
+            parent: None,
+            embed: None,
+            attachments: None,
+        };
+        assert_eq!(post.kind(), "Collection");
     }
 }

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -120,7 +120,7 @@ impl PubkyAppPostEmbed {
 
 /// Typed JSON envelope stored in `PubkyAppPost::content` when `kind == Collection`.
 ///
-/// A collection post curates an ordered list of URIs (via `attachments`)
+/// A collection post curates an ordered list of URIs (via `items`)
 /// under a `name` and optional `description`. The envelope is parsed and validated
 /// by the spec but never re-serialized as a top-level homeserver object.
 ///
@@ -140,12 +140,18 @@ impl PubkyAppPostEmbed {
 #[serde(rename_all = "snake_case")]
 pub struct PubkyAppCollectionContent {
     /// Display name of the collection. Length bounded by
-    /// `VALIDATION_LIMITS.collection_name_{min,max}_length` (in unicode
-    /// scalars, after trim).
+    /// `VALIDATION_LIMITS.collection_name_{min,max}_length` (unicode scalars).
+    /// Whitespace-only names are rejected separately by the validator.
     pub name: String,
     /// Optional human-readable description. Length bounded by
     /// `VALIDATION_LIMITS.collection_description_max_length` (unicode scalars).
     pub description: Option<String>,
+    /// Ordered list of URIs this collection curates. Bounded by
+    /// `VALIDATION_LIMITS.collection_items_max_count` and
+    /// `VALIDATION_LIMITS.collection_item_uri_max_length`. Each URI must use
+    /// a protocol in `VALIDATION_LIMITS.post_allowed_attachment_protocols`.
+    #[serde(default)]
+    pub items: Vec<String>,
 }
 
 /// Represents raw post in homeserver with content and kind
@@ -320,13 +326,19 @@ impl Validatable for PubkyAppPost {
             }
         }
 
-        // Collection posts use a typed JSON envelope in `content` and lift the
-        // attachment caps. They forbid `parent` and `embed`. Branch out before the
-        // legacy kind-switch so the existing per-kind tuple stays untouched.
         if matches!(self.kind, PubkyAppPostKind::Collection) {
             if self.parent.is_some() || self.embed.is_some() {
                 return Err(
                     "Validation Error: Collection posts cannot have parent or embed".into(),
+                );
+            }
+            // Anti-misuse guard: items belong in the envelope, not in
+            // `post.attachments`. Relax this when Collections gain real
+            // attachments (e.g. cover image).
+            if matches!(&self.attachments, Some(a) if !a.is_empty()) {
+                return Err(
+                    "Validation Error: Collection posts must not use post.attachments — items belong in the content envelope"
+                        .into(),
                 );
             }
             if self.content.chars().count() > VALIDATION_LIMITS.collection_content_max_length {
@@ -342,9 +354,6 @@ impl Validatable for PubkyAppPost {
                         e
                     )
                 })?;
-            // Whitespace-only names are not meaningful; reject them explicitly
-            // so the length check below can count the full string (matching
-            // description's no-trim behavior).
             if envelope.name.trim().is_empty() {
                 return Err(
                     "Validation Error: Collection name must contain non-whitespace characters"
@@ -368,40 +377,35 @@ impl Validatable for PubkyAppPost {
                     ));
                 }
             }
-            if let Some(attachments) = &self.attachments {
-                if attachments.len() > VALIDATION_LIMITS.collection_items_max_count {
+            if envelope.items.len() > VALIDATION_LIMITS.collection_items_max_count {
+                return Err(format!(
+                    "Validation Error: Collection cannot have more than {} items",
+                    VALIDATION_LIMITS.collection_items_max_count
+                ));
+            }
+            for (index, uri) in envelope.items.iter().enumerate() {
+                if uri.chars().count() > VALIDATION_LIMITS.collection_item_uri_max_length {
                     return Err(format!(
-                        "Validation Error: Collection cannot have more than {} items",
-                        VALIDATION_LIMITS.collection_items_max_count
+                        "Validation Error: Collection item URI exceeds {} characters",
+                        VALIDATION_LIMITS.collection_item_uri_max_length
                     ));
                 }
-                for (index, uri) in attachments.iter().enumerate() {
-                    if uri.chars().count() > VALIDATION_LIMITS.collection_item_uri_max_length {
-                        return Err(format!(
-                            "Validation Error: Collection item URI exceeds {} characters",
-                            VALIDATION_LIMITS.collection_item_uri_max_length
-                        ));
-                    }
-                    // Note: rejects pubky-sdk short-form URIs `pubky<pubkey>/pub/...`
-                    // (no `://`). Systemic across spec; tracked as a follow-up issue.
-                    let parsed = Url::parse(uri).map_err(|_| {
-                        format!("Validation Error: Invalid attachment URL: {}", uri)
-                    })?;
-                    if !VALIDATION_LIMITS
+                let parsed = Url::parse(uri)
+                    .map_err(|_| format!("Validation Error: Invalid item URL: {}", uri))?;
+                if !VALIDATION_LIMITS
+                    .post_allowed_attachment_protocols
+                    .contains(&parsed.scheme())
+                {
+                    let allowed_protocols = VALIDATION_LIMITS
                         .post_allowed_attachment_protocols
-                        .contains(&parsed.scheme())
-                    {
-                        let allowed_protocols = VALIDATION_LIMITS
-                            .post_allowed_attachment_protocols
-                            .iter()
-                            .map(|p| format!("{}://", p))
-                            .collect::<Vec<_>>()
-                            .join(", ");
-                        return Err(format!(
-                            "Validation Error: Collection attachment URL at index {} uses disallowed protocol '{}'; must use one of the allowed protocols: {}",
-                            index, parsed.scheme(), allowed_protocols
-                        ));
-                    }
+                        .iter()
+                        .map(|p| format!("{}://", p))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    return Err(format!(
+                        "Validation Error: Collection item URL at index {} uses disallowed protocol '{}'; must use one of the allowed protocols: {}",
+                        index, parsed.scheme(), allowed_protocols
+                    ));
                 }
             }
             return Ok(());
@@ -1214,32 +1218,27 @@ mod tests {
 
     // ----- v0.5.0 Collection variant + PubkyAppCollectionContent envelope -----
 
-    fn collection_envelope_json(name: &str, description: Option<&str>) -> String {
-        match description {
-            Some(d) => serde_json::to_string(&PubkyAppCollectionContent {
-                name: name.to_string(),
-                description: Some(d.to_string()),
-            })
-            .unwrap(),
-            None => serde_json::to_string(&PubkyAppCollectionContent {
-                name: name.to_string(),
-                description: None,
-            })
-            .unwrap(),
-        }
+    fn collection_envelope_json(name: &str, description: Option<&str>, items: &[String]) -> String {
+        serde_json::to_string(&PubkyAppCollectionContent {
+            name: name.to_string(),
+            description: description.map(|d| d.to_string()),
+            items: items.to_vec(),
+        })
+        .unwrap()
     }
 
     fn make_collection_post(
         name: &str,
         description: Option<&str>,
-        attachments: Option<Vec<String>>,
+        items: Option<Vec<String>>,
     ) -> PubkyAppPost {
+        let items = items.unwrap_or_default();
         PubkyAppPost::new(
-            collection_envelope_json(name, description),
+            collection_envelope_json(name, description, &items),
             PubkyAppPostKind::Collection,
             None,
             None,
-            attachments,
+            None,
         )
     }
 
@@ -1258,7 +1257,9 @@ mod tests {
         let blob = serde_json::to_vec(&post).unwrap();
         let parsed = <PubkyAppPost as Validatable>::try_from(&blob, &id).unwrap();
         assert_eq!(parsed.kind, PubkyAppPostKind::Collection);
-        assert_eq!(parsed.attachments.as_ref().unwrap().len(), 3);
+        assert!(parsed.attachments.is_none());
+        let envelope: PubkyAppCollectionContent = serde_json::from_str(&parsed.content).unwrap();
+        assert_eq!(envelope.items.len(), 3);
     }
 
     #[test]
@@ -1394,7 +1395,7 @@ mod tests {
     #[test]
     fn test_collection_post_rejects_parent() {
         let post = PubkyAppPost::new(
-            collection_envelope_json("X", None),
+            collection_envelope_json("X", None, &[]),
             PubkyAppPostKind::Collection,
             Some("pubky://userA/pub/pubky.app/posts/0034A0X7NJ52A".to_string()),
             None,
@@ -1414,7 +1415,7 @@ mod tests {
     #[test]
     fn test_collection_post_rejects_embed() {
         let post = PubkyAppPost::new(
-            collection_envelope_json("X", None),
+            collection_envelope_json("X", None, &[]),
             PubkyAppPostKind::Collection,
             None,
             Some(PubkyAppPostEmbed {
@@ -1430,21 +1431,21 @@ mod tests {
     }
 
     #[test]
-    fn test_collection_post_accepts_100_attachments() {
-        let attachments: Vec<String> = (0..100)
+    fn test_collection_post_accepts_100_items() {
+        let items: Vec<String> = (0..100)
             .map(|i| format!("pubky://userA/pub/pubky.app/posts/{:013}", i))
             .collect();
-        let post = make_collection_post("Big list", None, Some(attachments));
+        let post = make_collection_post("Big list", None, Some(items));
         let id = post.create_id();
         assert!(post.validate(Some(&id)).is_ok());
     }
 
     #[test]
-    fn test_collection_post_rejects_101_attachments() {
-        let attachments: Vec<String> = (0..101)
+    fn test_collection_post_rejects_101_items() {
+        let items: Vec<String> = (0..101)
             .map(|i| format!("pubky://userA/pub/pubky.app/posts/{:013}", i))
             .collect();
-        let post = make_collection_post("Too big", None, Some(attachments));
+        let post = make_collection_post("Too big", None, Some(items));
         let id = post.create_id();
         let result = post.validate(Some(&id));
         assert!(result.is_err());
@@ -1519,7 +1520,7 @@ mod tests {
     }
 
     #[test]
-    fn test_collection_post_rejects_disallowed_attachment_protocol() {
+    fn test_collection_post_rejects_disallowed_item_protocol() {
         let post =
             make_collection_post("X", None, Some(vec!["ftp://example.com/file".to_string()]));
         let id = post.create_id();
@@ -1556,6 +1557,65 @@ mod tests {
     }
 
     #[test]
+    fn test_collection_post_rejects_non_empty_attachments() {
+        let post = PubkyAppPost::new(
+            collection_envelope_json("X", None, &[]),
+            PubkyAppPostKind::Collection,
+            None,
+            None,
+            Some(vec![
+                "pubky://userA/pub/pubky.app/posts/0034A0X7NJ52A".to_string()
+            ]),
+        );
+        let id = post.create_id();
+        let err = post
+            .validate(Some(&id))
+            .expect_err("Collection with non-empty post.attachments must be rejected");
+        assert!(
+            err.contains("post.attachments"),
+            "expected anti-misuse error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_collection_post_accepts_missing_items_field() {
+        let envelope_json = r#"{"name":"X"}"#;
+        let post = PubkyAppPost::new(
+            envelope_json.to_string(),
+            PubkyAppPostKind::Collection,
+            None,
+            None,
+            None,
+        );
+        let id = post.create_id();
+        assert!(
+            post.validate(Some(&id)).is_ok(),
+            "missing `items` field must deserialize as empty list via serde(default)"
+        );
+    }
+
+    #[test]
+    fn test_collection_post_envelope_at_max_size() {
+        let items: Vec<String> = (0..VALIDATION_LIMITS.collection_items_max_count)
+            .map(|i| {
+                let prefix = format!("pubky://u{i:03}/pub/pubky.app/posts/");
+                let pad_len =
+                    VALIDATION_LIMITS.collection_item_uri_max_length - prefix.chars().count();
+                format!("{}{}", prefix, "x".repeat(pad_len))
+            })
+            .collect();
+        let max_name = "a".repeat(VALIDATION_LIMITS.collection_name_max_length);
+        let max_desc = "b".repeat(VALIDATION_LIMITS.collection_description_max_length);
+        let post = make_collection_post(&max_name, Some(&max_desc), Some(items));
+        assert!(
+            post.content.chars().count() < VALIDATION_LIMITS.collection_content_max_length,
+            "envelope at max field sizes must fit under collection_content_max_length"
+        );
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
     fn test_existing_post_kinds_unchanged_with_collection() {
         // Regression: each of the six legacy lowercase kinds still round-trips after
         // adding Collection. Catches accidental ordering / serde changes.
@@ -1574,7 +1634,7 @@ mod tests {
     #[wasm_bindgen_test::wasm_bindgen_test]
     fn test_postkind_collection_wasm_getter() {
         let post = PubkyAppPost {
-            content: collection_envelope_json("X", None),
+            content: collection_envelope_json("X", None, &[]),
             kind: PubkyAppPostKind::Collection,
             parent: None,
             embed: None,
@@ -1607,12 +1667,11 @@ mod tests {
 
         let post = result.post();
         assert_eq!(post.kind, PubkyAppPostKind::Collection);
-        assert_eq!(post.attachments.as_ref().unwrap().len(), 1);
-        // Envelope was JSON-encoded into content; round-trip it to confirm
-        // the name/description landed where validation will look for them.
+        assert!(post.attachments.is_none());
         let envelope: PubkyAppCollectionContent = serde_json::from_str(&post.content)
             .expect("Collection content must deserialize as PubkyAppCollectionContent");
         assert_eq!(envelope.name, "My favorites");
         assert_eq!(envelope.description.as_deref(), Some("Best things"));
+        assert_eq!(envelope.items.len(), 1);
     }
 }

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -314,8 +314,8 @@ impl Validatable for PubkyAppPost {
                     VALIDATION_LIMITS.collection_content_max_length
                 ));
             }
-            let envelope: PubkyAppCollectionContent = serde_json::from_str(&self.content)
-                .map_err(|e| {
+            let envelope: PubkyAppCollectionContent =
+                serde_json::from_str(&self.content).map_err(|e| {
                     format!(
                         "Validation Error: Collection content must be a valid JSON envelope: {}",
                         e
@@ -323,9 +323,7 @@ impl Validatable for PubkyAppPost {
                 })?;
             let name_chars = envelope.name.trim().chars().count();
             if !(1..=100).contains(&name_chars) {
-                return Err(
-                    "Validation Error: Collection name must be 1..=100 characters".into(),
-                );
+                return Err("Validation Error: Collection name must be 1..=100 characters".into());
             }
             if let Some(desc) = &envelope.description {
                 if desc.chars().count() > 500 {
@@ -1377,7 +1375,8 @@ mod tests {
         // Forward-compat: the envelope intentionally does NOT use deny_unknown_fields,
         // so future minor versions can add fields like `cover_image` without breaking
         // older parsers. This test locks in that behavior.
-        let envelope_json = r#"{"name":"X","description":"Y","cover_image":"https://example.com/x.png"}"#;
+        let envelope_json =
+            r#"{"name":"X","description":"Y","cover_image":"https://example.com/x.png"}"#;
         let post = PubkyAppPost::new(
             envelope_json.to_string(),
             PubkyAppPostKind::Collection,
@@ -1394,15 +1393,14 @@ mod tests {
 
     #[test]
     fn test_collection_post_rejects_disallowed_attachment_protocol() {
-        let post = make_collection_post(
-            "X",
-            None,
-            Some(vec!["ftp://example.com/file".to_string()]),
-        );
+        let post =
+            make_collection_post("X", None, Some(vec!["ftp://example.com/file".to_string()]));
         let id = post.create_id();
         let result = post.validate(Some(&id));
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Disallowed attachment protocol"));
+        assert!(result
+            .unwrap_err()
+            .contains("Disallowed attachment protocol"));
     }
 
     #[test]

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -1545,4 +1545,37 @@ mod tests {
         };
         assert_eq!(post.kind(), "Collection");
     }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn test_create_collection_post_wasm_builder() {
+        // End-to-end via the JS-facing builder:
+        //   PubkySpecsBuilder.createCollectionPost(name, description?, attachments?)
+        // builds the {name, description} envelope internally, packages it
+        // into a kind=Collection PubkyAppPost, and returns a PostResult
+        // ready to ship to the homeserver. JS callers don't have to
+        // JSON-stringify the envelope themselves.
+        use crate::PubkySpecsBuilder;
+        let pubky_id = "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".to_string();
+        let builder = PubkySpecsBuilder::new(pubky_id).expect("Failed to construct builder");
+        let result = builder
+            .create_collection_post(
+                "My favorites".to_string(),
+                Some("Best things".to_string()),
+                Some(vec![
+                    "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/posts/0034A0X7NJ52A".to_string(),
+                ]),
+            )
+            .expect("createCollectionPost should succeed");
+
+        let post = result.post();
+        assert_eq!(post.kind, PubkyAppPostKind::Collection);
+        assert_eq!(post.attachments.as_ref().unwrap().len(), 1);
+        // Envelope was JSON-encoded into content; round-trip it to confirm
+        // the name/description landed where validation will look for them.
+        let envelope: PubkyAppCollectionContent = serde_json::from_str(&post.content)
+            .expect("Collection content must deserialize as PubkyAppCollectionContent");
+        assert_eq!(envelope.name, "My favorites");
+        assert_eq!(envelope.description.as_deref(), Some("Best things"));
+    }
 }

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -119,9 +119,12 @@ impl PubkyAppPostEmbed {
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub struct PubkyAppCollectionContent {
-    /// Display name of the collection (1..=100 unicode scalars after trim).
+    /// Display name of the collection. Length bounded by
+    /// `VALIDATION_LIMITS.collection_name_{min,max}_length` (in unicode
+    /// scalars, after trim).
     pub name: String,
-    /// Optional human-readable description (..=500 unicode scalars).
+    /// Optional human-readable description. Length bounded by
+    /// `VALIDATION_LIMITS.collection_description_max_length` (unicode scalars).
     pub description: Option<String>,
 }
 
@@ -322,14 +325,20 @@ impl Validatable for PubkyAppPost {
                     )
                 })?;
             let name_chars = envelope.name.trim().chars().count();
-            if !(1..=100).contains(&name_chars) {
-                return Err("Validation Error: Collection name must be 1..=100 characters".into());
+            let name_min = VALIDATION_LIMITS.collection_name_min_length;
+            let name_max = VALIDATION_LIMITS.collection_name_max_length;
+            if !(name_min..=name_max).contains(&name_chars) {
+                return Err(format!(
+                    "Validation Error: Collection name must be {}..={} characters",
+                    name_min, name_max
+                ));
             }
             if let Some(desc) = &envelope.description {
-                if desc.chars().count() > 500 {
-                    return Err(
-                        "Validation Error: Collection description exceeds 500 characters".into(),
-                    );
+                if desc.chars().count() > VALIDATION_LIMITS.collection_description_max_length {
+                    return Err(format!(
+                        "Validation Error: Collection description exceeds {} characters",
+                        VALIDATION_LIMITS.collection_description_max_length
+                    ));
                 }
             }
             if let Some(attachments) = &self.attachments {

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -124,6 +124,14 @@ impl PubkyAppPostEmbed {
 /// under a `name` and optional `description`. The envelope is parsed and validated
 /// by the spec but never re-serialized as a top-level homeserver object.
 ///
+/// **Construction**: this struct is deserialized from the post's `content` JSON
+/// envelope during validation and is **not** intended to be constructed by
+/// callers directly. It is re-exported publicly (via `lib.rs`) so SDK consumers
+/// can inspect the envelope shape (OpenAPI schema, type definitions), but the
+/// authoritative way to produce a Collection post is to author a `PubkyAppPost`
+/// with `kind: Collection` and a `content` string that JSON-parses into this
+/// shape.
+///
 /// Forward-compat: `#[serde(deny_unknown_fields)]` is intentionally NOT used so
 /// future minor versions can add fields (e.g. `cover_image`) without breaking
 /// older parsers. New fields must be additive and ignorable.
@@ -358,13 +366,22 @@ impl Validatable for PubkyAppPost {
                         VALIDATION_LIMITS.collection_items_max_count
                     ));
                 }
-                for uri in attachments {
+                for (index, uri) in attachments.iter().enumerate() {
                     if uri.chars().count() > VALIDATION_LIMITS.collection_item_uri_max_length {
                         return Err(format!(
                             "Validation Error: Collection item URI exceeds {} characters",
                             VALIDATION_LIMITS.collection_item_uri_max_length
                         ));
                     }
+                    // TODO(pubky-sdk-absolute-uris): `Url::parse` rejects the
+                    // shortened pubky-sdk absolute URI form
+                    // `pubky<pubkey>/pub/<app>/<path>` (no `://` separator),
+                    // even though pubky-core / pubky-sdk treat that form as a
+                    // valid pubky resource. This rejection is systemic across
+                    // pubky-app-specs (tag.rs, bookmark.rs, user.rs, file.rs,
+                    // common.rs, uri_parser.rs all do `Url::parse` the same
+                    // way). Open a follow-up issue to add a normalization
+                    // shim that accepts both forms once Collections lands.
                     let parsed = Url::parse(uri).map_err(|_| {
                         format!("Validation Error: Invalid attachment URL: {}", uri)
                     })?;
@@ -372,9 +389,15 @@ impl Validatable for PubkyAppPost {
                         .post_allowed_attachment_protocols
                         .contains(&parsed.scheme())
                     {
+                        let allowed_protocols = VALIDATION_LIMITS
+                            .post_allowed_attachment_protocols
+                            .iter()
+                            .map(|p| format!("{}://", p))
+                            .collect::<Vec<_>>()
+                            .join(", ");
                         return Err(format!(
-                            "Validation Error: Disallowed attachment protocol: {}",
-                            parsed.scheme()
+                            "Validation Error: Collection attachment URL at index {} uses disallowed protocol '{}'; must use one of the allowed protocols: {}",
+                            index, parsed.scheme(), allowed_protocols
                         ));
                     }
                 }
@@ -1473,7 +1496,7 @@ mod tests {
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
-            .contains("Disallowed attachment protocol"));
+            .contains("must use one of the allowed protocols"));
     }
 
     #[test]
@@ -1490,7 +1513,7 @@ mod tests {
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
-            .contains("Disallowed attachment protocol"));
+            .contains("must use one of the allowed protocols"));
     }
 
     #[test]
@@ -1506,7 +1529,7 @@ mod tests {
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
-            .contains("Disallowed attachment protocol"));
+            .contains("must use one of the allowed protocols"));
     }
 
     #[test]

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -65,6 +65,20 @@ impl FromStr for PubkyAppPostKind {
     }
 }
 
+impl PubkyAppPostKind {
+    /// Returns `true` for every spec-recognized variant, `false` for `Unknown`.
+    ///
+    /// `Unknown` is the forwards-compat catch-all variant (via `#[serde(other)]`)
+    /// that captures any post-kind string this version of the spec doesn't
+    /// recognize yet. Most consumers — indexers, stream filters, search ranking —
+    /// want to skip such posts, and this helper lets them write
+    /// `if kind.is_known() { ... }` rather than
+    /// `if !matches!(kind, PubkyAppPostKind::Unknown) { ... }`.
+    pub fn is_known(&self) -> bool {
+        !matches!(self, PubkyAppPostKind::Unknown)
+    }
+}
+
 /// Represents embedded content within a post
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 #[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
@@ -1106,6 +1120,19 @@ mod tests {
         // Unknown is exclusively a serde catch-all.
         assert!(PubkyAppPostKind::from_str("foobar").is_err());
         assert!(PubkyAppPostKind::from_str("totally-new-kind").is_err());
+    }
+
+    #[test]
+    fn test_is_known_returns_true_for_all_recognized_variants() {
+        use PubkyAppPostKind::*;
+        for k in [Short, Long, Image, Video, Link, File, Collection] {
+            assert!(k.is_known(), "{k:?} should be known");
+        }
+    }
+
+    #[test]
+    fn test_is_known_returns_false_for_unknown() {
+        assert!(!PubkyAppPostKind::Unknown.is_known());
     }
 
     #[test]

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -311,19 +311,17 @@ impl PubkySpecsBuilder {
         &self,
         name: String,
         description: Option<String>,
-        attachments: Option<Vec<String>>,
+        items: Option<Vec<String>>,
     ) -> Result<PostResult, String> {
-        let envelope = PubkyAppCollectionContent { name, description };
+        let envelope = PubkyAppCollectionContent {
+            name,
+            description,
+            items: items.unwrap_or_default(),
+        };
         let content = serde_json::to_string(&envelope)
             .map_err(|e| format!("Failed to serialize Collection envelope: {e}"))?;
 
-        let post = PubkyAppPost::new(
-            content,
-            PubkyAppPostKind::Collection,
-            None,
-            None,
-            attachments,
-        );
+        let post = PubkyAppPost::new(content, PubkyAppPostKind::Collection, None, None, None);
         let post_id = post.create_id();
         post.validate(Some(&post_id))?;
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -294,6 +294,45 @@ impl PubkySpecsBuilder {
         Ok(PostResult { post, meta })
     }
 
+    /// Creates a `kind = Collection` post — a curated list of post URIs under
+    /// a name and optional description.
+    ///
+    /// Convenience wrapper around `createPost` that builds the
+    /// `PubkyAppCollectionContent` envelope (`{ name, description }`) and
+    /// JSON-serializes it into `content` internally, so JS callers don't
+    /// have to stringify the envelope themselves.
+    ///
+    /// `parent` and `embed` are not supported for Collection posts — the
+    /// validator rejects them — so this helper omits those arguments.
+    /// `attachments` carries the curated list of post URIs (validated against
+    /// the protocol allowlist and per-URI length cap).
+    #[wasm_bindgen(js_name = createCollectionPost)]
+    pub fn create_collection_post(
+        &self,
+        name: String,
+        description: Option<String>,
+        attachments: Option<Vec<String>>,
+    ) -> Result<PostResult, String> {
+        let envelope = PubkyAppCollectionContent { name, description };
+        let content = serde_json::to_string(&envelope)
+            .map_err(|e| format!("Failed to serialize Collection envelope: {e}"))?;
+
+        let post = PubkyAppPost::new(
+            content,
+            PubkyAppPostKind::Collection,
+            None,
+            None,
+            attachments,
+        );
+        let post_id = post.create_id();
+        post.validate(Some(&post_id))?;
+
+        let path = PubkyAppPost::create_path(&post_id);
+        let meta = Meta::from_object(Some(&post_id), self.pubky_id.clone(), path);
+
+        Ok(PostResult { post, meta })
+    }
+
     // -----------------------------------------------------------------------------
     // 5. PubkyAppTag
     // -----------------------------------------------------------------------------

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -294,18 +294,16 @@ impl PubkySpecsBuilder {
         Ok(PostResult { post, meta })
     }
 
-    /// Creates a `kind = Collection` post — a curated list of post URIs under
+    /// Creates a `kind = Collection` post — a curated list of URIs under
     /// a name and optional description.
     ///
     /// Convenience wrapper around `createPost` that builds the
-    /// `PubkyAppCollectionContent` envelope (`{ name, description }`) and
+    /// `PubkyAppCollectionContent` envelope (`{ name, description, items }`) and
     /// JSON-serializes it into `content` internally, so JS callers don't
     /// have to stringify the envelope themselves.
     ///
     /// `parent` and `embed` are not supported for Collection posts — the
     /// validator rejects them — so this helper omits those arguments.
-    /// `attachments` carries the curated list of post URIs (validated against
-    /// the protocol allowlist and per-URI length cap).
     #[wasm_bindgen(js_name = createCollectionPost)]
     pub fn create_collection_post(
         &self,


### PR DESCRIPTION
## Summary

Adds the `Collection` variant to `PubkyAppPostKind` plus a typed `PubkyAppCollectionContent` envelope so a collection post can carry a `name`, optional `description`, and an ordered list of post URIs in `attachments`. No new homeserver path; no new top-level type.

**Stacked on top of #115** (the v0.4.5 forwards-compat shim). Reviewers: please review only the commit range above #115 — the v0.4.5 PR is independent. This PR will be retargeted from `feat/spec-v0.4.5-postkind-unknown-shim` to `main` once #115 merges.

## Spec changes

- `PubkyAppPostKind::Collection` placed before `Unknown` so the `#[serde(other)]` catch-all still works.
- `FromStr`, `Display`, both WASM kind-getters wired for the new variant.
- `PubkyAppCollectionContent { name, description }` struct, parsed inside `validate` but never re-serialized as a top-level homeserver object.
- **Forward-compat by design**: NO `#[serde(deny_unknown_fields)]`. Future additive envelope fields (e.g. `cover_image`) must not break older parsers.
- Three new limits (`collection_content_max_length=2_000`, `collection_items_max_count=100`, `collection_item_uri_max_length=300`).
- Kind-gated `validate` early-branch: forbids parent and embed, parses the envelope, validates name (1..=100), description (..=500), attachment count (..=100), per-URI length (..=300), protocol allowlist. Existing kind-switch tuple is untouched for the six legacy kinds.
- VERSION bumped to 0.5.0.

## Locks v1 envelope shape

The envelope ships with **only `name` and `description`**. Deferred from v1:

- No `is_listed` / privacy flag — anything in `/pub/` is public.
- No `is_locked` — Paykit / locks are future work, and may end up as a post-level attribute (across all kinds) rather than buried in the collection envelope.
- No follow-collection primitive, reserved-label registry, or per-item curator commentary.