### PR TITLE
feat: add optional cover_image to PubkyAppCollectionContent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-app-specs"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "base32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,6 +1770,7 @@ dependencies = [
  "serde-wasm-bindgen",
  "serde_json",
  "tokio",
+ "tsify-next",
  "url",
  "utoipa",
  "wasm-bindgen",
@@ -2280,6 +2281,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2721,6 +2733,30 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tsify-next"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d0f2208feeb5f7a6edb15a2389c14cd42480ef6417318316bb866da5806a61d"
+dependencies = [
+ "serde",
+ "serde-wasm-bindgen",
+ "tsify-next-macros",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "tsify-next-macros"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81253930d0d388a3ab8fa4ae56da9973ab171ef833d1be2e9080fc3ce502bd6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky-app-specs"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 rust-version = "1.89"
 description = "Pubky.app Data Model Specifications"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ wasm-bindgen = "0.2.100"
 serde-wasm-bindgen = "0.6.5"
 js-sys = "0.3.77"
 web-sys = "0.3.77"
+tsify-next = { version = "0.5.6", default-features = false, features = ["js"] }
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3.68"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pubky.app Data Model Specification
 
-_Version 0.5.1_
+_Version 0.5.2_
 
 > ⚠️ **Warning: Rapid Development Phase**  
 > This specification is in an **early development phase** and is evolving quickly. Expect frequent changes and updates as the system matures. Consider this a **v0 draft**.
@@ -182,6 +182,7 @@ Collection posts use a typed JSON envelope as their `content`. The envelope shap
 {
   "name": "AI papers",
   "description": "Best stuff",
+  "cover_image": "pubky://userA/pub/pubky.app/files/0034A0X7NJ52C",
   "items": [
     "pubky://userA/pub/pubky.app/posts/0034A0X7NJ52A",
     "pubky://userB/pub/pubky.app/posts/0034A0X7NJ52B"
@@ -191,7 +192,8 @@ Collection posts use a typed JSON envelope as their `content`. The envelope shap
 
 - `name`: required, 1 to 100 unicode scalars, non-whitespace-only.
 - `description`: optional, max 500 scalars.
-- `items`: ordered list of pubky.app post URIs (max 100, each at most 300 chars). Each URI must resolve to a `Resource::Post` (form: `pubky://<pubky-id>/pub/pubky.app/posts/<post-id>`); all other URI types are rejected.
+- `cover_image`: optional hero/cover image URL (max 200 chars). Validated as a general attachment URL — protocol must be `pubky`, `http`, or `https`.
+- `items`: ordered list of pubky.app post URIs (max 100). Each URI must be in exact canonical form `pubky://<pubky-id>/pub/pubky.app/posts/<post-id>` (94 chars); any deviation (extra path segments, query, fragment, userinfo, etc.) is rejected.
 
 For `kind = collection`, `parent`, `embed`, and `post.attachments` must be unset. The `content` field is bounded by 40000 scalars instead of the regular short/long caps.
 

--- a/pkg/package.json
+++ b/pkg/package.json
@@ -55,5 +55,5 @@
   "sideEffects": false,
   "type": "module",
   "types": "pubky_app_specs.d.ts",
-  "version": "0.5.1"
+  "version": "0.5.2"
 }

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -60,8 +60,8 @@ pub struct ValidationLimits {
     /// Maximum scalar count (`chars().count()`, not bytes) for the JSON
     /// envelope content of a Collection post. Sized to hold a
     /// max-population envelope (100 canonical post URIs at 94 chars each,
-    /// plus name, description, JSON overhead, and headroom for additive
-    /// future fields).
+    /// plus name, description, cover_image (up to 200 chars), JSON
+    /// overhead, and headroom for additive future fields).
     pub collection_content_max_length: usize,
     /// Minimum character count for a Collection name. The validator rejects
     /// whitespace-only names separately, then counts the full string length.

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -342,8 +342,7 @@ impl Validatable for PubkyAppPost {
                 );
             }
             // Anti-misuse guard: items belong in the envelope, not in
-            // `post.attachments`. Relax this when Collections gain real
-            // attachments (e.g. cover image).
+            // `post.attachments`.
             if matches!(&self.attachments, Some(a) if !a.is_empty()) {
                 return Err(
                     "Validation Error: Collection posts must not use post.attachments — items belong in the content envelope"

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -1434,6 +1434,16 @@ mod tests {
     }
 
     #[test]
+    fn test_collection_post_rejects_cover_image_too_long() {
+        // post_attachment_url_max_length is 200; this URL exceeds it.
+        let too_long = format!("https://example.com/{}", "a".repeat(200));
+        let post = make_collection_post_with_cover(Some(&too_long));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("cover_image URL exceeds"), "got: {err}");
+    }
+
+    #[test]
     fn test_collection_post_rejects_oversized_description() {
         let too_long = "a".repeat(501);
         let post = make_collection_post("X", Some(&too_long), None);

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -15,6 +15,8 @@ const RESERVED_CONTENT_DELETED: &str = "[DELETED]";
 #[cfg(target_arch = "wasm32")]
 use crate::traits::Json;
 #[cfg(target_arch = "wasm32")]
+use tsify_next::Tsify;
+#[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
 #[cfg(feature = "openapi")]
@@ -138,6 +140,7 @@ impl PubkyAppPostEmbed {
 /// older parsers. New fields must be additive and ignorable.
 #[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(target_arch = "wasm32", derive(Tsify))]
 #[serde(rename_all = "snake_case")]
 pub struct PubkyAppCollectionContent {
     /// Display name of the collection. Length bounded by

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -149,6 +149,7 @@ pub struct PubkyAppCollectionContent {
     pub name: String,
     /// Optional human-readable description. Length bounded by
     /// `VALIDATION_LIMITS.collection_description_max_length` (unicode scalars).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// Ordered list of Post URIs this collection curates. Count bounded by
     /// `VALIDATION_LIMITS.collection_items_max_count`; each URI must be in
@@ -158,6 +159,7 @@ pub struct PubkyAppCollectionContent {
     /// Optional hero/cover image URL. Length bounded by
     /// `VALIDATION_LIMITS.post_attachment_url_max_length`; protocol must be in
     /// `VALIDATION_LIMITS.post_allowed_attachment_protocols`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cover_image: Option<String>,
 }
 

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -1572,10 +1572,10 @@ mod tests {
     #[test]
     fn test_collection_envelope_tolerates_extra_fields() {
         // Forward-compat: the envelope intentionally does NOT use deny_unknown_fields,
-        // so future minor versions can add fields like `cover_image` without breaking
-        // older parsers. This test locks in that behavior.
-        let envelope_json =
-            r#"{"name":"X","description":"Y","cover_image":"https://example.com/x.png"}"#;
+        // so future minor versions can add fields without breaking older parsers.
+        // Use a deliberately-fictional canary field name so this test stays
+        // meaningful even after real fields land.
+        let envelope_json = r#"{"name":"X","_forward_compat_canary":"future-only"}"#;
         let post = PubkyAppPost::new(
             envelope_json.to_string(),
             PubkyAppPostKind::Collection,
@@ -1586,7 +1586,7 @@ mod tests {
         let id = post.create_id();
         assert!(
             post.validate(Some(&id)).is_ok(),
-            "extra envelope fields must be tolerated"
+            "unknown envelope fields must be tolerated"
         );
     }
 

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -152,6 +152,10 @@ pub struct PubkyAppCollectionContent {
     /// exact canonical form (see `validate_collection_item_uri`).
     #[serde(default)]
     pub items: Vec<String>,
+    /// Optional hero/cover image URL. Length bounded by
+    /// `VALIDATION_LIMITS.post_attachment_url_max_length`; protocol must be in
+    /// `VALIDATION_LIMITS.post_allowed_attachment_protocols`.
+    pub cover_image: Option<String>,
 }
 
 /// Represents raw post in homeserver with content and kind
@@ -374,6 +378,31 @@ impl Validatable for PubkyAppPost {
                     return Err(format!(
                         "Validation Error: Collection description exceeds {} characters",
                         VALIDATION_LIMITS.collection_description_max_length
+                    ));
+                }
+            }
+            if let Some(cover) = &envelope.cover_image {
+                if cover.chars().count() > VALIDATION_LIMITS.post_attachment_url_max_length {
+                    return Err(format!(
+                        "Validation Error: Collection cover_image URL exceeds {} characters",
+                        VALIDATION_LIMITS.post_attachment_url_max_length
+                    ));
+                }
+                let parsed = Url::parse(cover).map_err(|_| {
+                    "Validation Error: Collection cover_image must be a valid URL".to_string()
+                })?;
+                if !VALIDATION_LIMITS
+                    .post_allowed_attachment_protocols
+                    .contains(&parsed.scheme())
+                {
+                    let allowed = VALIDATION_LIMITS
+                        .post_allowed_attachment_protocols
+                        .iter()
+                        .map(|p| format!("{p}://"))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    return Err(format!(
+                        "Validation Error: Collection cover_image must use one of the allowed protocols: {allowed}"
                     ));
                 }
             }
@@ -1227,6 +1256,7 @@ mod tests {
             name: name.to_string(),
             description: description.map(|d| d.to_string()),
             items: items.to_vec(),
+            cover_image: None,
         })
         .unwrap()
     }
@@ -1244,6 +1274,17 @@ mod tests {
             None,
             None,
         )
+    }
+
+    fn make_collection_post_with_cover(cover_image: Option<&str>) -> PubkyAppPost {
+        let envelope = PubkyAppCollectionContent {
+            name: "X".to_string(),
+            description: None,
+            items: vec![],
+            cover_image: cover_image.map(|s| s.to_string()),
+        };
+        let content = serde_json::to_string(&envelope).expect("envelope serialization");
+        PubkyAppPost::new(content, PubkyAppPostKind::Collection, None, None, None)
     }
 
     #[test]
@@ -1348,6 +1389,43 @@ mod tests {
         assert!(
             err.contains("1..=100"),
             "error should report the length range, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_collection_post_accepts_cover_image_pubky_uri() {
+        let cover = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/files/0034A0X7NJ52A");
+        let post = make_collection_post_with_cover(Some(&cover));
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_collection_post_accepts_cover_image_https() {
+        let post = make_collection_post_with_cover(Some("https://example.com/cover.png"));
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_collection_post_rejects_cover_image_invalid_url() {
+        let post = make_collection_post_with_cover(Some("not a url"));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(
+            err.contains("cover_image must be a valid URL"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_collection_post_rejects_cover_image_disallowed_protocol() {
+        let post = make_collection_post_with_cover(Some("ftp://example.com/cover.png"));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(
+            err.contains("cover_image must use one of the allowed protocols"),
+            "got: {err}"
         );
     }
 
@@ -1713,6 +1791,7 @@ mod tests {
                 Some(vec![
                     "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/posts/0034A0X7NJ52A".to_string(),
                 ]),
+                Some("https://example.com/cover.png".to_string()),
             )
             .expect("createCollectionPost should succeed");
 
@@ -1724,5 +1803,9 @@ mod tests {
         assert_eq!(envelope.name, "My favorites");
         assert_eq!(envelope.description.as_deref(), Some("Best things"));
         assert_eq!(envelope.items.len(), 1);
+        assert_eq!(
+            envelope.cover_image.as_deref(),
+            Some("https://example.com/cover.png")
+        );
     }
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -298,9 +298,9 @@ impl PubkySpecsBuilder {
     /// a name and optional description.
     ///
     /// Convenience wrapper around `createPost` that builds the
-    /// `PubkyAppCollectionContent` envelope (`{ name, description, items }`) and
-    /// JSON-serializes it into `content` internally, so JS callers don't
-    /// have to stringify the envelope themselves.
+    /// `PubkyAppCollectionContent` envelope (`{ name, description, items,
+    /// cover_image }`) and JSON-serializes it into `content` internally, so
+    /// JS callers don't have to stringify the envelope themselves.
     ///
     /// `parent` and `embed` are not supported for Collection posts — the
     /// validator rejects them — so this helper omits those arguments.
@@ -310,11 +310,13 @@ impl PubkySpecsBuilder {
         name: String,
         description: Option<String>,
         items: Option<Vec<String>>,
+        cover_image: Option<String>,
     ) -> Result<PostResult, String> {
         let envelope = PubkyAppCollectionContent {
             name,
             description,
             items: items.unwrap_or_default(),
+            cover_image,
         };
         let content = serde_json::to_string(&envelope)
             .map_err(|e| format!("Failed to serialize Collection envelope: {e}"))?;


### PR DESCRIPTION
In order to match the intentional new design of Collections with a cover image, this PR adds a new field to the collection envelop to allow for a single optional cover image. This is preferred solution over the less explicit attachment 1 to 4 objects that are generically used for pointing to files.

Adds an optional `cover_image: Option<String>` field to `PubkyAppCollectionContent` so Collection posts can carry a hero image URL for visual identification. Validated as a general attachment URL — same protocols (`pubky`/`http`/`https`) and length cap as `post.attachments`.

The WASM `createCollectionPost` builder gains a trailing optional `cover_image` argument. Backwards-compatible: older JS callers continue to work (trailing arg defaults to `undefined` → `None`), and v0.5.0/0.5.1 envelope parsers deserialize new envelopes transparently (`#[serde(default)]` + the envelope intentionally lacks `deny_unknown_fields`).

Bumps to v0.5.2 (pre-release v0.5.2-rc.1 is already out based on this branch).