### PR TITLE
feat: add list layout enum

### DIFF
--- a/src/models/feed.rs
+++ b/src/models/feed.rs
@@ -37,6 +37,7 @@ pub enum PubkyAppFeedLayout {
     Columns,
     Wide,
     Visual,
+    List,
 }
 
 /// Enum representing the sort order of the feed.
@@ -284,6 +285,7 @@ impl FromStr for PubkyAppFeedLayout {
             "columns" => Ok(PubkyAppFeedLayout::Columns),
             "wide" => Ok(PubkyAppFeedLayout::Wide),
             "visual" => Ok(PubkyAppFeedLayout::Visual),
+            "list" => Ok(PubkyAppFeedLayout::List),
             _ => Err(format!("Invalid feed layout: {}", s)),
         }
     }
@@ -618,6 +620,10 @@ mod tests {
         assert_eq!(
             "visual".parse::<PubkyAppFeedLayout>().unwrap(),
             PubkyAppFeedLayout::Visual
+        );
+        assert_eq!(
+            "list".parse::<PubkyAppFeedLayout>().unwrap(),
+            PubkyAppFeedLayout::List
         );
 
         // Invalid case


### PR DESCRIPTION
## Summary

Adds `list` as a valid `PubkyAppFeedLayout` option.

This extends the feed layout enum with a fourth layout variant:

- `columns`
- `wide`
- `visual`
- `list`

The new value is accepted anywhere feed layouts are parsed from strings, including the WASM builder path that calls `PubkyAppFeedLayout::from_str()`.

## Wiring

- Add `PubkyAppFeedLayout::List`
- Add `"list"` handling in `FromStr for PubkyAppFeedLayout`
- Add parser test coverage for the new layout value

## Why

Clients can now persist and share feeds that use a compact list-style layout without treating it as an invalid feed configuration.

## Tests

`cargo test feed`

Result: 19 passed, 0 failed.