### PR TITLE
fix(ci): use setup-firefox action in wasm workflow

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Install Wasm-Pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Install Firefox
-        run: sudo apt-get install -y firefox
+        uses: browser-actions/setup-firefox@v1
       - name: Run Wasm-Pack Tests
         run: wasm-pack test --headless --firefox


### PR DESCRIPTION
This PR fixes the (occasionally) failing `Rust (Wasm-Pack)` CI job.

## Root cause
The workflow installed Firefox via `apt-get install firefox`, which depends on snap bootstrap on Ubuntu runners and failed with a transient snap assertions fetch timeout.

## Changes
- Replace apt-based Firefox installation with `browser-actions/setup-firefox@v1` in `.github/workflows/wasm.yml`.