### PR TITLE
feat: PubkyAppLock model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1762,6 +1762,7 @@ version = "0.6.0"
 dependencies = [
  "anyhow",
  "base32",
+ "base64",
  "blake3",
  "js-sys",
  "mime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 url = "2.5.8"
 base32 = "0.5.1"
+base64 = "0.22"
 blake3 = "1.8.5"
 mime = "0.3"
 utoipa = { version = "5.5.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ Pubky.app models are designed for decentralized content sharing. The system uses
 | `parent`      | String   | URI of the parent post (if a reply). | Optional. Must be a valid URI if present.                                  |
 | `embed`       | Object   | Reposted content (type + URI).       | Optional. URI must be valid if present.                                    |
 | `attachments` | Array    | List of attachment URIs.             | Optional. Each must be a valid URI.                                        |
-| `lock`        | String   | Lock server URL for protected posts. | Optional. If present, must be a valid `pubky://` URL with a host, up to 200 characters. Missing or `null` means unlocked. |
 
 **Post Kinds:**
 
@@ -159,6 +158,7 @@ Pubky.app models are designed for decentralized content sharing. The system uses
 - `link`
 - `file`
 - `collection`
+- `lock`
 
 **Example: Valid Post**
 
@@ -171,14 +171,29 @@ Pubky.app models are designed for decentralized content sharing. The system uses
     "kind": "short",
     "uri": "pubky://user_id/pub/pubky.app/posts/0000000000000"
   },
-  "attachments": ["pubky://user_id/pub/pubky.app/files/0000000000000"],
+  "attachments": ["pubky://user_id/pub/pubky.app/files/0000000000000"]
+}
+```
+
+**Note on `kind = lock`:**
+
+A locked post uses a typed JSON envelope as its `content` and advertises the gate metadata publicly while the guarded payload lives behind a Lock Server. The envelope shape is:
+
+```json
+{
+  "header": "We were reckless adopting Lightning without understanding the tradeoffs.",
+  "title": "Locked Article",
+  "header_kind": "image",
   "lock": "pubky://lock_server_id/pub/locks/0000000000000"
 }
 ```
 
-**Locking:**
+- `header`: required public teaser used as the lock post's body, interpreted per `header_kind`; non-whitespace-only; max `lock_content_header_max_length` scalars.
+- `title`: required lock-card label; 1 to 100 scalars; non-whitespace-only.
+- `header_kind`: required display kind of the teaser. Must be one of `short`, `image`, `video`, `link`, `file` (`long`, `collection`, `lock`, and unknown kinds are rejected).
+- `lock`: required Lock Server URL. Must be a valid `pubky://` URL with a host, up to 200 characters.
 
-Posts are unlocked by default. A post may include `lock` to advertise that the full post is protected behind a lock server. When present, `lock` must be a valid `pubky://` URL with a host, up to 200 characters. Consumers that receive JSON without `lock`, or JSON with `"lock": null`, must treat the post as a regular unlocked post.
+For `kind = lock`, `parent` and `embed` must be unset. Teaser media (for an `image`/`file` header, for example) is carried in `post.attachments` and validated with the same rules as any other post. The `content` field is bounded by `lock_content_max_length` scalars. The guarded payload (the full post plus its attachment files) is described separately by `PubkyAppLock` (see below).
 
 **Note on `kind = collection`:**
 
@@ -202,6 +217,76 @@ Collection posts use a typed JSON envelope as their `content`. The envelope shap
 - `items`: ordered list of pubky.app post URIs (max 100). Each URI must be in exact canonical form `pubky://<pubky-id>/pub/pubky.app/posts/<post-id>` (94 chars); any deviation (extra path segments, query, fragment, userinfo, etc.) is rejected.
 
 For `kind = collection`, `parent`, `embed`, and `post.attachments` must be unset. The `content` field is bounded by 40000 scalars instead of the regular short/long caps.
+
+---
+
+### PubkyAppLock
+
+**Description:** The locked content resource served by the Lock Server.
+
+A locked post advertises a `lock` URL (in its public `PubkyAppLockContent` envelope) pointing at a `PubkyAppLock`. This is a single, self-contained JSON resource that bundles the full, unlocked `PubkyAppPost` together with all of its attachment files, each inlined as base64 in `files[].content_base64`. It is only released after the Lock Server verifies access.
+
+This is distinct from the public lock teaser (`header`/`title`) that a locked post carries in its `content` envelope — that teaser is public gate metadata, while `PubkyAppLock` is the private, guarded payload.
+
+**Identity:** `PubkyAppLock` is **content-addressed**: its ID is the blake3 hash of the serialized resource (same scheme as tags/bookmarks). The on-homeserver storage path is owned by the Locks app/SDK and is intentionally not defined by this spec.
+
+| **Field** | **Type** | **Description**                                  | **Validation Rules**                                                  |
+| --------- | -------- | ------------------------------------------------ | --------------------------------------------------------------------- |
+| `post`    | Object   | The full, unlocked post packaged in the resource. | Required. Stored `post.attachments` must be empty; validated as unlocked content with `files` reconstructed as attachments. |
+| `files`   | Array    | Attachment files inlined alongside `post`.        | Optional. Max 10 entries.                                             |
+
+The stored `post.attachments` must be empty: `files` is the single source of truth for the packed attachments, and the client reconstructs `post.attachments` from `files` (in order) on unlock. During validation, `files` are treated as the post's attachments so attachment-only locked media posts validate the same way they will behave after unlock.
+
+The overall size limit is enforced on the **whole serialized JSON resource** (what is written to the homeserver), which must be ≤ 100 MB. Because the files are base64-inlined (~33% overhead) alongside the post and JSON structure, the effective raw-content budget is roughly 73 MB.
+
+Each entry of `files` is a `PubkyAppLockFile`:
+
+| **Field**        | **Type** | **Description**                               | **Validation Rules**                                                        |
+| ---------------- | -------- | --------------------------------------------- | --------------------------------------------------------------------------- |
+| `name`           | String   | Original display name of the file.            | Required. 1–255 characters.                                                 |
+| `content_type`   | String   | MIME type of the file.                        | Required. Must be a valid IANA mime type.                                   |
+| `size`           | Integer  | Decoded size of the file in bytes.            | Required. Positive integer; must equal the decoded `content_base64` length. |
+| `content_base64` | String   | The file bytes, base64-encoded (standard).    | Required. Must be valid base64 whose decoded length equals `size`.          |
+
+**Example:**
+
+```json
+{
+  "post": {
+    "content": "The full unlocked article body.",
+    "kind": "long",
+    "parent": null,
+    "embed": null,
+    "attachments": null
+  },
+  "files": [
+    { "name": "cover.png", "content_type": "image/png", "size": 2048, "content_base64": "iVBORw0KGgoAAAANSUhEUgAA..." },
+    { "name": "episode.mp3", "content_type": "audio/mpeg", "size": 4096, "content_base64": "SUQzBAAAAAAAI1RTU0UAAAAP..." }
+  ]
+}
+```
+
+**Creating a lock:**
+
+`createLockBundle(post, files)` builds the resource for you. `files` is an array of `{ name, content_type, data }`, where `data` is the raw file bytes (`Uint8Array`); `size` and `content_base64` are derived automatically. The returned `meta` carries only the content-hash `id` (its `path`/`url` are empty, since the path is owned by the Locks app/SDK):
+
+```js
+const lockResult = builder.createLockBundle(post, [
+  { name: "cover.png", content_type: "image/png", data: coverU8 },
+  { name: "episode.mp3", content_type: "audio/mpeg", data: audioU8 },
+]);
+const lockId = lockResult.meta.id; // blake3 content hash
+const json = lockResult.lock.toJson();
+```
+
+**Security:**
+
+There is **no** homeserver/backend validation of locks — anything the Lock Server returns is untrusted. Clients MUST run `validate()` on the parsed resource (which decodes every `content_base64` and checks its length against `size`) and verify the resource's ID matches its content hash before presenting any content:
+
+```js
+const lock = PubkyAppLock.fromJson(json);
+lock.validate(); // decodes each content_base64, checks sizes, mime types, inner post
+```
 
 ---
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,9 +20,11 @@ pub use models::feed::{PubkyAppFeed, PubkyAppFeedLayout, PubkyAppFeedReach, Pubk
 pub use models::file::{PubkyAppFile, VALID_MIME_TYPES};
 pub use models::follow::PubkyAppFollow;
 pub use models::last_read::PubkyAppLastRead;
+pub use models::lock::{PubkyAppLock, PubkyAppLockFile};
 pub use models::mute::PubkyAppMute;
 pub use models::post::{
-    PubkyAppCollectionContent, PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind,
+    PubkyAppCollectionContent, PubkyAppLockContent, PubkyAppPost, PubkyAppPostEmbed,
+    PubkyAppPostKind,
 };
 pub use models::tag::PubkyAppTag;
 pub use models::user::{PubkyAppUser, PubkyAppUserLink};

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -73,6 +73,23 @@ pub struct ValidationLimits {
     pub collection_description_max_length: usize,
     /// Maximum number of items (attachment URIs) per Collection.
     pub collection_items_max_count: usize,
+    // `lock_content_*`: limits for the public `PubkyAppLockContent` envelope
+    // stored in a `kind = lock` post's `content`.
+    /// Maximum scalar count for the whole `PubkyAppLockContent` JSON envelope.
+    pub lock_content_max_length: usize,
+    /// Maximum character count for the envelope `header` (public teaser body).
+    pub lock_content_header_max_length: usize,
+    /// Minimum character count for the envelope `title` (lock-card label).
+    pub lock_content_title_min_length: usize,
+    /// Maximum character count for the envelope `title` (lock-card label).
+    pub lock_content_title_max_length: usize,
+    // `lock_*`: limits for the private `PubkyAppLock` resource (the single JSON
+    // doc inlining the guarded post and its base64-encoded attachment files).
+    /// Maximum size in bytes of the serialized `PubkyAppLock` JSON resource
+    /// (the resource written to the homeserver at `/pub/locks/:id`). This caps the
+    /// whole base64-inlined resource, not individual files; with base64 overhead
+    /// the effective raw-content budget is roughly 73% of this value.
+    pub lock_max_size_bytes: usize,
     /// Minimum file name length in characters.
     pub file_name_min_length: usize,
     /// Maximum file name length in characters.
@@ -108,6 +125,11 @@ pub const VALIDATION_LIMITS: ValidationLimits = ValidationLimits {
     collection_name_max_length: 100,
     collection_description_max_length: 500,
     collection_items_max_count: 100,
+    lock_content_max_length: 2_500,
+    lock_content_header_max_length: 2_000,
+    lock_content_title_min_length: 1,
+    lock_content_title_max_length: 100,
+    lock_max_size_bytes: 100 * (1 << 20), // 100 MB, aligned with blob caps.
     file_name_min_length: 1,
     file_name_max_length: 255,
     file_src_max_length: 1024,

--- a/src/models/lock.rs
+++ b/src/models/lock.rs
@@ -1,0 +1,627 @@
+use crate::{
+    limits::VALIDATION_LIMITS,
+    models::file::VALID_MIME_TYPES,
+    traits::{HashId, Validatable},
+    PubkyAppPost, PubkyAppPostKind,
+};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use mime::Mime;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+#[cfg(target_arch = "wasm32")]
+use crate::traits::Json;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+#[cfg(feature = "openapi")]
+use utoipa::ToSchema;
+
+/// One file inlined inside a [`PubkyAppLock`] resource, with its bytes
+/// base64-encoded in `content_base64`. See [`PubkyAppLock`] for the security
+/// model and the resource-wide size cap.
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(deny_unknown_fields)]
+pub struct PubkyAppLockFile {
+    /// Original display name of the file (e.g. `episode.mp3`). Length bounded by
+    /// `VALIDATION_LIMITS.file_name_{min,max}_length`.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    pub name: String,
+    /// MIME type of the file. Must be one of `VALID_MIME_TYPES`.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    pub content_type: String,
+    /// Decoded size of the file in bytes. Must be non-zero and equal to the
+    /// actual decoded length of `content_base64`.
+    pub size: usize,
+    /// The file bytes, base64-encoded (standard alphabet). Decoded length must
+    /// equal `size`.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    pub content_base64: String,
+}
+
+#[cfg(target_arch = "wasm32")]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+impl PubkyAppLockFile {
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
+    pub fn content_type(&self) -> String {
+        self.content_type.clone()
+    }
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter, js_name = contentBase64))]
+    pub fn content_base64(&self) -> String {
+        self.content_base64.clone()
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+impl PubkyAppLockFile {
+    /// Creates a new `PubkyAppLockFile` and sanitizes it.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(constructor))]
+    pub fn new(name: String, content_type: String, size: usize, content_base64: String) -> Self {
+        Self {
+            name,
+            content_type,
+            size,
+            content_base64,
+        }
+        .sanitize()
+    }
+}
+
+impl Validatable for PubkyAppLockFile {
+    fn sanitize(self) -> Self {
+        Self {
+            name: self.name.trim().to_string(),
+            content_type: self.content_type.trim().to_string(),
+            size: self.size,
+            content_base64: self.content_base64.trim().to_string(),
+        }
+    }
+
+    fn validate(&self, _id: Option<&str>) -> Result<(), String> {
+        let name_length = self.name.chars().count();
+        if !(VALIDATION_LIMITS.file_name_min_length..=VALIDATION_LIMITS.file_name_max_length)
+            .contains(&name_length)
+        {
+            return Err("Validation Error: Lock file name length is invalid".into());
+        }
+
+        match Mime::from_str(&self.content_type) {
+            Ok(mime) => {
+                if !VALID_MIME_TYPES.contains(&mime.essence_str()) {
+                    return Err("Validation Error: Lock file has invalid content type".into());
+                }
+            }
+            Err(_) => return Err("Validation Error: Lock file has invalid content type".into()),
+        }
+
+        if self.size == 0 {
+            return Err("Validation Error: Lock file size cannot be zero".into());
+        }
+
+        // Decode the inlined bytes and cross-check their length against `size`.
+        // The overall size cap is enforced on the whole serialized resource in
+        // `PubkyAppLock::validate`, so there is no per-file size limit here.
+        let decoded = BASE64
+            .decode(self.content_base64.as_bytes())
+            .map_err(|_| "Validation Error: Lock file content_base64 is not valid base64")?;
+        if decoded.len() != self.size {
+            return Err(format!(
+                "Validation Error: Lock file decoded length ({}) does not match size ({})",
+                decoded.len(),
+                self.size
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+/// A locked content resource served by the Lock Server.
+///
+/// A locked post advertises a `lock` URL (in its public
+/// `PubkyAppLockContent` envelope) pointing at this resource.
+/// `PubkyAppLock` is a single, self-contained JSON resource that
+/// bundles the full, unlocked `PubkyAppPost` together with all
+/// of its attachment files, each inlined as base64 in
+/// `files[].content_base64`. This resource is released only after
+/// the Lock Server verifies access.
+///
+/// # Identity
+///
+/// `PubkyAppLock` is content-addressed via [`HashId`]: its ID is the blake3
+/// hash of the serialized resource. The on-homeserver storage path is owned by
+/// the Locks application/SDK and is intentionally not derived here.
+///
+/// # Security
+///
+/// There is no homeserver/backend validation of locks — anything the Lock
+/// Server returns is untrusted. Clients MUST run [`Validatable::validate`] on
+/// the parsed resource (which decodes every `content_base64` and checks its
+/// length against `size`) and verify the resource ID matches its content hash
+/// before presenting any content.
+///
+/// `deny_unknown_fields` is intentional: lock resources are content-addressed by
+/// their canonical structured representation, so accepting ignored fields would
+/// allow bytes outside the ID and size checks.
+///
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[derive(Serialize, Deserialize, Default, Clone, Debug)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(deny_unknown_fields)]
+pub struct PubkyAppLock {
+    /// The full, unlocked post packaged inside the resource. Its `attachments`
+    /// MUST be empty — packed attachments are listed in `files`, which is the
+    /// single source of truth; the client rebuilds `post.attachments` from
+    /// `files` on unlock.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    pub post: PubkyAppPost,
+    /// Ordered list of attachment files inlined alongside the post. Count
+    /// bounded by `VALIDATION_LIMITS.post_attachments_max_count`; combined
+    /// decoded size by `VALIDATION_LIMITS.lock_max_size_bytes`.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    pub files: Vec<PubkyAppLockFile>,
+}
+
+#[cfg(target_arch = "wasm32")]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+impl PubkyAppLock {
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
+    pub fn post(&self) -> PubkyAppPost {
+        self.post.clone()
+    }
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
+    pub fn files(&self) -> Vec<PubkyAppLockFile> {
+        self.files.clone()
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromJson))]
+    pub fn from_json(js_value: &JsValue) -> Result<Self, String> {
+        Self::import_json(js_value)
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = toJson))]
+    pub fn to_json(&self) -> Result<JsValue, String> {
+        self.export_json()
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl Json for PubkyAppLock {}
+
+impl PubkyAppLock {
+    /// Creates a new `PubkyAppLock` resource and sanitizes it.
+    pub fn new(post: PubkyAppPost, files: Vec<PubkyAppLockFile>) -> Self {
+        Self { post, files }.sanitize()
+    }
+}
+
+impl HashId for PubkyAppLock {
+    /// Content-addresses the lock by hashing its full serialized form (post +
+    /// inlined files). Computed on the sanitized resource so the ID is stable
+    /// across the create/parse round-trip.
+    fn get_id_data(&self) -> String {
+        serde_json::to_string(self).unwrap_or_default()
+    }
+}
+
+impl Validatable for PubkyAppLock {
+    fn sanitize(self) -> Self {
+        Self {
+            post: self.post.sanitize(),
+            files: self.files.into_iter().map(|f| f.sanitize()).collect(),
+        }
+    }
+
+    fn validate(&self, id: Option<&str>) -> Result<(), String> {
+        if let Some(id) = id {
+            self.validate_id(id)?;
+        }
+
+        // The `files` list is the single source of truth for packed
+        // attachments, so the guarded post must not carry its own `attachments`
+        // (they would duplicate/contradict `files`). On unlock, the client
+        // reconstructs the post's attachments from `files`.
+        if matches!(&self.post.attachments, Some(a) if !a.is_empty()) {
+            return Err(
+                "Validation Error: Lock post must not set attachments; packed files are listed in `files`"
+                    .into(),
+            );
+        }
+
+        // A lock guards real content; it must not itself be a `lock` post
+        // (nested locks are not allowed).
+        if self.post.kind == PubkyAppPostKind::Lock {
+            return Err(
+                "Validation Error: Lock post must not be a `lock` kind (nested locks are not allowed)"
+                    .into(),
+            );
+        }
+
+        // TODO: Check with the design team whether the private unlocked payload
+        // should allow `parent` and `embed`, unlike the public lock teaser post.
+        if self.files.len() > VALIDATION_LIMITS.post_attachments_max_count {
+            return Err(format!(
+                "Validation Error: Lock cannot contain more than {} files",
+                VALIDATION_LIMITS.post_attachments_max_count
+            ));
+        }
+
+        for (index, file) in self.files.iter().enumerate() {
+            file.validate(None)
+                .map_err(|e| format!("Validation Error: Lock file at index {index}: {e}"))?;
+        }
+
+        let mut post_for_validation = self.post.clone();
+        if self.files.is_empty() {
+            // Treat `None` and `Some([])` as equivalent for the stored lock
+            // shape. An empty attachment list must not satisfy the generic
+            // post "has attachments" requirement when there are no packed
+            // files to reconstruct.
+            post_for_validation.attachments = None;
+        } else {
+            // Packed files are semantically attachments after unlock, but the
+            // serialized lock resource keeps `post.attachments` empty. Use
+            // validation-only placeholder URLs so the regular post validator
+            // still enforces kind/content/parent/embed rules without persisting
+            // duplicate attachment pointers.
+            post_for_validation.attachments = Some(
+                (0..self.files.len())
+                    .map(|index| format!("https://example.com/pubky-app-lock-validation/{index}"))
+                    .collect(),
+            );
+        }
+        post_for_validation
+            .validate(None)
+            .map_err(|e| format!("Validation Error: Lock post is invalid: {e}"))?;
+
+        // The artifact written to the homeserver is the serialized JSON
+        // resource (base64-inlined files + post + JSON overhead), so the size
+        // cap is enforced against that, not against the raw decoded bytes.
+        let serialized_len = serde_json::to_vec(self)
+            .map(|v| v.len())
+            .map_err(|e| format!("Validation Error: Lock failed to serialize: {e}"))?;
+        if serialized_len > VALIDATION_LIMITS.lock_max_size_bytes {
+            return Err(format!(
+                "Validation Error: Lock resource size ({serialized_len} bytes) exceeds maximum of {} bytes",
+                VALIDATION_LIMITS.lock_max_size_bytes
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::post::PubkyAppPostKind;
+    use crate::traits::{HashId, Validatable};
+
+    fn b64(bytes: &[u8]) -> String {
+        BASE64.encode(bytes)
+    }
+
+    fn lock_file(name: &str, content_type: &str, bytes: &[u8]) -> PubkyAppLockFile {
+        PubkyAppLockFile::new(
+            name.to_string(),
+            content_type.to_string(),
+            bytes.len(),
+            b64(bytes),
+        )
+    }
+
+    fn sample_post() -> PubkyAppPost {
+        PubkyAppPost::new(
+            "The full unlocked article body.".to_string(),
+            PubkyAppPostKind::Long,
+            None,
+            None,
+            None,
+        )
+    }
+
+    fn sample_lock() -> PubkyAppLock {
+        PubkyAppLock::new(
+            sample_post(),
+            vec![
+                lock_file("cover.png", "image/png", &[0u8; 2048]),
+                lock_file("episode.mp3", "audio/mpeg", &[1u8; 4096]),
+            ],
+        )
+    }
+
+    #[test]
+    fn test_new_keeps_files() {
+        let lock = sample_lock();
+        assert_eq!(lock.files.len(), 2);
+    }
+
+    #[test]
+    fn test_validate_ok() {
+        let lock = sample_lock();
+        let id = lock.create_id();
+        assert!(lock.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_id_is_stable_and_content_addressed() {
+        let lock = sample_lock();
+        // Same content -> same id.
+        assert_eq!(lock.create_id(), sample_lock().create_id());
+        // Different content -> different id.
+        let other = PubkyAppLock::new(sample_post(), vec![]);
+        assert_ne!(lock.create_id(), other.create_id());
+    }
+
+    #[test]
+    fn test_validate_rejects_tampered_id() {
+        let lock = sample_lock();
+        let err = lock.validate(Some("0000000000000")).unwrap_err();
+        assert!(err.contains("Invalid ID"), "got: {err}");
+    }
+
+    #[test]
+    fn test_roundtrip_via_try_from() {
+        let lock = sample_lock();
+        let id = lock.create_id();
+        let json = serde_json::to_vec(&lock).unwrap();
+        let parsed = <PubkyAppLock as Validatable>::try_from(&json, &id).unwrap();
+        assert_eq!(parsed.files.len(), 2);
+        assert_eq!(parsed.post.content, "The full unlocked article body.");
+    }
+
+    #[test]
+    fn test_rejects_invalid_inner_post() {
+        // Empty post (no content/embed/attachments) fails PubkyAppPost validation.
+        let lock = PubkyAppLock::new(
+            PubkyAppPost::new("".to_string(), PubkyAppPostKind::Short, None, None, None),
+            vec![],
+        );
+        let id = lock.create_id();
+        let err = lock.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("post"), "got: {err}");
+    }
+
+    #[test]
+    fn test_rejects_inner_post_with_attachments() {
+        // `files` is the source of truth for packed attachments, so the guarded
+        // post must not carry its own `attachments`.
+        let post = PubkyAppPost::new(
+            "Body".to_string(),
+            PubkyAppPostKind::Long,
+            None,
+            None,
+            Some(vec!["pubky://userA/pub/pubky.app/files/0034A0X7NJ52A".to_string()]),
+        );
+        let lock = PubkyAppLock::new(post, vec![lock_file("a.png", "image/png", &[0u8; 16])]);
+        let id = lock.create_id();
+        let err = lock.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("attachments"), "got: {err}");
+    }
+
+    #[test]
+    fn test_accepts_attachment_only_media_posts_with_files() {
+        for kind in [
+            PubkyAppPostKind::Image,
+            PubkyAppPostKind::Video,
+            PubkyAppPostKind::File,
+        ] {
+            let post = PubkyAppPost::new("".to_string(), kind.clone(), None, None, None);
+            let lock = PubkyAppLock::new(
+                post,
+                vec![lock_file("payload.bin", "application/octet-stream", &[0u8; 16])],
+            );
+            let id = lock.create_id();
+            assert!(
+                lock.validate(Some(&id)).is_ok(),
+                "attachment-only {kind:?} post should validate with files"
+            );
+            assert!(
+                lock.post.attachments.is_none(),
+                "synthetic validation attachments must not mutate the stored post"
+            );
+            let json = serde_json::to_value(&lock).expect("lock serialization");
+            assert!(json["post"]["attachments"].is_null());
+        }
+    }
+
+    #[test]
+    fn test_rejects_attachment_only_image_post_without_files() {
+        let post = PubkyAppPost::new(
+            "".to_string(),
+            PubkyAppPostKind::Image,
+            None,
+            None,
+            None,
+        );
+        let lock = PubkyAppLock::new(post, vec![]);
+        let id = lock.create_id();
+        let err = lock.validate(Some(&id)).unwrap_err();
+        assert!(
+            err.contains("content, an embed, or attachments"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_rejects_attachment_only_image_post_with_empty_attachment_list_and_no_files() {
+        let post = PubkyAppPost::new(
+            "".to_string(),
+            PubkyAppPostKind::Image,
+            None,
+            None,
+            Some(vec![]),
+        );
+        let lock = PubkyAppLock::new(post, vec![]);
+        let id = lock.create_id();
+        let err = lock.validate(Some(&id)).unwrap_err();
+        assert!(
+            err.contains("content, an embed, or attachments"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_rejects_attachment_only_post_with_invalid_parent() {
+        let post = PubkyAppPost::new(
+            "".to_string(),
+            PubkyAppPostKind::Image,
+            Some("not a url".to_string()),
+            None,
+            None,
+        );
+        let lock = PubkyAppLock::new(post, vec![lock_file("cover.png", "image/png", &[0u8; 16])]);
+        let id = lock.create_id();
+        let err = lock.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("Invalid parent URI format"), "got: {err}");
+    }
+
+    #[test]
+    fn test_rejects_nested_lock_post() {
+        // The guarded post must not itself be a `lock` kind. We build the inner
+        // post from a valid lock envelope so it would otherwise pass, isolating
+        // the nested-lock rejection.
+        let envelope = serde_json::json!({
+            "header": "Teaser",
+            "title": "Locked",
+            "header_kind": "short",
+            "lock": "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/locks/0034A0X7NJ52G"
+        })
+        .to_string();
+        let inner = PubkyAppPost::new(envelope, PubkyAppPostKind::Lock, None, None, None);
+        let lock = PubkyAppLock::new(inner, vec![]);
+        let id = lock.create_id();
+        let err = lock.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("nested locks"), "got: {err}");
+    }
+
+    #[test]
+    fn test_accepts_zero_files() {
+        let lock = PubkyAppLock::new(sample_post(), vec![]);
+        let id = lock.create_id();
+        assert!(lock.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_rejects_too_many_files() {
+        let files: Vec<PubkyAppLockFile> = (0..VALIDATION_LIMITS.post_attachments_max_count + 1)
+            .map(|_| lock_file("f.png", "image/png", &[0u8; 16]))
+            .collect();
+        let lock = PubkyAppLock::new(sample_post(), files);
+        let id = lock.create_id();
+        let err = lock.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("more than"), "got: {err}");
+    }
+
+    #[test]
+    fn test_rejects_invalid_content_type() {
+        let lock = PubkyAppLock::new(
+            sample_post(),
+            vec![lock_file("a.bin", "not/a-real-type", &[0u8; 16])],
+        );
+        let id = lock.create_id();
+        let err = lock.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("content type"), "got: {err}");
+    }
+
+    #[test]
+    fn test_rejects_zero_size_file() {
+        let lock = PubkyAppLock::new(
+            sample_post(),
+            vec![PubkyAppLockFile::new(
+                "a.png".to_string(),
+                "image/png".to_string(),
+                0,
+                String::new(),
+            )],
+        );
+        let id = lock.create_id();
+        let err = lock.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("size"), "got: {err}");
+    }
+
+    #[test]
+    fn test_rejects_malformed_base64() {
+        let lock = PubkyAppLock::new(
+            sample_post(),
+            vec![PubkyAppLockFile::new(
+                "a.png".to_string(),
+                "image/png".to_string(),
+                3,
+                "!!!not base64!!!".to_string(),
+            )],
+        );
+        let id = lock.create_id();
+        let err = lock.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("base64"), "got: {err}");
+    }
+
+    #[test]
+    fn test_rejects_size_decoded_mismatch() {
+        // `size` claims 100 bytes but the decoded content is only 4.
+        let lock = PubkyAppLock::new(
+            sample_post(),
+            vec![PubkyAppLockFile::new(
+                "a.png".to_string(),
+                "image/png".to_string(),
+                100,
+                b64(&[0u8; 4]),
+            )],
+        );
+        let id = lock.create_id();
+        let err = lock.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("does not match size"), "got: {err}");
+    }
+
+    #[test]
+    fn test_rejects_over_resource_size() {
+        // The cap is on the serialized resource. Raw bytes equal to the cap
+        // become ~1.33x larger once base64-encoded, so a single file of
+        // `lock_max_size_bytes` raw bytes pushes the resource over the limit.
+        // Validate with `None` to skip the (expensive) content-hash ID check on
+        // this large payload — we only exercise the resource-size logic.
+        let raw = vec![0u8; VALIDATION_LIMITS.lock_max_size_bytes];
+        let lock = PubkyAppLock::new(
+            sample_post(),
+            vec![lock_file("a.bin", "application/octet-stream", &raw)],
+        );
+        let err = lock.validate(None).unwrap_err();
+        assert!(err.contains("resource size"), "got: {err}");
+    }
+
+    #[test]
+    fn test_sanitize_trims_fields() {
+        let lock = PubkyAppLock::new(
+            sample_post(),
+            vec![PubkyAppLockFile::new(
+                "  a.png  ".to_string(),
+                "  image/png  ".to_string(),
+                16,
+                format!("  {}  ", b64(&[0u8; 16])),
+            )],
+        );
+        assert_eq!(lock.files[0].name, "a.png");
+        assert_eq!(lock.files[0].content_type, "image/png");
+        assert_eq!(lock.files[0].content_base64, b64(&[0u8; 16]));
+    }
+
+    #[test]
+    fn test_rejects_unknown_top_level_fields() {
+        let json = r#"{"post":{"content":"hi","kind":"short","parent":null,"embed":null,"attachments":null},"files":[],"_future_field":"ignored"}"#;
+        let err = serde_json::from_str::<PubkyAppLock>(json).unwrap_err();
+        assert!(err.to_string().contains("unknown field"), "got: {err}");
+    }
+
+    #[test]
+    fn test_rejects_unknown_file_fields() {
+        let json = r#"{"post":{"content":"hi","kind":"short","parent":null,"embed":null,"attachments":null},"files":[{"name":"a.png","content_type":"image/png","size":4,"content_base64":"AAAAAA==","_future_field":"ignored"}]}"#;
+        let err = serde_json::from_str::<PubkyAppLock>(json).unwrap_err();
+        assert!(err.to_string().contains("unknown field"), "got: {err}");
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -6,6 +6,7 @@ pub mod feed;
 pub mod file;
 pub mod follow;
 pub mod last_read;
+pub mod lock;
 pub mod mute;
 pub mod post;
 pub mod tag;

--- a/src/models/post/content/collection.rs
+++ b/src/models/post/content/collection.rs
@@ -1,0 +1,719 @@
+use crate::{
+    common::validate_crockford_id,
+    limits::VALIDATION_LIMITS,
+    types::PubkyId,
+};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+#[cfg(target_arch = "wasm32")]
+use tsify_next::Tsify;
+
+#[cfg(feature = "openapi")]
+use utoipa::ToSchema;
+
+use super::super::PubkyAppPost;
+
+/// Typed JSON envelope stored in `PubkyAppPost::content` when `kind == Collection`.
+///
+/// A collection post curates an ordered list of URIs (via `items`)
+/// under a `name` and optional `description`. The envelope is parsed and validated
+/// by the spec but never re-serialized as a top-level homeserver object.
+///
+/// **Construction**: this struct is deserialized from the post's `content` JSON
+/// envelope during validation and is **not** intended to be constructed by
+/// callers directly. It is re-exported publicly (via `lib.rs`) so SDK consumers
+/// can inspect the envelope shape (OpenAPI schema, type definitions), but the
+/// authoritative way to produce a Collection post is to author a `PubkyAppPost`
+/// with `kind: Collection` and a `content` string that JSON-parses into this
+/// shape.
+///
+/// Forward-compat: `#[serde(deny_unknown_fields)]` is intentionally NOT used so
+/// future minor versions can add fields (e.g. `cover_image`) without breaking
+/// older parsers. New fields must be additive and ignorable.
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(target_arch = "wasm32", derive(Tsify))]
+#[serde(rename_all = "snake_case")]
+pub struct PubkyAppCollectionContent {
+    /// Display name of the collection. Length bounded by
+    /// `VALIDATION_LIMITS.collection_name_{min,max}_length` (unicode scalars).
+    /// Whitespace-only names are rejected separately by the validator.
+    pub name: String,
+    /// Optional human-readable description. Length bounded by
+    /// `VALIDATION_LIMITS.collection_description_max_length` (unicode scalars).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Ordered list of Post URIs this collection curates. Count bounded by
+    /// `VALIDATION_LIMITS.collection_items_max_count`; each URI must be in
+    /// exact canonical form (see `validate_collection_item_uri`).
+    #[serde(default)]
+    pub items: Vec<String>,
+    /// Optional hero/cover image URL. Length bounded by
+    /// `VALIDATION_LIMITS.post_attachment_url_max_length`; protocol must be in
+    /// `VALIDATION_LIMITS.post_allowed_attachment_protocols`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cover_image: Option<String>,
+}
+
+/// Validates a `kind = Collection` post, including its JSON content envelope.
+pub(crate) fn validate_collection_post(post: &PubkyAppPost) -> Result<(), String> {
+    if post.parent.is_some() || post.embed.is_some() {
+        return Err(
+            "Validation Error: Collection posts cannot have parent or embed".into(),
+        );
+    }
+    // Anti-misuse guard: items belong in the envelope, not in `post.attachments`.
+    if matches!(&post.attachments, Some(a) if !a.is_empty()) {
+        return Err(
+            "Validation Error: Collection posts must not use post.attachments — items belong in the content envelope"
+                .into(),
+        );
+    }
+    if post.content.chars().count() > VALIDATION_LIMITS.collection_content_max_length {
+        return Err(format!(
+            "Validation Error: Collection content exceeds max length {}",
+            VALIDATION_LIMITS.collection_content_max_length
+        ));
+    }
+    let envelope: PubkyAppCollectionContent =
+        serde_json::from_str(&post.content).map_err(|e| {
+            format!(
+                "Validation Error: Collection content must be a valid JSON envelope: {}",
+                e
+            )
+        })?;
+    validate_collection_envelope(&envelope)
+}
+
+fn validate_collection_envelope(envelope: &PubkyAppCollectionContent) -> Result<(), String> {
+    if envelope.name.trim().is_empty() {
+        return Err(
+            "Validation Error: Collection name must contain non-whitespace characters".into(),
+        );
+    }
+    let name_chars = envelope.name.chars().count();
+    let name_min = VALIDATION_LIMITS.collection_name_min_length;
+    let name_max = VALIDATION_LIMITS.collection_name_max_length;
+    if !(name_min..=name_max).contains(&name_chars) {
+        return Err(format!(
+            "Validation Error: Collection name must be {}..={} characters",
+            name_min, name_max
+        ));
+    }
+    if let Some(desc) = &envelope.description {
+        if desc.chars().count() > VALIDATION_LIMITS.collection_description_max_length {
+            return Err(format!(
+                "Validation Error: Collection description exceeds {} characters",
+                VALIDATION_LIMITS.collection_description_max_length
+            ));
+        }
+    }
+    if let Some(cover) = &envelope.cover_image {
+        if cover.chars().count() > VALIDATION_LIMITS.post_attachment_url_max_length {
+            return Err(format!(
+                "Validation Error: Collection cover_image URL exceeds {} characters",
+                VALIDATION_LIMITS.post_attachment_url_max_length
+            ));
+        }
+        let parsed = Url::parse(cover).map_err(|_| {
+            "Validation Error: Collection cover_image must be a valid URL".to_string()
+        })?;
+        if !VALIDATION_LIMITS
+            .post_allowed_attachment_protocols
+            .contains(&parsed.scheme())
+        {
+            let allowed = VALIDATION_LIMITS
+                .post_allowed_attachment_protocols
+                .iter()
+                .map(|p| format!("{p}://"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(format!(
+                "Validation Error: Collection cover_image must use one of the allowed protocols: {allowed}"
+            ));
+        }
+    }
+    if envelope.items.len() > VALIDATION_LIMITS.collection_items_max_count {
+        return Err(format!(
+            "Validation Error: Collection cannot have more than {} items",
+            VALIDATION_LIMITS.collection_items_max_count
+        ));
+    }
+    for (index, uri) in envelope.items.iter().enumerate() {
+        validate_collection_item_uri(uri)
+            .map_err(|e| format!("Validation Error: Collection item at index {index}: {e}"))?;
+    }
+    Ok(())
+}
+
+/// Strict canonical post-URI check for Collection items. Accepts only the
+/// exact form `pubky://<pubky-id>/pub/pubky.app/posts/<post-id>`.
+///
+/// Deliberately avoids `Url::parse`: it silently strips userinfo and collapses
+/// `..` path segments, smuggling non-canonical strings past a parse-and-recheck
+/// approach. Splitting the raw string and delegating to `PubkyId::try_from`
+/// (52-char z-base-32) and `validate_crockford_id` (13-char Crockford) enforces
+/// the canonical 94-char form structurally.
+fn validate_collection_item_uri(uri: &str) -> Result<(), String> {
+    const PREFIX: &str = "pubky://";
+    const MIDDLE: &str = "/pub/pubky.app/posts/";
+    let rest = uri
+        .strip_prefix(PREFIX)
+        .ok_or_else(|| format!("must start with pubky://: {uri}"))?;
+    let (host, post_id) = rest
+        .split_once(MIDDLE)
+        .ok_or_else(|| format!("must be a canonical post URI: {uri}"))?;
+    PubkyId::try_from(host).map_err(|e| format!("invalid pubky-id in host: {e}"))?;
+    validate_crockford_id(post_id).map_err(|e| format!("invalid post id: {e}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::super::{PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind};
+    use crate::traits::{TimestampId, Validatable};
+
+    const TEST_PUBKY_ID: &str = "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo";
+
+    fn collection_envelope_json(name: &str, description: Option<&str>, items: &[String]) -> String {
+        serde_json::to_string(&PubkyAppCollectionContent {
+            name: name.to_string(),
+            description: description.map(|d| d.to_string()),
+            items: items.to_vec(),
+            cover_image: None,
+        })
+        .unwrap()
+    }
+
+    fn make_collection_post(
+        name: &str,
+        description: Option<&str>,
+        items: Option<Vec<String>>,
+    ) -> PubkyAppPost {
+        let items = items.unwrap_or_default();
+        PubkyAppPost::new(
+            collection_envelope_json(name, description, &items),
+            PubkyAppPostKind::Collection,
+            None,
+            None,
+            None,
+        )
+    }
+
+    fn make_collection_post_with_cover(cover_image: Option<&str>) -> PubkyAppPost {
+        let envelope = PubkyAppCollectionContent {
+            name: "X".to_string(),
+            description: None,
+            items: vec![],
+            cover_image: cover_image.map(|s| s.to_string()),
+        };
+        let content = serde_json::to_string(&envelope).expect("envelope serialization");
+        PubkyAppPost::new(content, PubkyAppPostKind::Collection, None, None, None)
+    }
+
+    #[test]
+    fn test_collection_post_roundtrip_valid() {
+        let post = make_collection_post(
+            "AI papers",
+            Some("Best stuff"),
+            Some(vec![
+                format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A"),
+                format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52B"),
+                format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52C"),
+            ]),
+        );
+        let id = post.create_id();
+        let blob = serde_json::to_vec(&post).unwrap();
+        let parsed = <PubkyAppPost as Validatable>::try_from(&blob, &id).unwrap();
+        assert_eq!(parsed.kind, PubkyAppPostKind::Collection);
+        assert!(parsed.attachments.is_none());
+        let envelope: PubkyAppCollectionContent = serde_json::from_str(&parsed.content).unwrap();
+        assert_eq!(envelope.items.len(), 3);
+    }
+
+    #[test]
+    fn test_collection_post_rejects_malformed_envelope() {
+        let post = PubkyAppPost::new(
+            "this is not JSON".to_string(),
+            PubkyAppPostKind::Collection,
+            None,
+            None,
+            None,
+        );
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("JSON envelope"),
+            "expected JSON envelope error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_collection_post_rejects_empty_name() {
+        let post = make_collection_post("", None, None);
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("name"));
+    }
+
+    #[test]
+    fn test_collection_post_rejects_oversized_name() {
+        // 101 grapheme-ish chars; mix in emoji to confirm we count by unicode scalars, not bytes.
+        let oversized = "a".repeat(99) + "🚀🚀";
+        assert_eq!(oversized.chars().count(), 101);
+        let post = make_collection_post(&oversized, None, None);
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("name"));
+    }
+
+    #[test]
+    fn test_collection_post_accepts_max_name() {
+        let exactly_100 = "a".repeat(100);
+        assert_eq!(exactly_100.chars().count(), 100);
+        let post = make_collection_post(&exactly_100, None, None);
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_collection_post_rejects_whitespace_only_name() {
+        // Whitespace-only names pass `min_length=1` purely by char count, so
+        // we reject them with a dedicated guard. Without that guard, a name
+        // of `"    "` would be a 4-char valid name with no meaningful content.
+        let post = make_collection_post("    ", None, None);
+        let id = post.create_id();
+        let err = post
+            .validate(Some(&id))
+            .expect_err("whitespace-only name must fail validation");
+        assert!(
+            err.contains("whitespace"),
+            "error should mention whitespace, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_collection_post_counts_whitespace_in_name_length() {
+        // Regression guard: the validator does NOT trim before counting. A
+        // 99-char name padded with one space on each side is 101 chars and
+        // must fail max=100. With the previous trim-then-count behavior this
+        // would have been 99 chars and passed.
+        let padded = format!(" {} ", "a".repeat(99));
+        assert_eq!(padded.chars().count(), 101);
+        let post = make_collection_post(&padded, None, None);
+        let id = post.create_id();
+        let err = post
+            .validate(Some(&id))
+            .expect_err("101-char padded name must fail validation");
+        assert!(
+            err.contains("1..=100"),
+            "error should report the length range, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_collection_post_accepts_cover_image_pubky_uri() {
+        let cover = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/files/0034A0X7NJ52A");
+        let post = make_collection_post_with_cover(Some(&cover));
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_collection_post_accepts_cover_image_https() {
+        let post = make_collection_post_with_cover(Some("https://example.com/cover.png"));
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_collection_post_rejects_cover_image_invalid_url() {
+        let post = make_collection_post_with_cover(Some("not a url"));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(
+            err.contains("cover_image must be a valid URL"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_collection_post_rejects_cover_image_disallowed_protocol() {
+        let post = make_collection_post_with_cover(Some("ftp://example.com/cover.png"));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(
+            err.contains("cover_image must use one of the allowed protocols"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_collection_post_rejects_cover_image_too_long() {
+        // post_attachment_url_max_length is 200; this URL exceeds it.
+        let too_long = format!("https://example.com/{}", "a".repeat(200));
+        let post = make_collection_post_with_cover(Some(&too_long));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("cover_image URL exceeds"), "got: {err}");
+    }
+
+    #[test]
+    fn test_collection_post_rejects_oversized_description() {
+        let too_long = "a".repeat(501);
+        let post = make_collection_post("X", Some(&too_long), None);
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("description"));
+    }
+
+    #[test]
+    fn test_collection_post_accepts_empty_description() {
+        // Explicit empty-string description is valid (the field is optional and
+        // 0..=500 chars allowed).
+        let post = make_collection_post("X", Some(""), None);
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_collection_post_accepts_max_description() {
+        let exactly_500 = "a".repeat(500);
+        assert_eq!(exactly_500.chars().count(), 500);
+        let post = make_collection_post("X", Some(&exactly_500), None);
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_collection_post_rejects_missing_name() {
+        // Envelope JSON without a `name` field at all (description-only).
+        // Distinct from `test_collection_post_rejects_empty_name`, which sends
+        // an empty string; this sends a missing key entirely.
+        let envelope = r#"{ "description": "no name here" }"#.to_string();
+        let post = PubkyAppPost::new(envelope, PubkyAppPostKind::Collection, None, None, None);
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("name") || err.to_lowercase().contains("missing"),
+            "expected name-required error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_collection_post_rejects_parent() {
+        let post = PubkyAppPost::new(
+            collection_envelope_json("X", None, &[]),
+            PubkyAppPostKind::Collection,
+            Some("pubky://userA/pub/pubky.app/posts/0034A0X7NJ52A".to_string()),
+            None,
+            None,
+        );
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("parent or embed"),
+            "expected parent-or-embed error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_collection_post_rejects_embed() {
+        let post = PubkyAppPost::new(
+            collection_envelope_json("X", None, &[]),
+            PubkyAppPostKind::Collection,
+            None,
+            Some(PubkyAppPostEmbed {
+                kind: PubkyAppPostKind::Short,
+                uri: "pubky://userA/pub/pubky.app/posts/0034A0X7NJ52A".to_string(),
+            }),
+            None,
+        );
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("parent or embed"));
+    }
+
+    #[test]
+    fn test_collection_post_accepts_100_items() {
+        let items: Vec<String> = (0..100)
+            .map(|i| format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/{:013}", i))
+            .collect();
+        let post = make_collection_post("Big list", None, Some(items));
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_collection_post_rejects_101_items() {
+        let items: Vec<String> = (0..101)
+            .map(|i| format!("pubky://userA/pub/pubky.app/posts/{:013}", i))
+            .collect();
+        let post = make_collection_post("Too big", None, Some(items));
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("100 items"));
+    }
+
+    #[test]
+    fn test_collection_post_accepts_zero_items() {
+        // Curators may create a draft and add items later via edits.
+        let post = make_collection_post("Drafts", None, None);
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_collection_envelope_tolerates_extra_fields() {
+        // Forward-compat: the envelope intentionally does NOT use deny_unknown_fields,
+        // so future minor versions can add fields without breaking older parsers.
+        // Use a deliberately-fictional canary field name so this test stays
+        // meaningful even after real fields land.
+        let envelope_json = r#"{"name":"X","_forward_compat_canary":"future-only"}"#;
+        let post = PubkyAppPost::new(
+            envelope_json.to_string(),
+            PubkyAppPostKind::Collection,
+            None,
+            None,
+            None,
+        );
+        let id = post.create_id();
+        assert!(
+            post.validate(Some(&id)).is_ok(),
+            "unknown envelope fields must be tolerated"
+        );
+    }
+
+    #[test]
+    fn test_collection_post_rejects_non_post_uri() {
+        let post =
+            make_collection_post("X", None, Some(vec!["ftp://example.com/file".to_string()]));
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Collection item"));
+    }
+
+    #[test]
+    fn test_collection_post_rejects_post_uri_with_invalid_post_id() {
+        // 13 chars but not valid Crockford: contains hyphens which aren't in the alphabet.
+        let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/abc-def-ghi-j");
+        let post = make_collection_post("X", None, Some(vec![uri]));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("invalid post id"), "got: {err}");
+    }
+
+    #[test]
+    fn test_collection_post_rejects_post_uri_with_extra_path_segment() {
+        // Extra segment lands inside the post-id slot, failing the 13-char
+        // Crockford check.
+        let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A/extra");
+        let post = make_collection_post("X", None, Some(vec![uri]));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("invalid post id"), "got: {err}");
+    }
+
+    #[test]
+    fn test_collection_post_rejects_post_uri_with_query_string() {
+        // Query string lands inside the post-id slot and fails the Crockford
+        // check (`?` and `=` aren't in the alphabet, and the length is wrong).
+        let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A?foo=bar");
+        let post = make_collection_post("X", None, Some(vec![uri]));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("invalid post id"), "got: {err}");
+    }
+
+    #[test]
+    fn test_collection_post_rejects_post_uri_with_fragment() {
+        // Same as the query-string case: `#` and the fragment body land in the
+        // post-id slot and fail Crockford.
+        let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A#frag");
+        let post = make_collection_post("X", None, Some(vec![uri]));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("invalid post id"), "got: {err}");
+    }
+
+    #[test]
+    fn test_collection_post_rejects_post_uri_with_trailing_slash() {
+        // A trailing slash bloats the post-id past 13 chars.
+        let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A/");
+        let post = make_collection_post("X", None, Some(vec![uri]));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("invalid post id"), "got: {err}");
+    }
+
+    #[test]
+    fn test_collection_post_rejects_post_uri_with_empty_post_id() {
+        // Empty post-id segment fails the 13-char Crockford check.
+        let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/");
+        let post = make_collection_post("X", None, Some(vec![uri]));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("invalid post id"), "got: {err}");
+    }
+
+    #[test]
+    fn test_collection_post_rejects_userinfo_padding_bypass() {
+        // `Url::parse(...).host_str()` strips userinfo, which would smuggle
+        // arbitrary bytes past a parse-and-recheck approach. The strict
+        // validator keeps the `JUNK@` in the host slot, failing the 52-char
+        // PubkyId length check.
+        let uri = format!(
+            "pubky://AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA@{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A"
+        );
+        let post = make_collection_post("X", None, Some(vec![uri]));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("invalid pubky-id"), "got: {err}");
+    }
+
+    #[test]
+    fn test_collection_post_rejects_dot_dot_path_bypass() {
+        // `Url::parse(...)` collapses `..` segments before path inspection,
+        // which would smuggle a non-canonical raw path past a parse-and-recheck
+        // approach. The strict validator splits the raw string, so the extra
+        // segments land in the host slot and fail PubkyId.
+        let uri = format!("pubky://{TEST_PUBKY_ID}/aa/bb/../../pub/pubky.app/posts/0034A0X7NJ52A");
+        let post = make_collection_post("X", None, Some(vec![uri]));
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("invalid pubky-id"), "got: {err}");
+    }
+
+    #[test]
+    fn test_collection_post_accepts_canonical_max_length_uri() {
+        // Success-side boundary: the longest valid canonical post URI is
+        // pubky://<52-char-pubky-id>/pub/pubky.app/posts/<13-char-crockford>
+        // which is exactly 94 chars. Validator must accept this.
+        let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A");
+        assert_eq!(uri.chars().count(), 94);
+        let post = make_collection_post("X", None, Some(vec![uri]));
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_collection_post_rejects_non_empty_attachments() {
+        let post = PubkyAppPost::new(
+            collection_envelope_json("X", None, &[]),
+            PubkyAppPostKind::Collection,
+            None,
+            None,
+            Some(vec![
+                "pubky://userA/pub/pubky.app/posts/0034A0X7NJ52A".to_string()
+            ]),
+        );
+        let id = post.create_id();
+        let err = post
+            .validate(Some(&id))
+            .expect_err("Collection with non-empty post.attachments must be rejected");
+        assert!(
+            err.contains("post.attachments"),
+            "expected anti-misuse error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_collection_post_accepts_missing_items_field() {
+        let envelope_json = r#"{"name":"X"}"#;
+        let post = PubkyAppPost::new(
+            envelope_json.to_string(),
+            PubkyAppPostKind::Collection,
+            None,
+            None,
+            None,
+        );
+        let id = post.create_id();
+        assert!(
+            post.validate(Some(&id)).is_ok(),
+            "missing `items` field must deserialize as empty list via serde(default)"
+        );
+    }
+
+    #[test]
+    fn test_collection_post_envelope_at_max_size() {
+        // 100 distinct valid pubky post URIs (max-count). Each exactly 94 chars.
+        let items: Vec<String> = (0..VALIDATION_LIMITS.collection_items_max_count)
+            .map(|i| format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/{:013}", i))
+            .collect();
+        let max_name = "a".repeat(VALIDATION_LIMITS.collection_name_max_length);
+        let max_desc = "b".repeat(VALIDATION_LIMITS.collection_description_max_length);
+        let post = make_collection_post(&max_name, Some(&max_desc), Some(items));
+        assert!(
+            post.content.chars().count() < VALIDATION_LIMITS.collection_content_max_length,
+            "envelope at max field sizes must fit under collection_content_max_length"
+        );
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn test_postkind_collection_wasm_getter() {
+        let post = PubkyAppPost {
+            content: collection_envelope_json("X", None, &[]),
+            kind: PubkyAppPostKind::Collection,
+            parent: None,
+            embed: None,
+            attachments: None,
+        };
+        assert_eq!(post.kind(), "Collection");
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn test_create_collection_post_wasm_builder() {
+        // End-to-end via the JS-facing builder:
+        //   PubkySpecsBuilder.createCollectionPost(name, description?, attachments?)
+        // builds the {name, description} envelope internally, packages it
+        // into a kind=Collection PubkyAppPost, and returns a PostResult
+        // ready to ship to the homeserver. JS callers don't have to
+        // JSON-stringify the envelope themselves.
+        use crate::PubkySpecsBuilder;
+        let pubky_id = "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".to_string();
+        let builder = PubkySpecsBuilder::new(pubky_id).expect("Failed to construct builder");
+        let result = builder
+            .create_collection_post(
+                "My favorites".to_string(),
+                Some("Best things".to_string()),
+                Some(vec![
+                    "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/posts/0034A0X7NJ52A".to_string(),
+                ]),
+                Some("https://example.com/cover.png".to_string()),
+            )
+            .expect("createCollectionPost should succeed");
+
+        let post = result.post();
+        assert_eq!(post.kind, PubkyAppPostKind::Collection);
+        assert!(post.attachments.is_none());
+        let envelope: PubkyAppCollectionContent = serde_json::from_str(&post.content)
+            .expect("Collection content must deserialize as PubkyAppCollectionContent");
+        assert_eq!(envelope.name, "My favorites");
+        assert_eq!(envelope.description.as_deref(), Some("Best things"));
+        assert_eq!(envelope.items.len(), 1);
+        assert_eq!(
+            envelope.cover_image.as_deref(),
+            Some("https://example.com/cover.png")
+        );
+    }
+}

--- a/src/models/post/content/lock.rs
+++ b/src/models/post/content/lock.rs
@@ -1,0 +1,563 @@
+use crate::limits::VALIDATION_LIMITS;
+use crate::PROTOCOL;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+#[cfg(target_arch = "wasm32")]
+use tsify_next::Tsify;
+
+#[cfg(feature = "openapi")]
+use utoipa::ToSchema;
+
+use super::super::{PubkyAppPost, PubkyAppPostKind};
+
+/// Post kinds permitted as a lock teaser's `header_kind`.
+///
+/// Restricted to the simple display kinds used to render the public lock card.
+/// `long`, `collection`, `lock`, and unknown kinds are intentionally excluded.
+pub const ALLOWED_LOCK_HEADER_KINDS: [PubkyAppPostKind; 5] = [
+    PubkyAppPostKind::Short,
+    PubkyAppPostKind::Image,
+    PubkyAppPostKind::Video,
+    PubkyAppPostKind::Link,
+    PubkyAppPostKind::File,
+];
+
+/// Typed JSON envelope stored in the `content` of a `kind = lock` post.
+///
+/// A locked post advertises gate metadata (`header`, `title`, `header_kind`)
+/// plus the `lock` URL in this public `content` JSON envelope. The full guarded
+/// payload lives in private storage and is served by the Lock Server after
+/// verification.
+///
+/// **Construction**: deserialized from the post's `content` JSON during validation.
+/// Re-exported publicly (via `lib.rs`) for SDK/OpenAPI consumers.
+///
+/// Forward-compat: `#[serde(deny_unknown_fields)]` is intentionally NOT used so
+/// future minor versions can add fields without breaking older parsers.
+#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(target_arch = "wasm32", derive(Tsify))]
+#[serde(rename_all = "snake_case")]
+pub struct PubkyAppLockContent {
+    /// Public teaser used as the lock post's body, interpreted per `header_kind`
+    /// (any media it references comes from the post's `attachments`). Length
+    /// bounded by `VALIDATION_LIMITS.lock_content_header_max_length` (unicode scalars);
+    /// whitespace-only headers are rejected separately by the validator.
+    pub header: String,
+    /// Short label on the lock card ("Locked Article", "Premium episode").
+    /// Length bounded by `VALIDATION_LIMITS.lock_content_title_{min,max}_length`.
+    /// Whitespace-only titles are rejected separately by the validator.
+    pub title: String,
+    /// Display kind of the guarded content, used to render the public teaser
+    /// card. Restricted to the simple display kinds: `short`, `image`, `video`,
+    /// `link`, `file`. `long`, `collection`, `lock`, and unknown kinds are
+    /// rejected by the validator.
+    pub header_kind: PubkyAppPostKind,
+    /// Lock Server URL the guarded bundle is served from. Must be a `pubky://`
+    /// URL with a host, up to `VALIDATION_LIMITS.post_attachment_url_max_length`
+    /// characters.
+    pub lock: String,
+}
+
+/// Validates a `kind = Lock` post, including its JSON content envelope.
+pub(crate) fn validate_lock_post(post: &PubkyAppPost) -> Result<(), String> {
+    if post.parent.is_some() || post.embed.is_some() {
+        return Err("Validation Error: Locked posts cannot have parent or embed".into());
+    }
+    // Teaser media (e.g. for an `image`/`file` header_kind) is carried in the
+    // post's `attachments` and validated with the same rules as any other post.
+    super::super::validate_attachments(&post.attachments)?;
+    if post.content.chars().count() > VALIDATION_LIMITS.lock_content_max_length {
+        return Err(format!(
+            "Validation Error: Lock content exceeds max length {}",
+            VALIDATION_LIMITS.lock_content_max_length
+        ));
+    }
+    let envelope: PubkyAppLockContent = serde_json::from_str(&post.content).map_err(|e| {
+        format!(
+            "Validation Error: Lock content must be a valid JSON envelope: {}",
+            e
+        )
+    })?;
+    validate_lock_envelope(&envelope)
+}
+
+fn validate_lock_envelope(envelope: &PubkyAppLockContent) -> Result<(), String> {
+    if envelope.header.trim().is_empty() {
+        return Err(
+            "Validation Error: Lock header must contain non-whitespace characters".into(),
+        );
+    }
+    let header_chars = envelope.header.chars().count();
+    if header_chars > VALIDATION_LIMITS.lock_content_header_max_length {
+        return Err(format!(
+            "Validation Error: Lock header exceeds {} characters",
+            VALIDATION_LIMITS.lock_content_header_max_length
+        ));
+    }
+    if envelope.title.trim().is_empty() {
+        return Err(
+            "Validation Error: Lock title must contain non-whitespace characters".into(),
+        );
+    }
+    let title_chars = envelope.title.chars().count();
+    let title_min = VALIDATION_LIMITS.lock_content_title_min_length;
+    let title_max = VALIDATION_LIMITS.lock_content_title_max_length;
+    if !(title_min..=title_max).contains(&title_chars) {
+        return Err(format!(
+            "Validation Error: Lock title must be {}..={} characters",
+            title_min, title_max
+        ));
+    }
+
+    // `header_kind` is restricted to the simple display kinds. `long`,
+    // `collection`, `lock`, and `unknown` are rejected.
+    if !ALLOWED_LOCK_HEADER_KINDS.contains(&envelope.header_kind) {
+        return Err(
+            "Validation Error: Lock header_kind must be one of short, image, video, link, file"
+                .into(),
+        );
+    }
+
+    validate_lock_url(&envelope.lock)
+}
+
+/// Validates the envelope `lock` URL: non-empty, length-capped, `pubky://`
+/// scheme, and a present host. Mirrors the rules previously enforced on the
+/// top-level `post.lock` field.
+fn validate_lock_url(lock_url: &str) -> Result<(), String> {
+    if lock_url.trim().is_empty() {
+        return Err("Validation Error: Lock URL cannot be empty".into());
+    }
+    if lock_url.chars().count() > VALIDATION_LIMITS.post_attachment_url_max_length {
+        return Err(format!(
+            "Validation Error: Lock URL exceeds maximum length (max: {} characters)",
+            VALIDATION_LIMITS.post_attachment_url_max_length
+        ));
+    }
+    let parsed = Url::parse(lock_url)
+        .map_err(|_| format!("Validation Error: Invalid lock URL format: {lock_url}"))?;
+    if parsed.scheme() != PROTOCOL.trim_end_matches("://") {
+        return Err(format!(
+            "Validation Error: Lock URL must use the {PROTOCOL} scheme: {lock_url}"
+        ));
+    }
+    // Reject opaque URLs like `pubky:lock-id` that carry the scheme but no
+    // authority and so point at no resolvable lock server.
+    if parsed.host().is_none() {
+        return Err(format!(
+            "Validation Error: Lock URL must include a host: {lock_url}"
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::super::super::{PubkyAppPost, PubkyAppPostKind};
+    use crate::traits::{TimestampId, Validatable};
+
+    const TEST_PUBKY_ID: &str = "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo";
+
+    fn default_lock() -> String {
+        format!("pubky://{TEST_PUBKY_ID}/pub/locks/0034A0X7NJ52G")
+    }
+
+    fn lock_envelope_json(
+        header: &str,
+        title: &str,
+        header_kind: PubkyAppPostKind,
+        lock: &str,
+    ) -> String {
+        serde_json::to_string(&PubkyAppLockContent {
+            header: header.to_string(),
+            title: title.to_string(),
+            header_kind,
+            lock: lock.to_string(),
+        })
+        .unwrap()
+    }
+
+    /// Builds a `kind = Lock` post with a valid `header_kind` (Short) and the
+    /// default lock URL, so the only variables under test are `header`/`title`.
+    fn make_locked_post(header: &str, title: &str) -> PubkyAppPost {
+        PubkyAppPost::new(
+            lock_envelope_json(header, title, PubkyAppPostKind::Short, &default_lock()),
+            PubkyAppPostKind::Lock,
+            None,
+            None,
+            None,
+        )
+    }
+
+    /// Builds a `kind = Lock` post from a raw `content` envelope string.
+    fn make_lock_post_from_content(content: &str) -> PubkyAppPost {
+        PubkyAppPost::new(
+            content.to_string(),
+            PubkyAppPostKind::Lock,
+            None,
+            None,
+            None,
+        )
+    }
+
+    #[test]
+    fn test_lock_post_roundtrip_valid() {
+        let lock = default_lock();
+        let content = lock_envelope_json(
+            "We were reckless adopting Lightning without understanding the tradeoffs.",
+            "Locked Article",
+            PubkyAppPostKind::Image,
+            &lock,
+        );
+        let post = make_lock_post_from_content(&content);
+        let id = post.create_id();
+        let blob = serde_json::to_vec(&post).unwrap();
+        let parsed = <PubkyAppPost as Validatable>::try_from(&blob, &id).unwrap();
+        assert_eq!(parsed.kind, PubkyAppPostKind::Lock);
+        assert!(parsed.attachments.is_none());
+        let envelope: PubkyAppLockContent = serde_json::from_str(&parsed.content).unwrap();
+        assert_eq!(
+            envelope.header,
+            "We were reckless adopting Lightning without understanding the tradeoffs."
+        );
+        assert_eq!(envelope.title, "Locked Article");
+        assert_eq!(envelope.header_kind, PubkyAppPostKind::Image);
+        assert_eq!(envelope.lock, lock);
+    }
+
+    #[test]
+    fn test_lock_post_rejects_malformed_envelope() {
+        let post = make_lock_post_from_content("not json");
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("JSON envelope"), "got: {err}");
+    }
+
+    #[test]
+    fn test_lock_post_rejects_empty_header() {
+        let post = make_locked_post("", "Locked Article");
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("header"), "got: {err}");
+    }
+
+    #[test]
+    fn test_lock_post_rejects_oversized_header() {
+        let oversized = "a".repeat(VALIDATION_LIMITS.lock_content_header_max_length + 1);
+        let post = make_locked_post(&oversized, "Locked Article");
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("header"), "got: {err}");
+    }
+
+    #[test]
+    fn test_lock_post_accepts_max_header() {
+        let exactly_max = "a".repeat(VALIDATION_LIMITS.lock_content_header_max_length);
+        let post = make_locked_post(&exactly_max, "Locked Article");
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_lock_post_rejects_whitespace_only_header() {
+        let post = make_locked_post("    ", "Locked Article");
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("whitespace"), "got: {err}");
+    }
+
+    #[test]
+    fn test_lock_post_rejects_empty_title() {
+        let post = make_locked_post("Teaser text", "");
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("title"), "got: {err}");
+    }
+
+    #[test]
+    fn test_lock_post_rejects_oversized_title() {
+        let oversized = "a".repeat(99) + "🚀🚀";
+        assert_eq!(oversized.chars().count(), 101);
+        let post = make_locked_post("Teaser text", &oversized);
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("title"), "got: {err}");
+    }
+
+    #[test]
+    fn test_lock_post_accepts_max_title() {
+        let exactly_100 = "a".repeat(100);
+        let post = make_locked_post("Teaser text", &exactly_100);
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_lock_post_rejects_whitespace_only_title() {
+        let post = make_locked_post("Teaser text", "    ");
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("whitespace"), "got: {err}");
+    }
+
+    #[test]
+    fn test_lock_post_counts_whitespace_in_title_length() {
+        let padded = format!(" {} ", "a".repeat(99));
+        assert_eq!(padded.chars().count(), 101);
+        let post = make_locked_post("Teaser text", &padded);
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("1..=100"), "got: {err}");
+    }
+
+    #[test]
+    fn test_lock_post_rejects_missing_header() {
+        let lock = default_lock();
+        let envelope =
+            format!(r#"{{ "title": "Locked Article", "header_kind": "short", "lock": "{lock}" }}"#);
+        let post = make_lock_post_from_content(&envelope);
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(
+            err.contains("header") || err.to_lowercase().contains("missing"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_lock_post_rejects_missing_title() {
+        let lock = default_lock();
+        let envelope =
+            format!(r#"{{ "header": "Teaser text", "header_kind": "short", "lock": "{lock}" }}"#);
+        let post = make_lock_post_from_content(&envelope);
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(
+            err.contains("title") || err.to_lowercase().contains("missing"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_lock_post_rejects_missing_header_kind() {
+        let lock = default_lock();
+        let envelope =
+            format!(r#"{{ "header": "Teaser text", "title": "Locked Article", "lock": "{lock}" }}"#);
+        let post = make_lock_post_from_content(&envelope);
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(
+            err.contains("header_kind") || err.to_lowercase().contains("missing"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_lock_post_rejects_missing_lock() {
+        let envelope = r#"{ "header": "Teaser text", "title": "Locked Article", "header_kind": "short" }"#;
+        let post = make_lock_post_from_content(envelope);
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(
+            err.contains("lock") || err.to_lowercase().contains("missing"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_lock_post_accepts_each_simple_header_kind() {
+        for hk in [
+            PubkyAppPostKind::Short,
+            PubkyAppPostKind::Image,
+            PubkyAppPostKind::Video,
+            PubkyAppPostKind::Link,
+            PubkyAppPostKind::File,
+        ] {
+            let content =
+                lock_envelope_json("Teaser text", "Locked Article", hk.clone(), &default_lock());
+            let post = make_lock_post_from_content(&content);
+            let id = post.create_id();
+            assert!(
+                post.validate(Some(&id)).is_ok(),
+                "header_kind {hk:?} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn test_lock_post_rejects_disallowed_header_kind() {
+        for hk in [
+            PubkyAppPostKind::Long,
+            PubkyAppPostKind::Collection,
+            PubkyAppPostKind::Lock,
+        ] {
+            let content =
+                lock_envelope_json("Teaser text", "Locked Article", hk.clone(), &default_lock());
+            let post = make_lock_post_from_content(&content);
+            let id = post.create_id();
+            let err = post.validate(Some(&id)).unwrap_err();
+            assert!(
+                err.contains("header_kind"),
+                "header_kind {hk:?} should be rejected, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_lock_post_rejects_non_pubky_lock_url() {
+        let content = lock_envelope_json(
+            "Teaser text",
+            "Locked Article",
+            PubkyAppPostKind::Short,
+            "https://locks.example.com/session/0034A0X7NJ52G",
+        );
+        let post = make_lock_post_from_content(&content);
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("must use the pubky:// scheme"), "got: {err}");
+    }
+
+    #[test]
+    fn test_lock_post_rejects_invalid_lock_url() {
+        let content = lock_envelope_json(
+            "Teaser text",
+            "Locked Article",
+            PubkyAppPostKind::Short,
+            "not a url",
+        );
+        let post = make_lock_post_from_content(&content);
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("Invalid lock URL format"), "got: {err}");
+    }
+
+    #[test]
+    fn test_lock_post_rejects_hostless_lock_url() {
+        let content = lock_envelope_json(
+            "Teaser text",
+            "Locked Article",
+            PubkyAppPostKind::Short,
+            "pubky:lock-id",
+        );
+        let post = make_lock_post_from_content(&content);
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("must include a host"), "got: {err}");
+    }
+
+    #[test]
+    fn test_lock_post_rejects_empty_lock_url() {
+        let content =
+            lock_envelope_json("Teaser text", "Locked Article", PubkyAppPostKind::Short, "");
+        let post = make_lock_post_from_content(&content);
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("Lock URL cannot be empty"), "got: {err}");
+    }
+
+    #[test]
+    fn test_lock_post_rejects_parent() {
+        let content =
+            lock_envelope_json("Teaser", "Locked Article", PubkyAppPostKind::Short, &default_lock());
+        let post = PubkyAppPost::new(
+            content,
+            PubkyAppPostKind::Lock,
+            Some("pubky://userA/pub/pubky.app/posts/0034A0X7NJ52A".to_string()),
+            None,
+            None,
+        );
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("parent or embed"), "got: {err}");
+    }
+
+    #[test]
+    fn test_lock_post_accepts_valid_attachments() {
+        // Teaser media (e.g. an `image` header_kind) is carried in post.attachments.
+        let content =
+            lock_envelope_json("Teaser", "Locked Article", PubkyAppPostKind::Image, &default_lock());
+        let post = PubkyAppPost::new(
+            content,
+            PubkyAppPostKind::Lock,
+            None,
+            None,
+            Some(vec!["pubky://userA/pub/pubky.app/files/0034A0X7NJ52A".to_string()]),
+        );
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_lock_post_rejects_invalid_attachment_url() {
+        let content =
+            lock_envelope_json("Teaser", "Locked Article", PubkyAppPostKind::Image, &default_lock());
+        let post = PubkyAppPost::new(
+            content,
+            PubkyAppPostKind::Lock,
+            None,
+            None,
+            Some(vec!["not a valid url".to_string()]),
+        );
+        let id = post.create_id();
+        let err = post.validate(Some(&id)).unwrap_err();
+        assert!(err.contains("attachment URL"), "got: {err}");
+    }
+
+    #[test]
+    fn test_lock_envelope_tolerates_extra_fields() {
+        let lock = default_lock();
+        let envelope_json = format!(
+            r#"{{"header":"Teaser","title":"Locked Article","header_kind":"image","lock":"{lock}","_forward_compat_canary":"future-only"}}"#
+        );
+        let post = make_lock_post_from_content(&envelope_json);
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_lock_post_envelope_at_max_size() {
+        let max_header = "a".repeat(VALIDATION_LIMITS.lock_content_header_max_length);
+        let max_title = "b".repeat(VALIDATION_LIMITS.lock_content_title_max_length);
+        let content =
+            lock_envelope_json(&max_header, &max_title, PubkyAppPostKind::Short, &default_lock());
+        let post = make_lock_post_from_content(&content);
+        assert!(
+            post.content.chars().count() < VALIDATION_LIMITS.lock_content_max_length,
+            "envelope at max field sizes must fit under lock_content_max_length"
+        );
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn test_create_lock_post_wasm_builder() {
+        // End-to-end via the JS-facing builder:
+        //   PubkySpecsBuilder.createLockPost(header, title, header_kind, lock)
+        // builds the {header, title, header_kind, lock} envelope internally,
+        // packages it into a kind=Lock PubkyAppPost, and returns a PostResult.
+        use crate::PubkySpecsBuilder;
+        let pubky_id = TEST_PUBKY_ID.to_string();
+        let builder = PubkySpecsBuilder::new(pubky_id).expect("Failed to construct builder");
+        let result = builder
+            .create_lock_post(
+                "We were reckless adopting Lightning.".to_string(),
+                "Locked Article".to_string(),
+                PubkyAppPostKind::Image,
+                default_lock(),
+            )
+            .expect("createLockPost should succeed");
+
+        let post = result.post();
+        assert_eq!(post.kind, PubkyAppPostKind::Lock);
+        assert!(post.attachments.is_none());
+        let envelope: PubkyAppLockContent = serde_json::from_str(&post.content)
+            .expect("Lock content must deserialize as PubkyAppLockContent");
+        assert_eq!(envelope.title, "Locked Article");
+        assert_eq!(envelope.header_kind, PubkyAppPostKind::Image);
+        assert_eq!(envelope.lock, default_lock());
+    }
+}

--- a/src/models/post/content/mod.rs
+++ b/src/models/post/content/mod.rs
@@ -1,0 +1,5 @@
+pub mod collection;
+pub mod lock;
+
+pub use collection::PubkyAppCollectionContent;
+pub use lock::PubkyAppLockContent;

--- a/src/models/post/mod.rs
+++ b/src/models/post/mod.rs
@@ -1,10 +1,14 @@
 use crate::{
-    common::{sanitize_url, validate_crockford_id},
+    common::sanitize_url,
     limits::VALIDATION_LIMITS,
     traits::{HasIdPath, TimestampId, Validatable},
-    types::PubkyId,
-    APP_PATH, PROTOCOL, PUBLIC_PATH,
+    APP_PATH, PUBLIC_PATH,
 };
+
+pub mod content;
+
+pub use content::PubkyAppCollectionContent;
+pub use content::PubkyAppLockContent;
 use serde::{Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 use url::Url;
@@ -14,8 +18,6 @@ const RESERVED_CONTENT_DELETED: &str = "[DELETED]";
 
 #[cfg(target_arch = "wasm32")]
 use crate::traits::Json;
-#[cfg(target_arch = "wasm32")]
-use tsify_next::Tsify;
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
@@ -37,6 +39,7 @@ pub enum PubkyAppPostKind {
     Link,
     File,
     Collection,
+    Lock,
     #[serde(other)]
     Unknown,
 }
@@ -63,6 +66,7 @@ impl FromStr for PubkyAppPostKind {
             "link" => Ok(PubkyAppPostKind::Link),
             "file" => Ok(PubkyAppPostKind::File),
             "collection" => Ok(PubkyAppPostKind::Collection),
+            "lock" => Ok(PubkyAppPostKind::Lock),
             _ => Err(format!("Invalid content kind: {}", s)),
         }
     }
@@ -111,6 +115,7 @@ impl PubkyAppPostEmbed {
             PubkyAppPostKind::Link => "Link".to_string(),
             PubkyAppPostKind::File => "File".to_string(),
             PubkyAppPostKind::Collection => "Collection".to_string(),
+            PubkyAppPostKind::Lock => "Lock".to_string(),
             PubkyAppPostKind::Unknown => "Unknown".to_string(),
         }
     }
@@ -119,48 +124,6 @@ impl PubkyAppPostEmbed {
     pub fn uri(&self) -> String {
         self.uri.clone()
     }
-}
-
-/// Typed JSON envelope stored in `PubkyAppPost::content` when `kind == Collection`.
-///
-/// A collection post curates an ordered list of URIs (via `items`)
-/// under a `name` and optional `description`. The envelope is parsed and validated
-/// by the spec but never re-serialized as a top-level homeserver object.
-///
-/// **Construction**: this struct is deserialized from the post's `content` JSON
-/// envelope during validation and is **not** intended to be constructed by
-/// callers directly. It is re-exported publicly (via `lib.rs`) so SDK consumers
-/// can inspect the envelope shape (OpenAPI schema, type definitions), but the
-/// authoritative way to produce a Collection post is to author a `PubkyAppPost`
-/// with `kind: Collection` and a `content` string that JSON-parses into this
-/// shape.
-///
-/// Forward-compat: `#[serde(deny_unknown_fields)]` is intentionally NOT used so
-/// future minor versions can add fields (e.g. `cover_image`) without breaking
-/// older parsers. New fields must be additive and ignorable.
-#[derive(Serialize, Deserialize, Default, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "openapi", derive(ToSchema))]
-#[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[serde(rename_all = "snake_case")]
-pub struct PubkyAppCollectionContent {
-    /// Display name of the collection. Length bounded by
-    /// `VALIDATION_LIMITS.collection_name_{min,max}_length` (unicode scalars).
-    /// Whitespace-only names are rejected separately by the validator.
-    pub name: String,
-    /// Optional human-readable description. Length bounded by
-    /// `VALIDATION_LIMITS.collection_description_max_length` (unicode scalars).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    /// Ordered list of Post URIs this collection curates. Count bounded by
-    /// `VALIDATION_LIMITS.collection_items_max_count`; each URI must be in
-    /// exact canonical form (see `validate_collection_item_uri`).
-    #[serde(default)]
-    pub items: Vec<String>,
-    /// Optional hero/cover image URL. Length bounded by
-    /// `VALIDATION_LIMITS.post_attachment_url_max_length`; protocol must be in
-    /// `VALIDATION_LIMITS.post_allowed_attachment_protocols`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cover_image: Option<String>,
 }
 
 /// Represents raw post in homeserver with content and kind
@@ -184,9 +147,6 @@ pub struct PubkyAppPost {
     pub embed: Option<PubkyAppPostEmbed>,
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
     pub attachments: Option<Vec<String>>,
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub lock: Option<String>,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -207,6 +167,7 @@ impl PubkyAppPost {
             PubkyAppPostKind::Link => "Link".to_string(),
             PubkyAppPostKind::File => "File".to_string(),
             PubkyAppPostKind::Collection => "Collection".to_string(),
+            PubkyAppPostKind::Lock => "Lock".to_string(),
             PubkyAppPostKind::Unknown => "Unknown".to_string(),
         }
     }
@@ -224,11 +185,6 @@ impl PubkyAppPost {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
     pub fn attachments(&self) -> Option<Vec<String>> {
         self.attachments.clone()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
-    pub fn lock(&self) -> Option<String> {
-        self.lock.clone()
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromJson))]
@@ -256,25 +212,12 @@ impl PubkyAppPost {
         embed: Option<PubkyAppPostEmbed>,
         attachments: Option<Vec<String>>,
     ) -> Self {
-        Self::new_with_lock(content, kind, parent, embed, attachments, None)
-    }
-
-    /// Creates a new lockable `PubkyAppPost` instance and sanitizes it.
-    pub fn new_with_lock(
-        content: String,
-        kind: PubkyAppPostKind,
-        parent: Option<String>,
-        embed: Option<PubkyAppPostEmbed>,
-        attachments: Option<Vec<String>>,
-        lock: Option<String>,
-    ) -> Self {
         let post = PubkyAppPost {
             content,
             kind,
             parent,
             embed,
             attachments,
-            lock,
         };
         post.sanitize()
     }
@@ -312,15 +255,12 @@ impl Validatable for PubkyAppPost {
                 .collect()
         });
 
-        let lock = self.lock.map(|uri_str| sanitize_url(&uri_str));
-
         PubkyAppPost {
             content,
             kind: self.kind,
             parent,
             embed,
             attachments,
-            lock,
         }
     }
 
@@ -359,123 +299,12 @@ impl Validatable for PubkyAppPost {
             }
         }
 
-        // Validate lock URL if present, for every kind (including collections,
-        // which return early below). Missing or null locks keep posts unlocked.
-        // Lock servers live on the Pubky network, so the URL must be `pubky://`
-        // with a host; the length cap is shared with attachment URLs.
-        if let Some(ref lock_url) = self.lock {
-            if lock_url.trim().is_empty() {
-                return Err("Validation Error: Lock URL cannot be empty".into());
-            }
-            if lock_url.chars().count() > VALIDATION_LIMITS.post_attachment_url_max_length {
-                return Err(format!(
-                    "Validation Error: Lock URL exceeds maximum length (max: {} characters)",
-                    VALIDATION_LIMITS.post_attachment_url_max_length
-                ));
-            }
-            let parsed = Url::parse(lock_url)
-                .map_err(|_| format!("Validation Error: Invalid lock URL format: {lock_url}"))?;
-            if parsed.scheme() != PROTOCOL.trim_end_matches("://") {
-                return Err(format!(
-                    "Validation Error: Lock URL must use the {PROTOCOL} scheme: {lock_url}"
-                ));
-            }
-            // Reject opaque URLs like `pubky:lock-id` that carry the scheme but
-            // no authority and so point at no resolvable lock server.
-            if parsed.host().is_none() {
-                return Err(format!(
-                    "Validation Error: Lock URL must include a host: {lock_url}"
-                ));
-            }
+        if matches!(self.kind, PubkyAppPostKind::Collection) {
+            return content::collection::validate_collection_post(self);
         }
 
-        if matches!(self.kind, PubkyAppPostKind::Collection) {
-            if self.parent.is_some() || self.embed.is_some() {
-                return Err(
-                    "Validation Error: Collection posts cannot have parent or embed".into(),
-                );
-            }
-            // Anti-misuse guard: items belong in the envelope, not in
-            // `post.attachments`.
-            if matches!(&self.attachments, Some(a) if !a.is_empty()) {
-                return Err(
-                    "Validation Error: Collection posts must not use post.attachments — items belong in the content envelope"
-                        .into(),
-                );
-            }
-            if self.content.chars().count() > VALIDATION_LIMITS.collection_content_max_length {
-                return Err(format!(
-                    "Validation Error: Collection content exceeds max length {}",
-                    VALIDATION_LIMITS.collection_content_max_length
-                ));
-            }
-            let envelope: PubkyAppCollectionContent =
-                serde_json::from_str(&self.content).map_err(|e| {
-                    format!(
-                        "Validation Error: Collection content must be a valid JSON envelope: {}",
-                        e
-                    )
-                })?;
-            if envelope.name.trim().is_empty() {
-                return Err(
-                    "Validation Error: Collection name must contain non-whitespace characters"
-                        .into(),
-                );
-            }
-            let name_chars = envelope.name.chars().count();
-            let name_min = VALIDATION_LIMITS.collection_name_min_length;
-            let name_max = VALIDATION_LIMITS.collection_name_max_length;
-            if !(name_min..=name_max).contains(&name_chars) {
-                return Err(format!(
-                    "Validation Error: Collection name must be {}..={} characters",
-                    name_min, name_max
-                ));
-            }
-            if let Some(desc) = &envelope.description {
-                if desc.chars().count() > VALIDATION_LIMITS.collection_description_max_length {
-                    return Err(format!(
-                        "Validation Error: Collection description exceeds {} characters",
-                        VALIDATION_LIMITS.collection_description_max_length
-                    ));
-                }
-            }
-            if let Some(cover) = &envelope.cover_image {
-                if cover.chars().count() > VALIDATION_LIMITS.post_attachment_url_max_length {
-                    return Err(format!(
-                        "Validation Error: Collection cover_image URL exceeds {} characters",
-                        VALIDATION_LIMITS.post_attachment_url_max_length
-                    ));
-                }
-                let parsed = Url::parse(cover).map_err(|_| {
-                    "Validation Error: Collection cover_image must be a valid URL".to_string()
-                })?;
-                if !VALIDATION_LIMITS
-                    .post_allowed_attachment_protocols
-                    .contains(&parsed.scheme())
-                {
-                    let allowed = VALIDATION_LIMITS
-                        .post_allowed_attachment_protocols
-                        .iter()
-                        .map(|p| format!("{p}://"))
-                        .collect::<Vec<_>>()
-                        .join(", ");
-                    return Err(format!(
-                        "Validation Error: Collection cover_image must use one of the allowed protocols: {allowed}"
-                    ));
-                }
-            }
-            if envelope.items.len() > VALIDATION_LIMITS.collection_items_max_count {
-                return Err(format!(
-                    "Validation Error: Collection cannot have more than {} items",
-                    VALIDATION_LIMITS.collection_items_max_count
-                ));
-            }
-            for (index, uri) in envelope.items.iter().enumerate() {
-                validate_collection_item_uri(uri).map_err(|e| {
-                    format!("Validation Error: Collection item at index {index}: {e}")
-                })?;
-            }
-            return Ok(());
+        if matches!(self.kind, PubkyAppPostKind::Lock) {
+            return content::lock::validate_lock_post(self);
         }
 
         // Validate content length based on post kind
@@ -489,7 +318,7 @@ impl Validatable for PubkyAppPost {
                 VALIDATION_LIMITS.post_short_content_max_length,
                 "Image/Video/Link/File",
             ),
-            PubkyAppPostKind::Collection | PubkyAppPostKind::Unknown => {
+            PubkyAppPostKind::Collection | PubkyAppPostKind::Lock | PubkyAppPostKind::Unknown => {
                 unreachable!("guarded by early-return above")
             }
         };
@@ -519,77 +348,66 @@ impl Validatable for PubkyAppPost {
         }
 
         // Validate attachments
-        if let Some(attachments) = &self.attachments {
-            if attachments.len() > VALIDATION_LIMITS.post_attachments_max_count {
-                return Err(format!(
-                    "Validation Error: Too many attachments (max: {})",
-                    VALIDATION_LIMITS.post_attachments_max_count
-                ));
-            }
-
-            for (index, url) in attachments.iter().enumerate() {
-                if url.trim().is_empty() {
-                    return Err(format!(
-                        "Validation Error: Attachment URL at index {} cannot be empty",
-                        index
-                    ));
-                }
-                if url.chars().count() > VALIDATION_LIMITS.post_attachment_url_max_length {
-                    return Err(format!(
-                        "Validation Error: Attachment URL at index {} exceeds maximum length (max: {} characters)",
-                        index, VALIDATION_LIMITS.post_attachment_url_max_length
-                    ));
-                }
-                // Validate URL format and ensure it uses an allowed protocol
-                let parsed_url = Url::parse(url).map_err(|_| {
-                    format!(
-                        "Validation Error: Invalid attachment URL format at index {}",
-                        index
-                    )
-                })?;
-
-                // Ensure the URL uses an allowed protocol
-                if !VALIDATION_LIMITS
-                    .post_allowed_attachment_protocols
-                    .contains(&parsed_url.scheme())
-                {
-                    let allowed_protocols = VALIDATION_LIMITS
-                        .post_allowed_attachment_protocols
-                        .iter()
-                        .map(|p| format!("{}://", p))
-                        .collect::<Vec<_>>()
-                        .join(", ");
-                    return Err(format!(
-                        "Validation Error: Attachment URL at index {} must use one of the allowed protocols: {}",
-                        index, allowed_protocols
-                    ));
-                }
-            }
-        }
+        validate_attachments(&self.attachments)?;
 
         Ok(())
     }
 }
 
-/// Strict canonical post-URI check for Collection items. Accepts only the
-/// exact form `pubky://<pubky-id>/pub/pubky.app/posts/<post-id>`.
-///
-/// Deliberately avoids `Url::parse`: it silently strips userinfo and collapses
-/// `..` path segments, smuggling non-canonical strings past a parse-and-recheck
-/// approach. Splitting the raw string and delegating to `PubkyId::try_from`
-/// (52-char z-base-32) and `validate_crockford_id` (13-char Crockford) enforces
-/// the canonical 94-char form structurally.
-fn validate_collection_item_uri(uri: &str) -> Result<(), String> {
-    const PREFIX: &str = "pubky://";
-    const MIDDLE: &str = "/pub/pubky.app/posts/";
-    let rest = uri
-        .strip_prefix(PREFIX)
-        .ok_or_else(|| format!("must start with pubky://: {uri}"))?;
-    let (host, post_id) = rest
-        .split_once(MIDDLE)
-        .ok_or_else(|| format!("must be a canonical post URI: {uri}"))?;
-    PubkyId::try_from(host).map_err(|e| format!("invalid pubky-id in host: {e}"))?;
-    validate_crockford_id(post_id).map_err(|e| format!("invalid post id: {e}"))?;
+/// Validates a post's `attachments`: count cap, non-empty URLs, length cap, and
+/// allowed protocols. Shared by the generic post validator and the `kind = lock`
+/// validator so teaser media follows the same rules everywhere.
+pub(crate) fn validate_attachments(attachments: &Option<Vec<String>>) -> Result<(), String> {
+    let Some(attachments) = attachments else {
+        return Ok(());
+    };
+
+    if attachments.len() > VALIDATION_LIMITS.post_attachments_max_count {
+        return Err(format!(
+            "Validation Error: Too many attachments (max: {})",
+            VALIDATION_LIMITS.post_attachments_max_count
+        ));
+    }
+
+    for (index, url) in attachments.iter().enumerate() {
+        if url.trim().is_empty() {
+            return Err(format!(
+                "Validation Error: Attachment URL at index {} cannot be empty",
+                index
+            ));
+        }
+        if url.chars().count() > VALIDATION_LIMITS.post_attachment_url_max_length {
+            return Err(format!(
+                "Validation Error: Attachment URL at index {} exceeds maximum length (max: {} characters)",
+                index, VALIDATION_LIMITS.post_attachment_url_max_length
+            ));
+        }
+        // Validate URL format and ensure it uses an allowed protocol
+        let parsed_url = Url::parse(url).map_err(|_| {
+            format!(
+                "Validation Error: Invalid attachment URL format at index {}",
+                index
+            )
+        })?;
+
+        // Ensure the URL uses an allowed protocol
+        if !VALIDATION_LIMITS
+            .post_allowed_attachment_protocols
+            .contains(&parsed_url.scheme())
+        {
+            let allowed_protocols = VALIDATION_LIMITS
+                .post_allowed_attachment_protocols
+                .iter()
+                .map(|p| format!("{}://", p))
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Err(format!(
+                "Validation Error: Attachment URL at index {} must use one of the allowed protocols: {}",
+                index, allowed_protocols
+            ));
+        }
+    }
+
     Ok(())
 }
 
@@ -599,6 +417,31 @@ mod tests {
 
     const TEST_PUBKY_ID: &str = "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo";
     use crate::{traits::Validatable, APP_PATH, PUBLIC_PATH};
+
+    fn lock_envelope_json(
+        header: &str,
+        title: &str,
+        header_kind: PubkyAppPostKind,
+        lock: &str,
+    ) -> String {
+        serde_json::to_string(&PubkyAppLockContent {
+            header: header.to_string(),
+            title: title.to_string(),
+            header_kind,
+            lock: lock.to_string(),
+        })
+        .unwrap()
+    }
+
+    fn make_lock_post(header: &str, title: &str, lock: &str) -> PubkyAppPost {
+        PubkyAppPost::new(
+            lock_envelope_json(header, title, PubkyAppPostKind::Short, lock),
+            PubkyAppPostKind::Lock,
+            None,
+            None,
+            None,
+        )
+    }
 
     #[test]
     fn test_create_id() {
@@ -821,29 +664,22 @@ mod tests {
     #[test]
     fn test_validate_pubky_lock_url() {
         let expected_lock = format!("pubky://{TEST_PUBKY_ID}/pub");
-        let post = PubkyAppPost::new_with_lock(
-            "Visible preview".to_string(),
-            PubkyAppPostKind::Short,
-            None,
-            None,
-            None,
-            Some(expected_lock.clone()),
+        let post = make_lock_post(
+            "We were reckless adopting Lightning.",
+            "Premium",
+            &expected_lock,
         );
 
         let id = post.create_id();
-        assert_eq!(post.lock.as_deref(), Some(expected_lock.as_str()));
         assert!(post.validate(Some(&id)).is_ok());
     }
 
     #[test]
     fn test_validate_non_pubky_lock_url_rejected() {
-        let post = PubkyAppPost::new_with_lock(
-            "Visible preview".to_string(),
-            PubkyAppPostKind::Short,
-            None,
-            None,
-            None,
-            Some("https://locks.example.com/session/0034A0X7NJ52G".to_string()),
+        let post = make_lock_post(
+            "We were reckless adopting Lightning.",
+            "Premium",
+            "https://locks.example.com/session/0034A0X7NJ52G",
         );
 
         let id = post.create_id();
@@ -854,82 +690,24 @@ mod tests {
 
     #[test]
     fn test_validate_invalid_lock_url() {
-        let post = PubkyAppPost::new_with_lock(
-            "Visible preview".to_string(),
-            PubkyAppPostKind::Short,
-            None,
-            None,
-            None,
-            Some("not a url".to_string()),
+        let post = make_lock_post(
+            "We were reckless adopting Lightning.",
+            "Premium",
+            "not a url",
         );
 
         let id = post.create_id();
         let result = post.validate(Some(&id));
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("Invalid lock URL format"));
-    }
-
-    #[test]
-    fn test_missing_lock_deserializes_unlocked() {
-        let post_json = r#"
-        {
-            "content": "Hello World!",
-            "kind": "short",
-            "parent": null,
-            "embed": null,
-            "attachments": null
-        }
-        "#;
-
-        let post: PubkyAppPost = serde_json::from_str(post_json).unwrap();
-        assert!(post.lock.is_none());
-        let id = post.create_id();
-        assert!(post.validate(Some(&id)).is_ok());
-    }
-
-    #[test]
-    fn test_collection_post_rejects_invalid_lock_url() {
-        let content = collection_envelope_json("My collection", None, &[]);
-        let post = PubkyAppPost::new_with_lock(
-            content,
-            PubkyAppPostKind::Collection,
-            None,
-            None,
-            None,
-            Some("not a url".to_string()),
-        );
-        let id = post.create_id();
-        let result = post.validate(Some(&id));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Invalid lock URL format"));
-    }
-
-    #[test]
-    fn test_collection_post_accepts_valid_lock_url() {
-        let content = collection_envelope_json("My collection", None, &[]);
-        let lock = format!("pubky://{TEST_PUBKY_ID}/pub");
-        let post = PubkyAppPost::new_with_lock(
-            content,
-            PubkyAppPostKind::Collection,
-            None,
-            None,
-            None,
-            Some(lock.clone()),
-        );
-        let id = post.create_id();
-        assert_eq!(post.lock.as_deref(), Some(lock.as_str()));
-        assert!(post.validate(Some(&id)).is_ok());
     }
 
     #[test]
     fn test_validate_hostless_lock_url_rejected() {
-        let post = PubkyAppPost::new_with_lock(
-            "Visible preview".to_string(),
-            PubkyAppPostKind::Short,
-            None,
-            None,
-            None,
-            Some("pubky:lock-id".to_string()),
+        let post = make_lock_post(
+            "We were reckless adopting Lightning.",
+            "Premium",
+            "pubky:lock-id",
         );
         let id = post.create_id();
         let result = post.validate(Some(&id));
@@ -939,14 +717,7 @@ mod tests {
 
     #[test]
     fn test_validate_empty_lock_url_rejected() {
-        let post = PubkyAppPost::new_with_lock(
-            "Visible preview".to_string(),
-            PubkyAppPostKind::Short,
-            None,
-            None,
-            None,
-            Some("".to_string()),
-        );
+        let post = make_lock_post("We were reckless adopting Lightning.", "Premium", "");
         let id = post.create_id();
         assert!(post.validate(Some(&id)).is_err());
     }
@@ -1105,7 +876,6 @@ mod tests {
                 parent: None,
                 embed: None,
                 attachments: Some(vec![invalid_url.to_string()]),
-                lock: None,
             };
 
             let id = post.create_id();
@@ -1124,7 +894,6 @@ mod tests {
             parent: None,
             embed: None,
             attachments: Some(vec!["not a valid url".to_string()]),
-            lock: None,
         };
 
         let id = post.create_id();
@@ -1177,7 +946,6 @@ mod tests {
             parent: None,
             embed: None,
             attachments: Some(vec!["   ".to_string()]), // Whitespace only
-            lock: None,
         };
 
         let id = post.create_id();
@@ -1351,7 +1119,6 @@ mod tests {
             parent: None,
             embed: None,
             attachments: None,
-            lock: None,
         };
         let id = post.create_id();
         let result = post.validate(Some(&id));
@@ -1378,7 +1145,7 @@ mod tests {
     #[test]
     fn test_is_known_returns_true_for_all_recognized_variants() {
         use PubkyAppPostKind::*;
-        for k in [Short, Long, Image, Video, Link, File, Collection] {
+        for k in [Short, Long, Image, Video, Link, File, Collection, Lock] {
             assert!(k.is_known(), "{k:?} should be known");
         }
     }
@@ -1386,6 +1153,19 @@ mod tests {
     #[test]
     fn test_is_known_returns_false_for_unknown() {
         assert!(!PubkyAppPostKind::Unknown.is_known());
+    }
+
+    #[test]
+    fn test_postkind_collection_display_lowercase() {
+        assert_eq!(PubkyAppPostKind::Collection.to_string(), "collection");
+    }
+
+    #[test]
+    fn test_postkind_fromstr_collection() {
+        assert_eq!(
+            PubkyAppPostKind::from_str("collection").unwrap(),
+            PubkyAppPostKind::Collection
+        );
     }
 
     #[test]
@@ -1419,7 +1199,6 @@ mod tests {
                 uri: "pubky://x/pub/pubky.app/posts/01".to_string(),
             }),
             attachments: None,
-            lock: None,
         };
         let id = post.create_id();
         let result = post.validate(Some(&id));
@@ -1441,514 +1220,8 @@ mod tests {
             parent: None,
             embed: None,
             attachments: None,
-            lock: None,
         };
         assert_eq!(post.kind(), "Unknown");
-    }
-
-    // ----- v0.5.0 Collection variant + PubkyAppCollectionContent envelope -----
-
-    fn collection_envelope_json(name: &str, description: Option<&str>, items: &[String]) -> String {
-        serde_json::to_string(&PubkyAppCollectionContent {
-            name: name.to_string(),
-            description: description.map(|d| d.to_string()),
-            items: items.to_vec(),
-            cover_image: None,
-        })
-        .unwrap()
-    }
-
-    fn make_collection_post(
-        name: &str,
-        description: Option<&str>,
-        items: Option<Vec<String>>,
-    ) -> PubkyAppPost {
-        let items = items.unwrap_or_default();
-        PubkyAppPost::new(
-            collection_envelope_json(name, description, &items),
-            PubkyAppPostKind::Collection,
-            None,
-            None,
-            None,
-        )
-    }
-
-    fn make_collection_post_with_cover(cover_image: Option<&str>) -> PubkyAppPost {
-        let envelope = PubkyAppCollectionContent {
-            name: "X".to_string(),
-            description: None,
-            items: vec![],
-            cover_image: cover_image.map(|s| s.to_string()),
-        };
-        let content = serde_json::to_string(&envelope).expect("envelope serialization");
-        PubkyAppPost::new(content, PubkyAppPostKind::Collection, None, None, None)
-    }
-
-    #[test]
-    fn test_collection_post_roundtrip_valid() {
-        let post = make_collection_post(
-            "AI papers",
-            Some("Best stuff"),
-            Some(vec![
-                format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A"),
-                format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52B"),
-                format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52C"),
-            ]),
-        );
-        let id = post.create_id();
-        let blob = serde_json::to_vec(&post).unwrap();
-        let parsed = <PubkyAppPost as Validatable>::try_from(&blob, &id).unwrap();
-        assert_eq!(parsed.kind, PubkyAppPostKind::Collection);
-        assert!(parsed.attachments.is_none());
-        let envelope: PubkyAppCollectionContent = serde_json::from_str(&parsed.content).unwrap();
-        assert_eq!(envelope.items.len(), 3);
-    }
-
-    #[test]
-    fn test_collection_post_rejects_malformed_envelope() {
-        let post = PubkyAppPost::new(
-            "this is not JSON".to_string(),
-            PubkyAppPostKind::Collection,
-            None,
-            None,
-            None,
-        );
-        let id = post.create_id();
-        let result = post.validate(Some(&id));
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(
-            err.contains("JSON envelope"),
-            "expected JSON envelope error, got: {}",
-            err
-        );
-    }
-
-    #[test]
-    fn test_collection_post_rejects_empty_name() {
-        let post = make_collection_post("", None, None);
-        let id = post.create_id();
-        let result = post.validate(Some(&id));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("name"));
-    }
-
-    #[test]
-    fn test_collection_post_rejects_oversized_name() {
-        // 101 grapheme-ish chars; mix in emoji to confirm we count by unicode scalars, not bytes.
-        let oversized = "a".repeat(99) + "🚀🚀";
-        assert_eq!(oversized.chars().count(), 101);
-        let post = make_collection_post(&oversized, None, None);
-        let id = post.create_id();
-        let result = post.validate(Some(&id));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("name"));
-    }
-
-    #[test]
-    fn test_collection_post_accepts_max_name() {
-        let exactly_100 = "a".repeat(100);
-        assert_eq!(exactly_100.chars().count(), 100);
-        let post = make_collection_post(&exactly_100, None, None);
-        let id = post.create_id();
-        assert!(post.validate(Some(&id)).is_ok());
-    }
-
-    #[test]
-    fn test_collection_post_rejects_whitespace_only_name() {
-        // Whitespace-only names pass `min_length=1` purely by char count, so
-        // we reject them with a dedicated guard. Without that guard, a name
-        // of `"    "` would be a 4-char valid name with no meaningful content.
-        let post = make_collection_post("    ", None, None);
-        let id = post.create_id();
-        let err = post
-            .validate(Some(&id))
-            .expect_err("whitespace-only name must fail validation");
-        assert!(
-            err.contains("whitespace"),
-            "error should mention whitespace, got: {err}"
-        );
-    }
-
-    #[test]
-    fn test_collection_post_counts_whitespace_in_name_length() {
-        // Regression guard: the validator does NOT trim before counting. A
-        // 99-char name padded with one space on each side is 101 chars and
-        // must fail max=100. With the previous trim-then-count behavior this
-        // would have been 99 chars and passed.
-        let padded = format!(" {} ", "a".repeat(99));
-        assert_eq!(padded.chars().count(), 101);
-        let post = make_collection_post(&padded, None, None);
-        let id = post.create_id();
-        let err = post
-            .validate(Some(&id))
-            .expect_err("101-char padded name must fail max length");
-        assert!(
-            err.contains("1..=100"),
-            "error should report the length range, got: {err}"
-        );
-    }
-
-    #[test]
-    fn test_collection_post_accepts_cover_image_pubky_uri() {
-        let cover = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/files/0034A0X7NJ52A");
-        let post = make_collection_post_with_cover(Some(&cover));
-        let id = post.create_id();
-        assert!(post.validate(Some(&id)).is_ok());
-    }
-
-    #[test]
-    fn test_collection_post_accepts_cover_image_https() {
-        let post = make_collection_post_with_cover(Some("https://example.com/cover.png"));
-        let id = post.create_id();
-        assert!(post.validate(Some(&id)).is_ok());
-    }
-
-    #[test]
-    fn test_collection_post_rejects_cover_image_invalid_url() {
-        let post = make_collection_post_with_cover(Some("not a url"));
-        let id = post.create_id();
-        let err = post.validate(Some(&id)).unwrap_err();
-        assert!(
-            err.contains("cover_image must be a valid URL"),
-            "got: {err}"
-        );
-    }
-
-    #[test]
-    fn test_collection_post_rejects_cover_image_disallowed_protocol() {
-        let post = make_collection_post_with_cover(Some("ftp://example.com/cover.png"));
-        let id = post.create_id();
-        let err = post.validate(Some(&id)).unwrap_err();
-        assert!(
-            err.contains("cover_image must use one of the allowed protocols"),
-            "got: {err}"
-        );
-    }
-
-    #[test]
-    fn test_collection_post_rejects_cover_image_too_long() {
-        // post_attachment_url_max_length is 200; this URL exceeds it.
-        let too_long = format!("https://example.com/{}", "a".repeat(200));
-        let post = make_collection_post_with_cover(Some(&too_long));
-        let id = post.create_id();
-        let err = post.validate(Some(&id)).unwrap_err();
-        assert!(err.contains("cover_image URL exceeds"), "got: {err}");
-    }
-
-    #[test]
-    fn test_collection_post_rejects_oversized_description() {
-        let too_long = "a".repeat(501);
-        let post = make_collection_post("X", Some(&too_long), None);
-        let id = post.create_id();
-        let result = post.validate(Some(&id));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("description"));
-    }
-
-    #[test]
-    fn test_collection_post_accepts_empty_description() {
-        // Explicit empty-string description is valid (the field is optional and
-        // 0..=500 chars allowed).
-        let post = make_collection_post("X", Some(""), None);
-        let id = post.create_id();
-        assert!(post.validate(Some(&id)).is_ok());
-    }
-
-    #[test]
-    fn test_collection_post_accepts_max_description() {
-        let exactly_500 = "a".repeat(500);
-        assert_eq!(exactly_500.chars().count(), 500);
-        let post = make_collection_post("X", Some(&exactly_500), None);
-        let id = post.create_id();
-        assert!(post.validate(Some(&id)).is_ok());
-    }
-
-    #[test]
-    fn test_collection_post_rejects_missing_name() {
-        // Envelope JSON without a `name` field at all (description-only).
-        // Distinct from `test_collection_post_rejects_empty_name`, which sends
-        // an empty string; this sends a missing key entirely.
-        let envelope = r#"{ "description": "no name here" }"#.to_string();
-        let post = PubkyAppPost::new(envelope, PubkyAppPostKind::Collection, None, None, None);
-        let id = post.create_id();
-        let result = post.validate(Some(&id));
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(
-            err.contains("name") || err.to_lowercase().contains("missing"),
-            "expected name-required error, got: {err}"
-        );
-    }
-
-    #[test]
-    fn test_collection_post_rejects_parent() {
-        let post = PubkyAppPost::new(
-            collection_envelope_json("X", None, &[]),
-            PubkyAppPostKind::Collection,
-            Some("pubky://userA/pub/pubky.app/posts/0034A0X7NJ52A".to_string()),
-            None,
-            None,
-        );
-        let id = post.create_id();
-        let result = post.validate(Some(&id));
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(
-            err.contains("parent or embed"),
-            "expected parent-or-embed error, got: {}",
-            err
-        );
-    }
-
-    #[test]
-    fn test_collection_post_rejects_embed() {
-        let post = PubkyAppPost::new(
-            collection_envelope_json("X", None, &[]),
-            PubkyAppPostKind::Collection,
-            None,
-            Some(PubkyAppPostEmbed {
-                kind: PubkyAppPostKind::Short,
-                uri: "pubky://userA/pub/pubky.app/posts/0034A0X7NJ52A".to_string(),
-            }),
-            None,
-        );
-        let id = post.create_id();
-        let result = post.validate(Some(&id));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("parent or embed"));
-    }
-
-    #[test]
-    fn test_collection_post_accepts_100_items() {
-        let items: Vec<String> = (0..100)
-            .map(|i| format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/{:013}", i))
-            .collect();
-        let post = make_collection_post("Big list", None, Some(items));
-        let id = post.create_id();
-        assert!(post.validate(Some(&id)).is_ok());
-    }
-
-    #[test]
-    fn test_collection_post_rejects_101_items() {
-        let items: Vec<String> = (0..101)
-            .map(|i| format!("pubky://userA/pub/pubky.app/posts/{:013}", i))
-            .collect();
-        let post = make_collection_post("Too big", None, Some(items));
-        let id = post.create_id();
-        let result = post.validate(Some(&id));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("100 items"));
-    }
-
-    #[test]
-    fn test_postkind_collection_display_lowercase() {
-        assert_eq!(PubkyAppPostKind::Collection.to_string(), "collection");
-    }
-
-    #[test]
-    fn test_postkind_fromstr_collection() {
-        assert_eq!(
-            PubkyAppPostKind::from_str("collection").unwrap(),
-            PubkyAppPostKind::Collection
-        );
-    }
-
-    #[test]
-    fn test_collection_post_accepts_zero_items() {
-        // Curators may create a draft and add items later via edits.
-        let post = make_collection_post("Drafts", None, None);
-        let id = post.create_id();
-        assert!(post.validate(Some(&id)).is_ok());
-    }
-
-    #[test]
-    fn test_collection_envelope_tolerates_extra_fields() {
-        // Forward-compat: the envelope intentionally does NOT use deny_unknown_fields,
-        // so future minor versions can add fields without breaking older parsers.
-        // Use a deliberately-fictional canary field name so this test stays
-        // meaningful even after real fields land.
-        let envelope_json = r#"{"name":"X","_forward_compat_canary":"future-only"}"#;
-        let post = PubkyAppPost::new(
-            envelope_json.to_string(),
-            PubkyAppPostKind::Collection,
-            None,
-            None,
-            None,
-        );
-        let id = post.create_id();
-        assert!(
-            post.validate(Some(&id)).is_ok(),
-            "unknown envelope fields must be tolerated"
-        );
-    }
-
-    #[test]
-    fn test_collection_post_rejects_non_post_uri() {
-        let post =
-            make_collection_post("X", None, Some(vec!["ftp://example.com/file".to_string()]));
-        let id = post.create_id();
-        let result = post.validate(Some(&id));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Collection item"));
-    }
-
-    #[test]
-    fn test_collection_post_rejects_post_uri_with_invalid_post_id() {
-        // 13 chars but not valid Crockford: contains hyphens which aren't in the alphabet.
-        let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/abc-def-ghi-j");
-        let post = make_collection_post("X", None, Some(vec![uri]));
-        let id = post.create_id();
-        let err = post.validate(Some(&id)).unwrap_err();
-        assert!(err.contains("invalid post id"), "got: {err}");
-    }
-
-    #[test]
-    fn test_collection_post_rejects_post_uri_with_extra_path_segment() {
-        // Extra segment lands inside the post-id slot, failing the 13-char
-        // Crockford check.
-        let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A/extra");
-        let post = make_collection_post("X", None, Some(vec![uri]));
-        let id = post.create_id();
-        let err = post.validate(Some(&id)).unwrap_err();
-        assert!(err.contains("invalid post id"), "got: {err}");
-    }
-
-    #[test]
-    fn test_collection_post_rejects_post_uri_with_query_string() {
-        // Query string lands inside the post-id slot and fails the Crockford
-        // check (`?` and `=` aren't in the alphabet, and the length is wrong).
-        let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A?foo=bar");
-        let post = make_collection_post("X", None, Some(vec![uri]));
-        let id = post.create_id();
-        let err = post.validate(Some(&id)).unwrap_err();
-        assert!(err.contains("invalid post id"), "got: {err}");
-    }
-
-    #[test]
-    fn test_collection_post_rejects_post_uri_with_fragment() {
-        // Same as the query-string case: `#` and the fragment body land in the
-        // post-id slot and fail Crockford.
-        let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A#frag");
-        let post = make_collection_post("X", None, Some(vec![uri]));
-        let id = post.create_id();
-        let err = post.validate(Some(&id)).unwrap_err();
-        assert!(err.contains("invalid post id"), "got: {err}");
-    }
-
-    #[test]
-    fn test_collection_post_rejects_post_uri_with_trailing_slash() {
-        // A trailing slash bloats the post-id past 13 chars.
-        let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A/");
-        let post = make_collection_post("X", None, Some(vec![uri]));
-        let id = post.create_id();
-        let err = post.validate(Some(&id)).unwrap_err();
-        assert!(err.contains("invalid post id"), "got: {err}");
-    }
-
-    #[test]
-    fn test_collection_post_rejects_post_uri_with_empty_post_id() {
-        // Empty post-id segment fails the 13-char Crockford check.
-        let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/");
-        let post = make_collection_post("X", None, Some(vec![uri]));
-        let id = post.create_id();
-        let err = post.validate(Some(&id)).unwrap_err();
-        assert!(err.contains("invalid post id"), "got: {err}");
-    }
-
-    #[test]
-    fn test_collection_post_rejects_userinfo_padding_bypass() {
-        // `Url::parse(...).host_str()` strips userinfo, which would smuggle
-        // arbitrary bytes past a parse-and-recheck approach. The strict
-        // validator keeps the `JUNK@` in the host slot, failing the 52-char
-        // PubkyId length check.
-        let uri = format!(
-            "pubky://AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA@{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A"
-        );
-        let post = make_collection_post("X", None, Some(vec![uri]));
-        let id = post.create_id();
-        let err = post.validate(Some(&id)).unwrap_err();
-        assert!(err.contains("invalid pubky-id"), "got: {err}");
-    }
-
-    #[test]
-    fn test_collection_post_rejects_dot_dot_path_bypass() {
-        // `Url::parse(...)` collapses `..` segments before path inspection,
-        // which would smuggle a non-canonical raw path past a parse-and-recheck
-        // approach. The strict validator splits the raw string, so the extra
-        // segments land in the host slot and fail PubkyId.
-        let uri = format!("pubky://{TEST_PUBKY_ID}/aa/bb/../../pub/pubky.app/posts/0034A0X7NJ52A");
-        let post = make_collection_post("X", None, Some(vec![uri]));
-        let id = post.create_id();
-        let err = post.validate(Some(&id)).unwrap_err();
-        assert!(err.contains("invalid pubky-id"), "got: {err}");
-    }
-
-    #[test]
-    fn test_collection_post_accepts_canonical_max_length_uri() {
-        // Success-side boundary: the longest valid canonical post URI is
-        // pubky://<52-char-pubky-id>/pub/pubky.app/posts/<13-char-crockford>
-        // which is exactly 94 chars. Validator must accept this.
-        let uri = format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/0034A0X7NJ52A");
-        assert_eq!(uri.chars().count(), 94);
-        let post = make_collection_post("X", None, Some(vec![uri]));
-        let id = post.create_id();
-        assert!(post.validate(Some(&id)).is_ok());
-    }
-
-    #[test]
-    fn test_collection_post_rejects_non_empty_attachments() {
-        let post = PubkyAppPost::new(
-            collection_envelope_json("X", None, &[]),
-            PubkyAppPostKind::Collection,
-            None,
-            None,
-            Some(vec![
-                "pubky://userA/pub/pubky.app/posts/0034A0X7NJ52A".to_string()
-            ]),
-        );
-        let id = post.create_id();
-        let err = post
-            .validate(Some(&id))
-            .expect_err("Collection with non-empty post.attachments must be rejected");
-        assert!(
-            err.contains("post.attachments"),
-            "expected anti-misuse error, got: {err}"
-        );
-    }
-
-    #[test]
-    fn test_collection_post_accepts_missing_items_field() {
-        let envelope_json = r#"{"name":"X"}"#;
-        let post = PubkyAppPost::new(
-            envelope_json.to_string(),
-            PubkyAppPostKind::Collection,
-            None,
-            None,
-            None,
-        );
-        let id = post.create_id();
-        assert!(
-            post.validate(Some(&id)).is_ok(),
-            "missing `items` field must deserialize as empty list via serde(default)"
-        );
-    }
-
-    #[test]
-    fn test_collection_post_envelope_at_max_size() {
-        // 100 distinct valid pubky post URIs (max-count). Each exactly 94 chars.
-        let items: Vec<String> = (0..VALIDATION_LIMITS.collection_items_max_count)
-            .map(|i| format!("pubky://{TEST_PUBKY_ID}/pub/pubky.app/posts/{:013}", i))
-            .collect();
-        let max_name = "a".repeat(VALIDATION_LIMITS.collection_name_max_length);
-        let max_desc = "b".repeat(VALIDATION_LIMITS.collection_description_max_length);
-        let post = make_collection_post(&max_name, Some(&max_desc), Some(items));
-        assert!(
-            post.content.chars().count() < VALIDATION_LIMITS.collection_content_max_length,
-            "envelope at max field sizes must fit under collection_content_max_length"
-        );
-        let id = post.create_id();
-        assert!(post.validate(Some(&id)).is_ok());
     }
 
     #[test]
@@ -1964,56 +1237,5 @@ mod tests {
             let re = serde_json::to_value(&post.kind).unwrap();
             assert_eq!(re.as_str(), Some(s), "kind={} did not round-trip", s);
         }
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen_test::wasm_bindgen_test]
-    fn test_postkind_collection_wasm_getter() {
-        let post = PubkyAppPost {
-            content: collection_envelope_json("X", None, &[]),
-            kind: PubkyAppPostKind::Collection,
-            parent: None,
-            embed: None,
-            attachments: None,
-            lock: None,
-        };
-        assert_eq!(post.kind(), "Collection");
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    #[wasm_bindgen_test::wasm_bindgen_test]
-    fn test_create_collection_post_wasm_builder() {
-        // End-to-end via the JS-facing builder:
-        //   PubkySpecsBuilder.createCollectionPost(name, description?, attachments?)
-        // builds the {name, description} envelope internally, packages it
-        // into a kind=Collection PubkyAppPost, and returns a PostResult
-        // ready to ship to the homeserver. JS callers don't have to
-        // JSON-stringify the envelope themselves.
-        use crate::PubkySpecsBuilder;
-        let pubky_id = "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo".to_string();
-        let builder = PubkySpecsBuilder::new(pubky_id).expect("Failed to construct builder");
-        let result = builder
-            .create_collection_post(
-                "My favorites".to_string(),
-                Some("Best things".to_string()),
-                Some(vec![
-                    "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/posts/0034A0X7NJ52A".to_string(),
-                ]),
-                Some("https://example.com/cover.png".to_string()),
-            )
-            .expect("createCollectionPost should succeed");
-
-        let post = result.post();
-        assert_eq!(post.kind, PubkyAppPostKind::Collection);
-        assert!(post.attachments.is_none());
-        let envelope: PubkyAppCollectionContent = serde_json::from_str(&post.content)
-            .expect("Collection content must deserialize as PubkyAppCollectionContent");
-        assert_eq!(envelope.name, "My favorites");
-        assert_eq!(envelope.description.as_deref(), Some("Best things"));
-        assert_eq!(envelope.items.len(), 1);
-        assert_eq!(
-            envelope.cover_image.as_deref(),
-            Some("https://example.com/cover.png")
-        );
     }
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,6 +1,8 @@
 use crate::limits::VALIDATION_LIMITS;
 use crate::traits::{HasIdPath, HasPath, HashId, TimestampId, Validatable};
 use crate::*;
+use base64::{engine::general_purpose::STANDARD as LOCK_BASE64, Engine as _};
+use serde::Deserialize;
 use serde_wasm_bindgen::{from_value, to_value};
 use std::str::FromStr;
 use wasm_bindgen::prelude::*;
@@ -137,6 +139,7 @@ result_struct!(BookmarkResult, bookmark, PubkyAppBookmark);
 result_struct!(MuteResult, mute, PubkyAppMute);
 result_struct!(LastReadResult, last_read, PubkyAppLastRead);
 result_struct!(BlobResult, blob, PubkyAppBlob);
+result_struct!(LockResult, lock, PubkyAppLock);
 
 #[wasm_bindgen]
 impl PubkySpecsBuilder {
@@ -260,9 +263,8 @@ impl PubkySpecsBuilder {
         parent: Option<String>,
         embed: Option<PubkyAppPostEmbed>,
         attachments: Option<Vec<String>>,
-        lock: Option<String>,
     ) -> Result<PostResult, String> {
-        let post = PubkyAppPost::new_with_lock(content, kind, parent, embed, attachments, lock);
+        let post = PubkyAppPost::new(content, kind, parent, embed, attachments);
         let post_id = post.create_id();
         post.validate(Some(&post_id))?;
 
@@ -323,6 +325,44 @@ impl PubkySpecsBuilder {
             .map_err(|e| format!("Failed to serialize Collection envelope: {e}"))?;
 
         let post = PubkyAppPost::new(content, PubkyAppPostKind::Collection, None, None, None);
+        let post_id = post.create_id();
+        post.validate(Some(&post_id))?;
+
+        let path = PubkyAppPost::create_path(&post_id);
+        let meta = Meta::from_object(Some(&post_id), self.pubky_id.clone(), path);
+
+        Ok(PostResult { post, meta })
+    }
+
+    /// Creates a `kind = Lock` post — a locked post whose `content` is a
+    /// `PubkyAppLockContent` envelope advertising the public gate metadata
+    /// (`header`, `title`, `header_kind`) plus the `lock` Lock Server URL.
+    ///
+    /// Convenience wrapper around `createPost` that builds the
+    /// `PubkyAppLockContent` envelope and JSON-serializes it into `content`
+    /// internally, so JS callers don't have to stringify the envelope
+    /// themselves.
+    ///
+    /// `parent` and `embed` are not supported for Lock posts — the validator
+    /// rejects them — so this helper omits those arguments.
+    #[wasm_bindgen(js_name = createLockPost)]
+    pub fn create_lock_post(
+        &self,
+        header: String,
+        title: String,
+        header_kind: PubkyAppPostKind,
+        lock: String,
+    ) -> Result<PostResult, String> {
+        let envelope = PubkyAppLockContent {
+            header,
+            title,
+            header_kind,
+            lock,
+        };
+        let content = serde_json::to_string(&envelope)
+            .map_err(|e| format!("Failed to serialize Lock envelope: {e}"))?;
+
+        let post = PubkyAppPost::new(content, PubkyAppPostKind::Lock, None, None, None);
         let post_id = post.create_id();
         post.validate(Some(&post_id))?;
 
@@ -431,6 +471,62 @@ impl PubkySpecsBuilder {
 
         Ok(BlobResult { blob, meta })
     }
+
+    // -----------------------------------------------------------------------------
+    // 11. PubkyAppLock
+    // -----------------------------------------------------------------------------
+
+    /// Builds a `PubkyAppLock` document — the full, unlocked post plus its
+    /// attachment files inlined as base64 — content-addressed via `HashId` and
+    /// served by the Lock Server.
+    ///
+    /// `files` is a JS array of `{ name, content_type, data }` objects, where
+    /// `data` is a `Uint8Array` of the raw file bytes. `size` and
+    /// `content_base64` are derived automatically from `data`.
+    ///
+    /// The lock's homeserver path is owned by the Locks app/SDK, so the returned
+    /// `meta` carries only the content-hash `id` (its `path`/`url` are empty).
+    #[wasm_bindgen(js_name = createLockBundle)]
+    pub fn create_lock_bundle(
+        &self,
+        post: PubkyAppPost,
+        files: JsValue,
+    ) -> Result<LockResult, String> {
+        let raw_files: Vec<LockFileInput> = if files.is_null() || files.is_undefined() {
+            Vec::new()
+        } else {
+            from_value(files).map_err(|e| e.to_string())?
+        };
+
+        let files_vec: Vec<PubkyAppLockFile> = raw_files
+            .into_iter()
+            .map(|f| {
+                PubkyAppLockFile::new(
+                    f.name,
+                    f.content_type,
+                    f.data.len(),
+                    LOCK_BASE64.encode(&f.data),
+                )
+            })
+            .collect();
+
+        let lock = PubkyAppLock::new(post, files_vec);
+        let lock_id = lock.create_id();
+        lock.validate(Some(&lock_id))?;
+
+        let meta = Meta::from_object(Some(&lock_id), self.pubky_id.clone(), String::new());
+
+        Ok(LockResult { lock, meta })
+    }
+}
+
+/// Raw file input for [`PubkySpecsBuilder::create_lock_bundle`]: the display
+/// `name`, MIME `content_type`, and raw `data` bytes (a JS `Uint8Array`).
+#[derive(Deserialize)]
+struct LockFileInput {
+    name: String,
+    content_type: String,
+    data: Vec<u8>,
 }
 
 /// This object represents the result of parsing a Pubky URI. It contains:


### PR DESCRIPTION
## Summary

- Adds `PubkyAppLock` and `PubkyAppLockFile` for locked payload bundles with base64-inlined files, content-hash IDs, strict unknown-field rejection, and resource-size validation.
- Introduces `kind = lock` public post envelopes via `PubkyAppLockContent`, including teaser metadata validation and lock-server URL checks.
- Updates lock bundle validation so packed `files` act as reconstructed attachments for inner post validation, supporting attachment-only image/video/file payloads while keeping stored `post.attachments` empty.
- Refactors post content envelopes into `models/post/content/*`, exports the new types, updates wasm builders, limits, and README docs.

## Test Plan

- [x] `cargo test`
- [x] `cargo check --target wasm32-unknown-unknown`