### PR TITLE
feat: add crockford id validation fn

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -34,6 +34,11 @@ pub fn sanitize_url(input: &str) -> String {
 
 /// Validates structural correctness of a Crockford Base32-encoded ID (13
 /// characters, decodes to 8 bytes). Returns the decoded bytes on success.
+///
+/// # Errors
+///
+/// This function will return an error if `id` is not exactly 13 characters
+/// long, is not valid Crockford Base32, or does not decode to exactly 8 bytes.
 pub fn validate_crockford_id(id: &str) -> Result<[u8; 8], String> {
     if id.len() != 13 {
         return Err("Validation Error: Invalid ID length: must be 13 characters".into());
@@ -68,5 +73,4 @@ mod tests {
     fn invalid_id_fails() {
         assert!(validate_crockford_id("UUUUUUUUUUUUU").is_err());
     }
-
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,6 +1,7 @@
 #[cfg(target_arch = "wasm32")]
 use js_sys::Date;
 
+use base32::{decode, Alphabet};
 use url::Url;
 
 /// Returns the current timestamp in microseconds since the UNIX epoch.
@@ -29,4 +30,43 @@ pub fn sanitize_url(input: &str) -> String {
         Ok(parsed_url) => parsed_url.to_string(),
         Err(_) => trimmed.to_string(),
     }
+}
+
+/// Validates structural correctness of a Crockford Base32-encoded ID (13
+/// characters, decodes to 8 bytes). Returns the decoded bytes on success.
+pub fn validate_crockford_id(id: &str) -> Result<[u8; 8], String> {
+    if id.len() != 13 {
+        return Err("Validation Error: Invalid ID length: must be 13 characters".into());
+    }
+
+    let decoded_bytes = decode(Alphabet::Crockford, id)
+        .ok_or("Validation Error: Invalid Crockford Base32 encoding")?;
+
+    if decoded_bytes.len() != 8 {
+        return Err("Validation Error: Invalid ID length after decoding".into());
+    }
+
+    Ok(decoded_bytes.try_into().unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_id_passes() {
+        let id = "0000000000000";
+        assert!(validate_crockford_id(id).is_ok());
+    }
+
+    #[test]
+    fn wrong_length_fails() {
+        assert!(validate_crockford_id("12345").is_err());
+    }
+
+    #[test]
+    fn invalid_id_fails() {
+        assert!(validate_crockford_id("UUUUUUUUUUUUU").is_err());
+    }
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ mod utils;
 
 // Re-export constants
 pub use constants::{APP_PATH, PROTOCOL, PUBLIC_PATH, VERSION};
+// Re-export common utilities
+pub use common::validate_crockford_id;
 #[doc(inline)]
 pub use limits::*;
 // Re-export domain types

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,5 +1,5 @@
-use crate::common::timestamp;
-use base32::{decode, encode, Alphabet};
+use crate::common::{timestamp, validate_crockford_id};
+use base32::{encode, Alphabet};
 use blake3::Hasher;
 use serde::de::DeserializeOwned;
 
@@ -19,21 +19,11 @@ pub trait TimestampId {
     /// Validates that the provided ID is a valid Crockford Base32-encoded timestamp,
     /// 13 characters long, and represents a reasonable timestamp.
     fn validate_id(&self, id: &str) -> Result<(), String> {
-        // Ensure ID is 13 characters long
-        if id.len() != 13 {
-            return Err("Validation Error: Invalid ID length: must be 13 characters".into());
-        }
-
-        // Decode the Crockford Base32-encoded ID
-        let decoded_bytes =
-            decode(Alphabet::Crockford, id).ok_or("Failed to decode Crockford Base32 ID")?;
-
-        if decoded_bytes.len() != 8 {
-            return Err("Validation Error: Invalid ID length after decoding".into());
-        }
+        // Structural validation (length, encoding, decoded size)
+        let decoded_bytes = validate_crockford_id(id)?;
 
         // Convert the decoded bytes to a timestamp in microseconds
-        let timestamp_micros = i64::from_be_bytes(decoded_bytes.try_into().unwrap());
+        let timestamp_micros = i64::from_be_bytes(decoded_bytes);
 
         // Get current time in microseconds
         let now_micros = timestamp();


### PR DESCRIPTION
Adds a `validate_crockford_id` function that can be used by downstream consumers to validate structural correctness of ids generated by `TimestampId` impl.