### PR TITLE
spec: tighten Collection items to post URIs only + document Collection in README

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-app-specs"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky-app-specs"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 rust-version = "1.89"
 description = "Pubky.app Data Model Specifications"

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Collection posts use a typed JSON envelope as their `content`. The envelope shap
 
 - `name`: required, 1 to 100 unicode scalars, non-whitespace-only.
 - `description`: optional, max 500 scalars.
-- `items`: ordered list of pubky.app post URIs (max 100, each at most 300 chars). Each URI must resolve to a `Resource::Post` (form: `pubky://<pubky-id>/pub/pubky.app/posts/<post-id>`); file, profile, and external URIs are rejected.
+- `items`: ordered list of pubky.app post URIs (max 100, each at most 300 chars). Each URI must resolve to a `Resource::Post` (form: `pubky://<pubky-id>/pub/pubky.app/posts/<post-id>`); all other URI types are rejected.
 
 For `kind = collection`, `parent`, `embed`, and `post.attachments` must be unset. The `content` field is bounded by 40000 scalars instead of the regular short/long caps.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pubky.app Data Model Specification
 
-_Version 0.4.4_
+_Version 0.5.1_
 
 > ⚠️ **Warning: Rapid Development Phase**  
 > This specification is in an **early development phase** and is evolving quickly. Expect frequent changes and updates as the system matures. Consider this a **v0 draft**.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Pubky.app models are designed for decentralized content sharing. The system uses
 - `video`
 - `link`
 - `file`
+- `collection`
 
 **Example: Valid Post**
 
@@ -172,6 +173,27 @@ Pubky.app models are designed for decentralized content sharing. The system uses
   "attachments": ["pubky://user_id/pub/pubky.app/files/0000000000000"]
 }
 ```
+
+**Note on `kind = collection`:**
+
+Collection posts use a typed JSON envelope as their `content`. The envelope shape is:
+
+```json
+{
+  "name": "AI papers",
+  "description": "Best stuff",
+  "items": [
+    "pubky://userA/pub/pubky.app/posts/0034A0X7NJ52A",
+    "pubky://userB/pub/pubky.app/posts/0034A0X7NJ52B"
+  ]
+}
+```
+
+- `name` — required, 1–100 unicode scalars, non-whitespace-only.
+- `description` — optional, max 500 scalars.
+- `items` — ordered list of URIs (≤ 100, each ≤ 300 chars, protocols in `[pubky, http, https]`).
+
+For `kind = collection`, `parent`, `embed`, and `post.attachments` must be unset. The `content` field is bounded by 40000 scalars instead of the regular short/long caps.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -189,9 +189,9 @@ Collection posts use a typed JSON envelope as their `content`. The envelope shap
 }
 ```
 
-- `name` — required, 1–100 unicode scalars, non-whitespace-only.
-- `description` — optional, max 500 scalars.
-- `items` — ordered list of URIs (≤ 100, each ≤ 300 chars, protocols in `[pubky, http, https]`).
+- `name`: required, 1 to 100 unicode scalars, non-whitespace-only.
+- `description`: optional, max 500 scalars.
+- `items`: ordered list of pubky.app post URIs (max 100, each at most 300 chars). Each URI must resolve to a `Resource::Post` (form: `pubky://<pubky-id>/pub/pubky.app/posts/<post-id>`); file, profile, and external URIs are rejected.
 
 For `kind = collection`, `parent`, `embed`, and `post.attachments` must be unset. The `content` field is bounded by 40000 scalars instead of the regular short/long caps.
 

--- a/pkg/LICENSE
+++ b/pkg/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2024-2026 Synonym
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/pkg/package.json
+++ b/pkg/package.json
@@ -55,5 +55,5 @@
   "sideEffects": false,
   "type": "module",
   "types": "pubky_app_specs.d.ts",
-  "version": "0.4.4"
+  "version": "0.5.1"
 }

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -59,8 +59,9 @@ pub struct ValidationLimits {
     pub post_allowed_attachment_protocols: &'static [&'static str],
     /// Maximum scalar count (`chars().count()`, not bytes) for the JSON
     /// envelope content of a Collection post. Sized to hold a
-    /// max-population envelope: 100 items × 300 chars + name + description
-    /// + JSON overhead + headroom for additive future fields.
+    /// max-population envelope (100 canonical post URIs at 94 chars each,
+    /// plus name, description, JSON overhead, and headroom for additive
+    /// future fields).
     pub collection_content_max_length: usize,
     /// Minimum character count for a Collection name. The validator rejects
     /// whitespace-only names separately, then counts the full string length.
@@ -72,8 +73,6 @@ pub struct ValidationLimits {
     pub collection_description_max_length: usize,
     /// Maximum number of items (attachment URIs) per Collection.
     pub collection_items_max_count: usize,
-    /// Maximum character count for a single Collection item URI.
-    pub collection_item_uri_max_length: usize,
     /// Minimum file name length in characters.
     pub file_name_min_length: usize,
     /// Maximum file name length in characters.
@@ -109,7 +108,6 @@ pub const VALIDATION_LIMITS: ValidationLimits = ValidationLimits {
     collection_name_max_length: 100,
     collection_description_max_length: 500,
     collection_items_max_count: 100,
-    collection_item_uri_max_length: 300,
     file_name_min_length: 1,
     file_name_max_length: 255,
     file_src_max_length: 1024,

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -150,7 +150,9 @@ pub struct PubkyAppCollectionContent {
     /// Ordered list of URIs this collection curates. Bounded by
     /// `VALIDATION_LIMITS.collection_items_max_count` and
     /// `VALIDATION_LIMITS.collection_item_uri_max_length`. Each URI must use
-    /// a protocol in `VALIDATION_LIMITS.post_allowed_attachment_protocols`.
+   /// Ordered list of Post URIs this collection curates. Bounded by
+   /// `VALIDATION_LIMITS.collection_items_max_count` and
+   /// `VALIDATION_LIMITS.collection_item_uri_max_length`.
     #[serde(default)]
     pub items: Vec<String>,
 }

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -391,10 +391,7 @@ impl Validatable for PubkyAppPost {
                     ));
                 }
                 validate_collection_item_uri(uri).map_err(|e| {
-                    format!(
-                        "Validation Error: Collection item at index {}: {}",
-                        index, e
-                    )
+                    format!("Validation Error: Collection item at index {index}: {e}")
                 })?;
             }
             return Ok(());

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -504,9 +504,6 @@ impl Validatable for PubkyAppPost {
 mod tests {
     use super::*;
 
-    /// 52-char Crockford-base32 pubky id used in Collection-item URIs for tests.
-    /// Real pubky user-ids are 52 chars; shorter placeholders (e.g. `userA`)
-    /// fail `ParsedUri::try_from`.
     const TEST_PUBKY_ID: &str = "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo";
     use crate::{traits::Validatable, APP_PATH, PUBLIC_PATH};
 

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -147,9 +147,9 @@ pub struct PubkyAppCollectionContent {
     /// Optional human-readable description. Length bounded by
     /// `VALIDATION_LIMITS.collection_description_max_length` (unicode scalars).
     pub description: Option<String>,
-    /// Ordered list of Post URIs this collection curates. Bounded by
-    /// `VALIDATION_LIMITS.collection_items_max_count` and
-    /// `VALIDATION_LIMITS.collection_item_uri_max_length`.
+    /// Ordered list of Post URIs this collection curates. Count bounded by
+    /// `VALIDATION_LIMITS.collection_items_max_count`; each URI must be in
+    /// exact canonical form (see `validate_collection_item_uri`).
     #[serde(default)]
     pub items: Vec<String>,
 }
@@ -384,12 +384,6 @@ impl Validatable for PubkyAppPost {
                 ));
             }
             for (index, uri) in envelope.items.iter().enumerate() {
-                if uri.chars().count() > VALIDATION_LIMITS.collection_item_uri_max_length {
-                    return Err(format!(
-                        "Validation Error: Collection item URI exceeds {} characters",
-                        VALIDATION_LIMITS.collection_item_uri_max_length
-                    ));
-                }
                 validate_collection_item_uri(uri).map_err(|e| {
                     format!("Validation Error: Collection item at index {index}: {e}")
                 })?;
@@ -490,34 +484,24 @@ impl Validatable for PubkyAppPost {
     }
 }
 
-/// Strict canonical post-URI check for Collection items. Rejects non-pubky
-/// schemes, malformed pubky-ids, non-canonical paths (anything other than
-/// `/pub/pubky.app/posts/<id>`, including trailing/extra segments), and
-/// non-Crockford post-ids.
+/// Strict canonical post-URI check for Collection items. Accepts only the
+/// exact form `pubky://<pubky-id>/pub/pubky.app/posts/<post-id>`.
+///
+/// Deliberately avoids `Url::parse`: it silently strips userinfo and collapses
+/// `..` path segments, smuggling non-canonical strings past a parse-and-recheck
+/// approach. Splitting the raw string and delegating to `PubkyId::try_from`
+/// (52-char z-base-32) and `validate_crockford_id` (13-char Crockford) enforces
+/// the canonical 94-char form structurally.
 fn validate_collection_item_uri(uri: &str) -> Result<(), String> {
-    let url = Url::parse(uri).map_err(|_| format!("not a valid URI: {uri}"))?;
-    if url.scheme() != "pubky" {
-        return Err(format!("must use the pubky:// scheme: {uri}"));
-    }
-    if url.query().is_some() || url.fragment().is_some() {
-        return Err(format!("must not include a query or fragment: {uri}"));
-    }
-    let host = url
-        .host_str()
-        .ok_or_else(|| format!("missing pubky-id host: {uri}"))?;
+    const PREFIX: &str = "pubky://";
+    const MIDDLE: &str = "/pub/pubky.app/posts/";
+    let rest = uri
+        .strip_prefix(PREFIX)
+        .ok_or_else(|| format!("must start with pubky://: {uri}"))?;
+    let (host, post_id) = rest
+        .split_once(MIDDLE)
+        .ok_or_else(|| format!("must be a canonical post URI: {uri}"))?;
     PubkyId::try_from(host).map_err(|e| format!("invalid pubky-id in host: {e}"))?;
-    let segments: Vec<&str> = url
-        .path_segments()
-        .map(Iterator::collect)
-        .unwrap_or_default();
-    let post_id = match segments.as_slice() {
-        ["pub", "pubky.app", "posts", id] => *id,
-        _ => {
-            return Err(format!(
-                "must be a canonical post URI (pubky://<id>/pub/pubky.app/posts/<post-id>): {uri}"
-            ))
-        }
-    };
     validate_crockford_id(post_id).map_err(|e| format!("invalid post id: {e}"))?;
     Ok(())
 }
@@ -1473,19 +1457,6 @@ mod tests {
     }
 
     #[test]
-    fn test_collection_post_rejects_301_char_uri() {
-        let prefix = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/");
-        let pad = "x".repeat(301 - prefix.chars().count());
-        let uri = format!("{}{}", prefix, pad);
-        assert_eq!(uri.chars().count(), 301);
-        let post = make_collection_post("X", None, Some(vec![uri]));
-        let id = post.create_id();
-        let result = post.validate(Some(&id));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("URI exceeds"));
-    }
-
-    #[test]
     fn test_postkind_collection_display_lowercase() {
         assert_eq!(PubkyAppPostKind::Collection.to_string(), "collection");
     }
@@ -1549,60 +1520,83 @@ mod tests {
 
     #[test]
     fn test_collection_post_rejects_post_uri_with_extra_path_segment() {
-        // The current `ParsedUri` parser strips extra path segments via the
-        // `[res_type, id, ..]` pattern, so a strict canonical check is required
-        // at the validator level to reject these.
+        // Extra segment lands inside the post-id slot, failing the 13-char
+        // Crockford check.
         let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A/extra");
         let post = make_collection_post("X", None, Some(vec![uri]));
         let id = post.create_id();
         let err = post.validate(Some(&id)).unwrap_err();
-        assert!(err.contains("canonical post URI"), "got: {err}");
+        assert!(err.contains("invalid post id"), "got: {err}");
     }
 
     #[test]
     fn test_collection_post_rejects_post_uri_with_query_string() {
-        // `Url::path_segments()` strips query strings; without an explicit
-        // query check the segment match would silently accept the URI.
+        // Query string lands inside the post-id slot and fails the Crockford
+        // check (`?` and `=` aren't in the alphabet, and the length is wrong).
         let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A?foo=bar");
         let post = make_collection_post("X", None, Some(vec![uri]));
         let id = post.create_id();
         let err = post.validate(Some(&id)).unwrap_err();
-        assert!(err.contains("query or fragment"), "got: {err}");
+        assert!(err.contains("invalid post id"), "got: {err}");
     }
 
     #[test]
     fn test_collection_post_rejects_post_uri_with_fragment() {
-        // Same as the query-string case: `path_segments()` strips fragments.
+        // Same as the query-string case: `#` and the fragment body land in the
+        // post-id slot and fail Crockford.
         let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A#frag");
         let post = make_collection_post("X", None, Some(vec![uri]));
         let id = post.create_id();
         let err = post.validate(Some(&id)).unwrap_err();
-        assert!(err.contains("query or fragment"), "got: {err}");
+        assert!(err.contains("invalid post id"), "got: {err}");
     }
 
     #[test]
     fn test_collection_post_rejects_post_uri_with_trailing_slash() {
-        // Pin the rejection: a trailing slash produces a 5-segment path which
-        // misses the canonical 4-segment match arm.
+        // A trailing slash bloats the post-id past 13 chars.
         let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A/");
         let post = make_collection_post("X", None, Some(vec![uri]));
         let id = post.create_id();
         let err = post.validate(Some(&id)).unwrap_err();
-        assert!(err.contains("canonical post URI"), "got: {err}");
+        assert!(err.contains("invalid post id"), "got: {err}");
     }
 
     #[test]
     fn test_collection_post_rejects_post_uri_with_empty_post_id() {
-        // Pin the rejection: an empty post-id segment fails the 13-char
-        // Crockford check.
+        // Empty post-id segment fails the 13-char Crockford check.
         let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/");
         let post = make_collection_post("X", None, Some(vec![uri]));
         let id = post.create_id();
         let err = post.validate(Some(&id)).unwrap_err();
-        assert!(
-            err.contains("canonical post URI") || err.contains("invalid post id"),
-            "got: {err}"
+        assert!(err.contains("invalid post id"), "got: {err}");
+    }
+
+    #[test]
+    fn test_collection_post_rejects_userinfo_padding_bypass() {
+        // `Url::parse(...).host_str()` strips userinfo, which would smuggle
+        // arbitrary bytes past a parse-and-recheck approach. The strict
+        // validator keeps the `JUNK@` in the host slot, failing the 52-char
+        // PubkyId length check.
+        let uri = format!(
+            "pubky://AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA@{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A"
         );
+        let post = make_collection_post("X", None, Some(vec![uri]));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("invalid pubky-id"), "got: {err}");
+    }
+
+    #[test]
+    fn test_collection_post_rejects_dot_dot_path_bypass() {
+        // `Url::parse(...)` collapses `..` segments before path inspection,
+        // which would smuggle a non-canonical raw path past a parse-and-recheck
+        // approach. The strict validator splits the raw string, so the extra
+        // segments land in the host slot and fail PubkyId.
+        let uri = format!("pubky://{TEST_PUBKY_ID}/aa/bb/../../pub/pubky.app/posts/0034A0X7NJ52A");
+        let post = make_collection_post("X", None, Some(vec![uri]));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("invalid pubky-id"), "got: {err}");
     }
 
     #[test]

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -147,12 +147,9 @@ pub struct PubkyAppCollectionContent {
     /// Optional human-readable description. Length bounded by
     /// `VALIDATION_LIMITS.collection_description_max_length` (unicode scalars).
     pub description: Option<String>,
-    /// Ordered list of URIs this collection curates. Bounded by
+    /// Ordered list of Post URIs this collection curates. Bounded by
     /// `VALIDATION_LIMITS.collection_items_max_count` and
-    /// `VALIDATION_LIMITS.collection_item_uri_max_length`. Each URI must use
-   /// Ordered list of Post URIs this collection curates. Bounded by
-   /// `VALIDATION_LIMITS.collection_items_max_count` and
-   /// `VALIDATION_LIMITS.collection_item_uri_max_length`.
+    /// `VALIDATION_LIMITS.collection_item_uri_max_length`.
     #[serde(default)]
     pub items: Vec<String>,
 }
@@ -1515,45 +1512,6 @@ mod tests {
         let result = post.validate(Some(&id));
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Collection item"));
-    }
-
-    #[test]
-    fn test_collection_post_rejects_javascript_protocol() {
-        // XSS-vector defense: never accept `javascript:` URIs as items.
-        let post = make_collection_post("X", None, Some(vec!["javascript:alert(1)".to_string()]));
-        let id = post.create_id();
-        let result = post.validate(Some(&id));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Collection item"));
-    }
-
-    #[test]
-    fn test_collection_post_rejects_data_uri_protocol() {
-        // Same XSS-vector defense for `data:` URIs.
-        let post = make_collection_post("X", None, Some(vec!["data:text/plain,hello".to_string()]));
-        let id = post.create_id();
-        let result = post.validate(Some(&id));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Collection item"));
-    }
-
-    #[test]
-    fn test_collection_post_rejects_user_uri_in_items() {
-        // Pubky-app URI that parses cleanly but is NOT a post — items must be
-        // posts only (Resource::Post(_)). Represents the wider rejection of
-        // non-post pubky.app URIs (profile, files, collection-pointer, etc.).
-        let user_uri =
-            "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/profile.json"
-                .to_string();
-        let post = make_collection_post("X", None, Some(vec![user_uri]));
-        let id = post.create_id();
-        let err = post
-            .validate(Some(&id))
-            .expect_err("user-profile URI must be rejected as a Collection item");
-        assert!(
-            err.contains("must be a pubky.app post URI"),
-            "expected post-URI rejection error, got: {err}"
-        );
     }
 
     #[test]

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -2,6 +2,7 @@ use crate::{
     common::sanitize_url,
     limits::VALIDATION_LIMITS,
     traits::{HasIdPath, TimestampId, Validatable},
+    uri_parser::{ParsedUri, Resource},
     APP_PATH, PUBLIC_PATH,
 };
 use serde::{Deserialize, Serialize};
@@ -390,21 +391,16 @@ impl Validatable for PubkyAppPost {
                         VALIDATION_LIMITS.collection_item_uri_max_length
                     ));
                 }
-                let parsed = Url::parse(uri)
-                    .map_err(|_| format!("Validation Error: Invalid item URL: {}", uri))?;
-                if !VALIDATION_LIMITS
-                    .post_allowed_attachment_protocols
-                    .contains(&parsed.scheme())
-                {
-                    let allowed_protocols = VALIDATION_LIMITS
-                        .post_allowed_attachment_protocols
-                        .iter()
-                        .map(|p| format!("{}://", p))
-                        .collect::<Vec<_>>()
-                        .join(", ");
+                let parsed = ParsedUri::try_from(uri.as_str()).map_err(|e| {
+                    format!(
+                        "Validation Error: Collection item at index {} is not a valid URI: {}",
+                        index, e
+                    )
+                })?;
+                if !matches!(parsed.resource, Resource::Post(_)) {
                     return Err(format!(
-                        "Validation Error: Collection item URL at index {} uses disallowed protocol '{}'; must use one of the allowed protocols: {}",
-                        index, parsed.scheme(), allowed_protocols
+                        "Validation Error: Collection item at index {} must be a pubky.app post URI, got: {}",
+                        index, uri
                     ));
                 }
             }
@@ -507,6 +503,11 @@ impl Validatable for PubkyAppPost {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// 52-char Crockford-base32 pubky id used in Collection-item URIs for tests.
+    /// Real pubky user-ids are 52 chars; shorter placeholders (e.g. `userA`)
+    /// fail `ParsedUri::try_from`.
+    const TEST_PUBKY_ID: &str = "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo";
     use crate::{traits::Validatable, APP_PATH, PUBLIC_PATH};
 
     #[test]
@@ -1248,9 +1249,9 @@ mod tests {
             "AI papers",
             Some("Best stuff"),
             Some(vec![
-                "pubky://userA/pub/pubky.app/posts/0034A0X7NJ52A".to_string(),
-                "pubky://userB/pub/pubky.app/posts/0034A0X7NJ52B".to_string(),
-                "pubky://userC/pub/pubky.app/posts/0034A0X7NJ52C".to_string(),
+                format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A"),
+                format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52B"),
+                format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52C"),
             ]),
         );
         let id = post.create_id();
@@ -1433,7 +1434,7 @@ mod tests {
     #[test]
     fn test_collection_post_accepts_100_items() {
         let items: Vec<String> = (0..100)
-            .map(|i| format!("pubky://userA/pub/pubky.app/posts/{:013}", i))
+            .map(|i| format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/{:013}", i))
             .collect();
         let post = make_collection_post("Big list", None, Some(items));
         let id = post.create_id();
@@ -1453,19 +1454,9 @@ mod tests {
     }
 
     #[test]
-    fn test_collection_post_accepts_300_char_uri() {
-        // Build a pubky URI with the user host + a long path filling out to exactly 300 chars.
-        let prefix = "pubky://userA/pub/pubky.app/posts/";
-        let pad = "x".repeat(300 - prefix.chars().count());
-        let uri = format!("{}{}", prefix, pad);
-        assert_eq!(uri.chars().count(), 300);
-        let post = make_collection_post("X", None, Some(vec![uri]));
-        let id = post.create_id();
-        assert!(post.validate(Some(&id)).is_ok());
-    }
-
-    #[test]
     fn test_collection_post_rejects_301_char_uri() {
+        // Length check fires before URI shape validation, so an oversized
+        // string (regardless of pubky-validity) must be rejected at the cap.
         let prefix = "pubky://userA/pub/pubky.app/posts/";
         let pad = "x".repeat(301 - prefix.chars().count());
         let uri = format!("{}{}", prefix, pad);
@@ -1520,28 +1511,23 @@ mod tests {
     }
 
     #[test]
-    fn test_collection_post_rejects_disallowed_item_protocol() {
+    fn test_collection_post_rejects_non_post_uri() {
         let post =
             make_collection_post("X", None, Some(vec!["ftp://example.com/file".to_string()]));
         let id = post.create_id();
         let result = post.validate(Some(&id));
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .contains("must use one of the allowed protocols"));
+        assert!(result.unwrap_err().contains("Collection item"));
     }
 
     #[test]
     fn test_collection_post_rejects_javascript_protocol() {
-        // XSS-vector defense: never accept `javascript:` URIs as attachments,
-        // even though they technically parse as URLs.
+        // XSS-vector defense: never accept `javascript:` URIs as items.
         let post = make_collection_post("X", None, Some(vec!["javascript:alert(1)".to_string()]));
         let id = post.create_id();
         let result = post.validate(Some(&id));
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .contains("must use one of the allowed protocols"));
+        assert!(result.unwrap_err().contains("Collection item"));
     }
 
     #[test]
@@ -1551,9 +1537,26 @@ mod tests {
         let id = post.create_id();
         let result = post.validate(Some(&id));
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .contains("must use one of the allowed protocols"));
+        assert!(result.unwrap_err().contains("Collection item"));
+    }
+
+    #[test]
+    fn test_collection_post_rejects_user_uri_in_items() {
+        // Pubky-app URI that parses cleanly but is NOT a post — items must be
+        // posts only (Resource::Post(_)). Represents the wider rejection of
+        // non-post pubky.app URIs (profile, files, collection-pointer, etc.).
+        let user_uri =
+            "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/profile.json"
+                .to_string();
+        let post = make_collection_post("X", None, Some(vec![user_uri]));
+        let id = post.create_id();
+        let err = post
+            .validate(Some(&id))
+            .expect_err("user-profile URI must be rejected as a Collection item");
+        assert!(
+            err.contains("must be a pubky.app post URI"),
+            "expected post-URI rejection error, got: {err}"
+        );
     }
 
     #[test]
@@ -1596,13 +1599,9 @@ mod tests {
 
     #[test]
     fn test_collection_post_envelope_at_max_size() {
+        // 100 distinct valid pubky post URIs (max-count). Each ~97 chars.
         let items: Vec<String> = (0..VALIDATION_LIMITS.collection_items_max_count)
-            .map(|i| {
-                let prefix = format!("pubky://u{i:03}/pub/pubky.app/posts/");
-                let pad_len =
-                    VALIDATION_LIMITS.collection_item_uri_max_length - prefix.chars().count();
-                format!("{}{}", prefix, "x".repeat(pad_len))
-            })
+            .map(|i| format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/{:013}", i))
             .collect();
         let max_name = "a".repeat(VALIDATION_LIMITS.collection_name_max_length);
         let max_desc = "b".repeat(VALIDATION_LIMITS.collection_description_max_length);

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -1651,7 +1651,7 @@ mod tests {
 
     #[test]
     fn test_collection_post_envelope_at_max_size() {
-        // 100 distinct valid pubky post URIs (max-count). Each ~97 chars.
+        // 100 distinct valid pubky post URIs (max-count). Each exactly 94 chars.
         let items: Vec<String> = (0..VALIDATION_LIMITS.collection_items_max_count)
             .map(|i| format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/{:013}", i))
             .collect();

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -1452,8 +1452,6 @@ mod tests {
 
     #[test]
     fn test_collection_post_rejects_301_char_uri() {
-        // Length check fires before URI shape validation, so an oversized
-        // string (regardless of pubky-validity) must be rejected at the cap.
         let prefix = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/");
         let pad = "x".repeat(301 - prefix.chars().count());
         let uri = format!("{}{}", prefix, pad);

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -502,6 +502,9 @@ fn validate_collection_item_uri(uri: &str) -> Result<(), String> {
     if url.scheme() != "pubky" {
         return Err(format!("must use the pubky:// scheme: {uri}"));
     }
+    if url.query().is_some() || url.fragment().is_some() {
+        return Err(format!("must not include a query or fragment: {uri}"));
+    }
     let host = url
         .host_str()
         .ok_or_else(|| format!("missing pubky-id host: {uri}"))?;
@@ -1557,6 +1560,64 @@ mod tests {
         let id = post.create_id();
         let err = post.validate(Some(&id)).unwrap_err();
         assert!(err.contains("canonical post URI"), "got: {err}");
+    }
+
+    #[test]
+    fn test_collection_post_rejects_post_uri_with_query_string() {
+        // `Url::path_segments()` strips query strings; without an explicit
+        // query check the segment match would silently accept the URI.
+        let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A?foo=bar");
+        let post = make_collection_post("X", None, Some(vec![uri]));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("query or fragment"), "got: {err}");
+    }
+
+    #[test]
+    fn test_collection_post_rejects_post_uri_with_fragment() {
+        // Same as the query-string case: `path_segments()` strips fragments.
+        let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A#frag");
+        let post = make_collection_post("X", None, Some(vec![uri]));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("query or fragment"), "got: {err}");
+    }
+
+    #[test]
+    fn test_collection_post_rejects_post_uri_with_trailing_slash() {
+        // Pin the rejection: a trailing slash produces a 5-segment path which
+        // misses the canonical 4-segment match arm.
+        let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A/");
+        let post = make_collection_post("X", None, Some(vec![uri]));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("canonical post URI"), "got: {err}");
+    }
+
+    #[test]
+    fn test_collection_post_rejects_post_uri_with_empty_post_id() {
+        // Pin the rejection: an empty post-id segment fails the 13-char
+        // Crockford check.
+        let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/");
+        let post = make_collection_post("X", None, Some(vec![uri]));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(
+            err.contains("canonical post URI") || err.contains("invalid post id"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_collection_post_accepts_canonical_max_length_uri() {
+        // Success-side boundary: the longest valid canonical post URI is
+        // pubky://<52-char-pubky-id>/pub/pubky.app/posts/<13-char-crockford>
+        // which is exactly 94 chars. Validator must accept this.
+        let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A");
+        assert_eq!(uri.chars().count(), 94);
+        let post = make_collection_post("X", None, Some(vec![uri]));
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
     }
 
     #[test]

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -1454,7 +1454,7 @@ mod tests {
     fn test_collection_post_rejects_301_char_uri() {
         // Length check fires before URI shape validation, so an oversized
         // string (regardless of pubky-validity) must be rejected at the cap.
-        let prefix = "pubky://userA/pub/pubky.app/posts/";
+        let prefix = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/");
         let pad = "x".repeat(301 - prefix.chars().count());
         let uri = format!("{}{}", prefix, pad);
         assert_eq!(uri.chars().count(), 301);

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -1,8 +1,8 @@
 use crate::{
-    common::sanitize_url,
+    common::{sanitize_url, validate_crockford_id},
     limits::VALIDATION_LIMITS,
     traits::{HasIdPath, TimestampId, Validatable},
-    uri_parser::{ParsedUri, Resource},
+    types::PubkyId,
     APP_PATH, PUBLIC_PATH,
 };
 use serde::{Deserialize, Serialize};
@@ -390,18 +390,12 @@ impl Validatable for PubkyAppPost {
                         VALIDATION_LIMITS.collection_item_uri_max_length
                     ));
                 }
-                let parsed = ParsedUri::try_from(uri.as_str()).map_err(|e| {
+                validate_collection_item_uri(uri).map_err(|e| {
                     format!(
-                        "Validation Error: Collection item at index {} is not a valid URI: {}",
+                        "Validation Error: Collection item at index {}: {}",
                         index, e
                     )
                 })?;
-                if !matches!(parsed.resource, Resource::Post(_)) {
-                    return Err(format!(
-                        "Validation Error: Collection item at index {} must be a pubky.app post URI, got: {}",
-                        index, uri
-                    ));
-                }
             }
             return Ok(());
         }
@@ -497,6 +491,35 @@ impl Validatable for PubkyAppPost {
 
         Ok(())
     }
+}
+
+/// Strict canonical post-URI check for Collection items. Rejects non-pubky
+/// schemes, malformed pubky-ids, non-canonical paths (anything other than
+/// `/pub/pubky.app/posts/<id>`, including trailing/extra segments), and
+/// non-Crockford post-ids.
+fn validate_collection_item_uri(uri: &str) -> Result<(), String> {
+    let url = Url::parse(uri).map_err(|_| format!("not a valid URI: {uri}"))?;
+    if url.scheme() != "pubky" {
+        return Err(format!("must use the pubky:// scheme: {uri}"));
+    }
+    let host = url
+        .host_str()
+        .ok_or_else(|| format!("missing pubky-id host: {uri}"))?;
+    PubkyId::try_from(host).map_err(|e| format!("invalid pubky-id in host: {e}"))?;
+    let segments: Vec<&str> = url
+        .path_segments()
+        .map(Iterator::collect)
+        .unwrap_or_default();
+    let post_id = match segments.as_slice() {
+        ["pub", "pubky.app", "posts", id] => *id,
+        _ => {
+            return Err(format!(
+                "must be a canonical post URI (pubky://<id>/pub/pubky.app/posts/<post-id>): {uri}"
+            ))
+        }
+    };
+    validate_crockford_id(post_id).map_err(|e| format!("invalid post id: {e}"))?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1512,6 +1535,28 @@ mod tests {
         let result = post.validate(Some(&id));
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Collection item"));
+    }
+
+    #[test]
+    fn test_collection_post_rejects_post_uri_with_invalid_post_id() {
+        // 13 chars but not valid Crockford: contains hyphens which aren't in the alphabet.
+        let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/abc-def-ghi-j");
+        let post = make_collection_post("X", None, Some(vec![uri]));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("invalid post id"), "got: {err}");
+    }
+
+    #[test]
+    fn test_collection_post_rejects_post_uri_with_extra_path_segment() {
+        // The current `ParsedUri` parser strips extra path segments via the
+        // `[res_type, id, ..]` pattern, so a strict canonical check is required
+        // at the validator level to reject these.
+        let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A/extra");
+        let post = make_collection_post("X", None, Some(vec![uri]));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("canonical post URI"), "got: {err}");
     }
 
     #[test]


### PR DESCRIPTION
Two commits, both targeting v0.5.1:

1. **README** — adds Collection post kind to the supported kinds list and documents the envelope shape (`{name, description?, items[]}`) with an example. Crates.io docs for v0.5.0 are missing this; v0.5.1 will have it.

2. **Items tightening** — `PubkyAppCollectionContent.items` now must resolve to `Resource::Post(_)` via `ParsedUri::try_from`. Replaces the old protocol-allowlist (`[pubky, http, https]`) so file / profile / external / collection-pointer URIs are rejected. Defense-in-depth for the upcoming Nexus collection-items endpoint, which still tombstones non-post URIs at read time for legacy v0.5.0 data.

Decoupled from PR #119 (collection-pointer) so this can land independently as the next patch release.