### PR TITLE
feat: add PubkyAppLockedPost private bundle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-app-specs"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky-app-specs"
-version = "0.5.3"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.89"
 description = "Pubky.app Data Model Specifications"

--- a/README.md
+++ b/README.md
@@ -180,6 +180,31 @@ Pubky.app models are designed for decentralized content sharing. The system uses
 
 Posts are unlocked by default. A post may include `lock` to advertise that the full post is protected behind a lock server. When present, `lock` must be a valid `pubky://` URL with a host, up to 200 characters. Consumers that receive JSON without `lock`, or JSON with `"lock": null`, must treat the post as a regular unlocked post.
 
+Locking has three layers, kept deliberately separate:
+
+1. **The teaser post**: its `kind` (short/long/collection/video/…) stays the real kind so the post indexes and renders normally (a locked article still shows in article streams, a locked collection on the collections page). Its `lock` field is the `pubky://` URL of layer 2.
+2. **The public lock-metadata file**: author-signed public gate metadata (routing, pricing, and the content-hash ID committing to the private bundle). Its shape is owned by the lock-server model and is **out of scope for this crate**.
+3. **The private bundle** (`PubkyAppLockedPost`, below): the gated payload the lock server serves after verifying access.
+
+The `lock` field points at layer 2, not the bundle. The bundle's content-hash commitment lives in the author-signed layer 2, which is what lets a client trust an untrusted lock server.
+
+**`PubkyAppLockedPost` (private bundle):**
+
+The full unlocked post plus all of its attachment files, packed into a single content-addressed **binary** blob stored at `/priv/pubky.app/posts/:id`. Files are raw bytes (no base64), so there is no encoding overhead. Container layout:
+
+```text
+magic "PALP" (4) | version (1) | manifest_len: u32 LE (4) | manifest JSON | file bytes…
+```
+
+The manifest is `{ post, files: [{ name, content_type, size }] }` (`size` is a `u64`); the file bytes follow concatenated in order and are sliced back out by `size`. This crate is the canonical writer; the golden-vector test pins the exact bytes and ID.
+
+- **Identity:** the ID is Crockford-Base32 of the first half of `blake3(bytes)` over the exact stored bytes.
+- **Integrity:** the lock server is untrusted. After fetching, a client MUST recompute the ID over the received bytes, check it against the ID committed in the author-signed layer-2 metadata, and run `validate()` (packed post, file count/names/MIME types, total size) before presenting anything.
+- **Invariants:** the packed post must not set its own `attachments` (the bundle's `files` are the source of truth) and must not itself carry a `lock`. File count and total size reuse the attachment and blob limits.
+- **Unlock:** reconstructing the post's `attachments` from `files` (writing them out and mapping to URIs) is the client/SDK's responsibility, out of scope for this crate.
+
+Build it with `createLockedPost(post, files)` where `files` is an array of `{ name, content_type, data }` (`data` a `Uint8Array`); read it back with `PubkyAppLockedPost.fromBytes(bytes)` and upload bytes via `result.lockedPost.toBytes()`.
+
 **Note on `kind = collection`:**
 
 Collection posts use a typed JSON envelope as their `content`. The envelope shape is:

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Pubky.app models are designed for decentralized content sharing. The system uses
 | `parent`      | String   | URI of the parent post (if a reply). | Optional. Must be a valid URI if present.                                  |
 | `embed`       | Object   | Reposted content (type + URI).       | Optional. URI must be valid if present.                                    |
 | `attachments` | Array    | List of attachment URIs.             | Optional. Each must be a valid URI.                                        |
-| `lock`        | String   | Lock server URL for protected posts. | Optional. If present, must be a valid `pubky://`, `http://`, or `https://` URL up to 200 characters. Missing or `null` means unlocked. |
+| `lock`        | String   | Lock server URL for protected posts. | Optional. If present, must be a valid `pubky://` URL with a host, up to 200 characters. Missing or `null` means unlocked. |
 
 **Post Kinds:**
 
@@ -172,13 +172,13 @@ Pubky.app models are designed for decentralized content sharing. The system uses
     "uri": "pubky://user_id/pub/pubky.app/posts/0000000000000"
   },
   "attachments": ["pubky://user_id/pub/pubky.app/files/0000000000000"],
-  "lock": "https://locks.example.com/session/0000000000000"
+  "lock": "pubky://lock_server_id/pub/locks/0000000000000"
 }
 ```
 
 **Locking:**
 
-Posts are unlocked by default. A post may include `lock` to advertise that the full post is protected behind a lock server. When present, `lock` must be a valid `pubky://`, `http://`, or `https://` URL up to 200 characters, the same limits applied to attachments. Consumers that receive JSON without `lock`, or JSON with `"lock": null`, must treat the post as a regular unlocked post.
+Posts are unlocked by default. A post may include `lock` to advertise that the full post is protected behind a lock server. When present, `lock` must be a valid `pubky://` URL with a host, up to 200 characters. Consumers that receive JSON without `lock`, or JSON with `"lock": null`, must treat the post as a regular unlocked post.
 
 **Note on `kind = collection`:**
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pubky.app Data Model Specification
 
-_Version 0.5.3_
+_Version 0.6.0_
 
 > ⚠️ **Warning: Rapid Development Phase**  
 > This specification is in an **early development phase** and is evolving quickly. Expect frequent changes and updates as the system matures. Consider this a **v0 draft**.
@@ -148,6 +148,7 @@ Pubky.app models are designed for decentralized content sharing. The system uses
 | `parent`      | String   | URI of the parent post (if a reply). | Optional. Must be a valid URI if present.                                  |
 | `embed`       | Object   | Reposted content (type + URI).       | Optional. URI must be valid if present.                                    |
 | `attachments` | Array    | List of attachment URIs.             | Optional. Each must be a valid URI.                                        |
+| `lock`        | String   | Lock server URL for protected posts. | Optional. Must be a valid URL if present. Missing or `null` means unlocked. |
 
 **Post Kinds:**
 
@@ -170,9 +171,14 @@ Pubky.app models are designed for decentralized content sharing. The system uses
     "kind": "short",
     "uri": "pubky://user_id/pub/pubky.app/posts/0000000000000"
   },
-  "attachments": ["pubky://user_id/pub/pubky.app/files/0000000000000"]
+  "attachments": ["pubky://user_id/pub/pubky.app/files/0000000000000"],
+  "lock": "https://locks.example.com/session/0000000000000"
 }
 ```
+
+**Locking:**
+
+Posts are unlocked by default. A post may include `lock` to advertise that the full post is protected behind a lock server. Consumers that receive JSON without `lock`, or JSON with `"lock": null`, must treat the post as a regular unlocked post.
 
 **Note on `kind = collection`:**
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Pubky.app models are designed for decentralized content sharing. The system uses
 | `parent`      | String   | URI of the parent post (if a reply). | Optional. Must be a valid URI if present.                                  |
 | `embed`       | Object   | Reposted content (type + URI).       | Optional. URI must be valid if present.                                    |
 | `attachments` | Array    | List of attachment URIs.             | Optional. Each must be a valid URI.                                        |
-| `lock`        | String   | Lock server URL for protected posts. | Optional. Must be a valid URL if present. Missing or `null` means unlocked. |
+| `lock`        | String   | Lock server URL for protected posts. | Optional. If present, must be a valid `pubky://`, `http://`, or `https://` URL up to 200 characters. Missing or `null` means unlocked. |
 
 **Post Kinds:**
 
@@ -178,7 +178,7 @@ Pubky.app models are designed for decentralized content sharing. The system uses
 
 **Locking:**
 
-Posts are unlocked by default. A post may include `lock` to advertise that the full post is protected behind a lock server. Consumers that receive JSON without `lock`, or JSON with `"lock": null`, must treat the post as a regular unlocked post.
+Posts are unlocked by default. A post may include `lock` to advertise that the full post is protected behind a lock server. When present, `lock` must be a valid `pubky://`, `http://`, or `https://` URL up to 200 characters, the same limits applied to attachments. Consumers that receive JSON without `lock`, or JSON with `"lock": null`, must treat the post as a regular unlocked post.
 
 **Note on `kind = collection`:**
 

--- a/pkg/package.json
+++ b/pkg/package.json
@@ -55,5 +55,5 @@
   "sideEffects": false,
   "type": "module",
   "types": "pubky_app_specs.d.ts",
-  "version": "0.5.3"
+  "version": "0.6.0"
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub use models::feed::{PubkyAppFeed, PubkyAppFeedLayout, PubkyAppFeedReach, Pubk
 pub use models::file::{PubkyAppFile, VALID_MIME_TYPES};
 pub use models::follow::PubkyAppFollow;
 pub use models::last_read::PubkyAppLastRead;
+pub use models::locked_post::{LockedFile, PubkyAppLockedPost};
 pub use models::mute::PubkyAppMute;
 pub use models::post::{
     PubkyAppCollectionContent, PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind,

--- a/src/models/locked_post.rs
+++ b/src/models/locked_post.rs
@@ -1,0 +1,510 @@
+//! `PubkyAppLockedPost`: the private single-blob bundle backing a locked post.
+//! Holds the full unlocked [`PubkyAppPost`] plus its attachment files, released
+//! by the Lock Server after it verifies access.
+//!
+//! Wire format (raw bytes, no base64, so no ~33% inflation and no full decode to
+//! read just the manifest):
+//!
+//! ```text
+//! magic "PALP" (4) | version (1) | manifest_len: u32 LE (4) | manifest JSON | file bytes…
+//! ```
+//!
+//! manifest = `{ post, files: [{ name, content_type, size }] }`; file bytes
+//! follow concatenated and are sliced back by `size`. The manifest is the index.
+//!
+//! Content-addressed: ID = Crockford-Base32 of the first half of the blake3 of
+//! the exact stored bytes. The Lock Server is untrusted, so a client MUST re-hash
+//! the fetched bytes against the `lock` URL's ID and `validate()` before showing
+//! anything.
+//!
+//! ponytail: custom container, not zip. zip's timestamps/ordering/compression
+//! are non-deterministic and break content-addressing, and the dep adds wasm
+//! weight for ~0 gain on already-compressed media. Switch to zip-as-blob only if
+//! an external reader (e.g. checkstep) must parse the payload without this spec.
+
+use crate::limits::VALIDATION_LIMITS;
+use crate::traits::Validatable;
+use crate::{PubkyAppPost, APP_PATH, VALID_MIME_TYPES};
+use base32::{encode, Alphabet};
+use blake3::Hasher;
+use mime::Mime;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+const MAGIC: &[u8; 4] = b"PALP";
+const FORMAT_VERSION: u8 = 1;
+const HEADER_LEN: usize = 4 + 1 + 4; // magic + version + manifest_len
+
+/// One attachment file packed in a [`PubkyAppLockedPost`], as raw bytes.
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[derive(Clone, Debug)]
+pub struct LockedFile {
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    pub name: String,
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    pub content_type: String,
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    pub bytes: Vec<u8>,
+}
+
+impl LockedFile {
+    pub fn new(name: String, content_type: String, bytes: Vec<u8>) -> Self {
+        Self {
+            name,
+            content_type,
+            bytes,
+        }
+        .sanitize()
+    }
+
+    fn sanitize(self) -> Self {
+        Self {
+            name: self.name.trim().to_string(),
+            content_type: self.content_type.trim().to_string(),
+            bytes: self.bytes,
+        }
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        let name_len = self.name.chars().count();
+        if !(VALIDATION_LIMITS.file_name_min_length..=VALIDATION_LIMITS.file_name_max_length)
+            .contains(&name_len)
+        {
+            return Err("file name length is invalid".into());
+        }
+        match Mime::from_str(&self.content_type) {
+            Ok(mime) if VALID_MIME_TYPES.contains(&mime.essence_str()) => {}
+            _ => return Err("invalid content type".into()),
+        }
+        if self.bytes.is_empty() {
+            return Err("file cannot be empty".into());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+impl LockedFile {
+    #[wasm_bindgen(getter)]
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+    #[wasm_bindgen(getter)]
+    pub fn content_type(&self) -> String {
+        self.content_type.clone()
+    }
+    #[wasm_bindgen(getter)]
+    pub fn bytes(&self) -> js_sys::Uint8Array {
+        js_sys::Uint8Array::from(&self.bytes[..])
+    }
+}
+
+/// Manifest portion of the container (everything except the raw file bytes).
+#[derive(Serialize, Deserialize)]
+struct Manifest {
+    post: PubkyAppPost,
+    files: Vec<FileEntry>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct FileEntry {
+    name: String,
+    content_type: String,
+    size: u64,
+}
+
+/// The private, single-blob bundle backing a locked post. See the module docs.
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[derive(Clone, Debug)]
+pub struct PubkyAppLockedPost {
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    pub post: PubkyAppPost,
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    pub files: Vec<LockedFile>,
+}
+
+impl PubkyAppLockedPost {
+    pub fn new(post: PubkyAppPost, files: Vec<LockedFile>) -> Self {
+        Self {
+            post: post.sanitize(),
+            files: files.into_iter().map(LockedFile::sanitize).collect(),
+        }
+    }
+
+    /// Homeserver path for the bundle: `/priv/pubky.app/posts/:id`.
+    pub fn create_path(id: &str) -> String {
+        ["/priv/", APP_PATH, "posts/", id].concat()
+    }
+
+    /// Canonical bytes: what gets stored on the homeserver and hashed for the ID.
+    pub fn to_bytes(&self) -> Result<Vec<u8>, String> {
+        let manifest = Manifest {
+            post: self.post.clone(),
+            files: self
+                .files
+                .iter()
+                .map(|f| FileEntry {
+                    name: f.name.clone(),
+                    content_type: f.content_type.clone(),
+                    size: f.bytes.len() as u64,
+                })
+                .collect(),
+        };
+        let manifest_json = serde_json::to_vec(&manifest)
+            .map_err(|e| format!("Failed to serialize lock manifest: {e}"))?;
+        let manifest_len = u32::try_from(manifest_json.len())
+            .map_err(|_| "Lock manifest exceeds 4 GiB".to_string())?;
+        let heap_len: usize = self.files.iter().map(|f| f.bytes.len()).sum();
+
+        let mut out = Vec::with_capacity(HEADER_LEN + manifest_json.len() + heap_len);
+        out.extend_from_slice(MAGIC);
+        out.push(FORMAT_VERSION);
+        out.extend_from_slice(&manifest_len.to_le_bytes());
+        out.extend_from_slice(&manifest_json);
+        for f in &self.files {
+            out.extend_from_slice(&f.bytes);
+        }
+        Ok(out)
+    }
+
+    /// Does NOT sanitize/validate: bytes are preserved exactly so the caller can
+    /// verify the content hash. Run [`Self::validate`] afterwards.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, String> {
+        // Fail fast on untrusted server bytes before copying any file slices.
+        if bytes.len() > VALIDATION_LIMITS.max_blob_size_bytes {
+            return Err(format!(
+                "Invalid lock bundle: size ({} bytes) exceeds maximum of {} bytes",
+                bytes.len(),
+                VALIDATION_LIMITS.max_blob_size_bytes
+            ));
+        }
+        if bytes.len() < HEADER_LEN {
+            return Err("Invalid lock bundle: truncated header".into());
+        }
+        if &bytes[0..4] != MAGIC {
+            return Err("Invalid lock bundle: bad magic".into());
+        }
+        if bytes[4] != FORMAT_VERSION {
+            return Err(format!(
+                "Invalid lock bundle: unsupported version {}",
+                bytes[4]
+            ));
+        }
+        let manifest_len = u32::from_le_bytes([bytes[5], bytes[6], bytes[7], bytes[8]]) as usize;
+        let heap_start = HEADER_LEN
+            .checked_add(manifest_len)
+            .ok_or("Invalid lock bundle: manifest length overflow")?;
+        if bytes.len() < heap_start {
+            return Err("Invalid lock bundle: manifest truncated".into());
+        }
+        let manifest: Manifest = serde_json::from_slice(&bytes[HEADER_LEN..heap_start])
+            .map_err(|e| format!("Invalid lock bundle manifest: {e}"))?;
+
+        let mut files = Vec::with_capacity(manifest.files.len());
+        let mut cursor = heap_start;
+        for entry in &manifest.files {
+            let size = usize::try_from(entry.size)
+                .map_err(|_| "Invalid lock bundle: file size overflow")?;
+            let end = cursor
+                .checked_add(size)
+                .ok_or("Invalid lock bundle: file size overflow")?;
+            if end > bytes.len() {
+                return Err("Invalid lock bundle: file data truncated".into());
+            }
+            files.push(LockedFile {
+                name: entry.name.clone(),
+                content_type: entry.content_type.clone(),
+                bytes: bytes[cursor..end].to_vec(),
+            });
+            cursor = end;
+        }
+        if cursor != bytes.len() {
+            return Err("Invalid lock bundle: trailing bytes after file data".into());
+        }
+        Ok(Self {
+            post: manifest.post,
+            files,
+        })
+    }
+
+    /// Content-addressed ID over the canonical bytes.
+    pub fn create_id(&self) -> Result<String, String> {
+        Ok(id_from_bytes(&self.to_bytes()?))
+    }
+
+    /// When `id` is supplied, verifies it equals the content hash.
+    pub fn validate(&self, id: Option<&str>) -> Result<(), String> {
+        let bytes = self.to_bytes()?;
+        if let Some(id) = id {
+            let expected = id_from_bytes(&bytes);
+            if expected != id {
+                return Err(format!("Invalid ID: expected {expected}, found {id}"));
+            }
+        }
+
+        // `files` is the single source of truth for the post's attachments, so
+        // the packed post must not carry its own; nor may it itself be locked.
+        if matches!(&self.post.attachments, Some(a) if !a.is_empty()) {
+            return Err(
+                "Validation Error: Locked post must not set attachments; packed files are listed in `files`"
+                    .into(),
+            );
+        }
+        if self.post.lock.is_some() {
+            return Err(
+                "Validation Error: Locked post payload must not set a `lock` (nested locks are not allowed)"
+                    .into(),
+            );
+        }
+        if self.files.len() > VALIDATION_LIMITS.post_attachments_max_count {
+            return Err(format!(
+                "Validation Error: Locked post cannot contain more than {} files",
+                VALIDATION_LIMITS.post_attachments_max_count
+            ));
+        }
+        for (index, file) in self.files.iter().enumerate() {
+            file.validate()
+                .map_err(|e| format!("Validation Error: Locked post file at index {index}: {e}"))?;
+        }
+
+        // Packed files stand in for the post's not-yet-written attachments.
+        self.post
+            .validate_in_lock_bundle(!self.files.is_empty())
+            .map_err(|e| format!("Validation Error: Locked post payload is invalid: {e}"))?;
+
+        if bytes.len() > VALIDATION_LIMITS.max_blob_size_bytes {
+            return Err(format!(
+                "Validation Error: Locked post bundle size ({} bytes) exceeds maximum of {} bytes",
+                bytes.len(),
+                VALIDATION_LIMITS.max_blob_size_bytes
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Crockford-Base32 of the first half of the blake3 hash of `bytes`.
+fn id_from_bytes(bytes: &[u8]) -> String {
+    let mut hasher = Hasher::new();
+    hasher.update(bytes);
+    let hash = hasher.finalize();
+    let half = &hash.as_bytes()[..hash.as_bytes().len() / 2];
+    encode(Alphabet::Crockford, half)
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+impl PubkyAppLockedPost {
+    #[wasm_bindgen(getter)]
+    pub fn post(&self) -> PubkyAppPost {
+        self.post.clone()
+    }
+    #[wasm_bindgen(getter)]
+    pub fn files(&self) -> Vec<LockedFile> {
+        self.files.clone()
+    }
+    #[wasm_bindgen(js_name = toBytes)]
+    pub fn to_bytes_js(&self) -> Result<js_sys::Uint8Array, String> {
+        Ok(js_sys::Uint8Array::from(&self.to_bytes()?[..]))
+    }
+    #[wasm_bindgen(js_name = fromBytes)]
+    pub fn from_bytes_js(bytes: &[u8]) -> Result<PubkyAppLockedPost, String> {
+        Self::from_bytes(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PubkyAppPostKind;
+
+    fn lf(name: &str, ct: &str, bytes: &[u8]) -> LockedFile {
+        LockedFile::new(name.to_string(), ct.to_string(), bytes.to_vec())
+    }
+
+    fn sample() -> PubkyAppLockedPost {
+        let post = PubkyAppPost::new(
+            "The full unlocked article body.".to_string(),
+            PubkyAppPostKind::Long,
+            None,
+            None,
+            None,
+        );
+        PubkyAppLockedPost::new(
+            post,
+            vec![
+                lf("cover.png", "image/png", &[7u8; 2048]),
+                lf("episode.mp3", "audio/mpeg", &[3u8; 4096]),
+            ],
+        )
+    }
+
+    #[test]
+    fn test_roundtrip_bytes_preserves_content() {
+        let bundle = sample();
+        let bytes = bundle.to_bytes().unwrap();
+        let parsed = PubkyAppLockedPost::from_bytes(&bytes).unwrap();
+        assert_eq!(parsed.post.content, "The full unlocked article body.");
+        assert_eq!(parsed.files.len(), 2);
+        assert_eq!(parsed.files[0].name, "cover.png");
+        assert_eq!(parsed.files[0].bytes, vec![7u8; 2048]);
+        assert_eq!(parsed.files[1].bytes, vec![3u8; 4096]);
+        // Byte-exact round-trip is what makes the content hash stable on read.
+        assert_eq!(parsed.to_bytes().unwrap(), bytes);
+    }
+
+    #[test]
+    fn test_id_is_content_addressed_and_validates() {
+        let bundle = sample();
+        let id = bundle.create_id().unwrap();
+        assert!(bundle.validate(Some(&id)).is_ok());
+        // Same content -> same id; different content -> different id.
+        assert_eq!(id, sample().create_id().unwrap());
+        let other =
+            PubkyAppLockedPost::new(sample().post, vec![lf("a.png", "image/png", &[1u8; 8])]);
+        assert_ne!(id, other.create_id().unwrap());
+    }
+
+    #[test]
+    fn test_validate_rejects_tampered_id() {
+        let bundle = sample();
+        let err = bundle.validate(Some("0000000000000")).unwrap_err();
+        assert!(err.contains("Invalid ID"), "got: {err}");
+    }
+
+    #[test]
+    fn test_no_base64_overhead_payload_stored_raw() {
+        // The raw file bytes appear verbatim in the container (no base64).
+        let bundle = PubkyAppLockedPost::new(
+            PubkyAppPost::new("hi".to_string(), PubkyAppPostKind::Short, None, None, None),
+            vec![lf("a.bin", "application/octet-stream", b"RAWBYTES")],
+        );
+        let bytes = bundle.to_bytes().unwrap();
+        assert!(
+            bytes.windows(8).any(|w| w == b"RAWBYTES"),
+            "raw file bytes must be embedded verbatim, not base64-encoded"
+        );
+    }
+
+    #[test]
+    fn test_accepts_attachment_only_media_without_placeholder_hack() {
+        // Empty-content image post is valid in a bundle because the packed file
+        // stands in for the attachment (no synthesized placeholder URLs).
+        for kind in [
+            PubkyAppPostKind::Image,
+            PubkyAppPostKind::Video,
+            PubkyAppPostKind::File,
+        ] {
+            let post = PubkyAppPost::new("".to_string(), kind, None, None, None);
+            let bundle = PubkyAppLockedPost::new(
+                post,
+                vec![lf("p.bin", "application/octet-stream", &[0u8; 16])],
+            );
+            let id = bundle.create_id().unwrap();
+            assert!(bundle.validate(Some(&id)).is_ok());
+        }
+    }
+
+    #[test]
+    fn test_rejects_post_with_attachments() {
+        let post = PubkyAppPost::new(
+            "Body".to_string(),
+            PubkyAppPostKind::Long,
+            None,
+            None,
+            Some(vec![
+                "pubky://userA/pub/pubky.app/files/0034A0X7NJ52A".to_string()
+            ]),
+        );
+        let bundle = PubkyAppLockedPost::new(post, vec![lf("a.png", "image/png", &[0u8; 16])]);
+        let err = bundle
+            .validate(Some(&bundle.create_id().unwrap()))
+            .unwrap_err();
+        assert!(err.contains("must not set attachments"), "got: {err}");
+    }
+
+    #[test]
+    fn test_rejects_nested_lock() {
+        let mut post =
+            PubkyAppPost::new("Body".to_string(), PubkyAppPostKind::Long, None, None, None);
+        post.lock = Some("pubky://server/pub/locks/x".to_string());
+        let bundle = PubkyAppLockedPost::new(post, vec![]);
+        let err = bundle
+            .validate(Some(&bundle.create_id().unwrap()))
+            .unwrap_err();
+        assert!(err.contains("nested locks"), "got: {err}");
+    }
+
+    #[test]
+    fn test_rejects_empty_payload() {
+        // No content, no files -> the inner post has nothing meaningful.
+        let bundle = PubkyAppLockedPost::new(
+            PubkyAppPost::new("".to_string(), PubkyAppPostKind::Short, None, None, None),
+            vec![],
+        );
+        let err = bundle
+            .validate(Some(&bundle.create_id().unwrap()))
+            .unwrap_err();
+        assert!(err.contains("payload is invalid"), "got: {err}");
+    }
+
+    #[test]
+    fn test_rejects_too_many_files() {
+        let files: Vec<LockedFile> = (0..VALIDATION_LIMITS.post_attachments_max_count + 1)
+            .map(|i| lf(&format!("f{i}.bin"), "application/octet-stream", &[0u8; 4]))
+            .collect();
+        let post = PubkyAppPost::new(
+            "body".to_string(),
+            PubkyAppPostKind::Short,
+            None,
+            None,
+            None,
+        );
+        let bundle = PubkyAppLockedPost::new(post, files);
+        let err = bundle
+            .validate(Some(&bundle.create_id().unwrap()))
+            .unwrap_err();
+        assert!(err.contains("more than"), "got: {err}");
+    }
+
+    #[test]
+    fn test_from_bytes_rejects_truncation_and_bad_magic() {
+        let bytes = sample().to_bytes().unwrap();
+        assert!(PubkyAppLockedPost::from_bytes(&bytes[..bytes.len() - 1]).is_err());
+        let mut bad = bytes.clone();
+        bad[0] = b'X';
+        assert!(PubkyAppLockedPost::from_bytes(&bad).is_err());
+    }
+
+    // Golden vector: fixed inputs pin the exact wire bytes and ID, so any change
+    // to the manifest serialization that would break cross-version interop fails
+    // here loudly.
+    #[test]
+    fn test_golden_vector() {
+        let post = PubkyAppPost::new(
+            "hello".to_string(),
+            PubkyAppPostKind::Short,
+            None,
+            None,
+            None,
+        );
+        let bundle = PubkyAppLockedPost::new(post, vec![lf("a.txt", "text/plain", b"hi")]);
+        let bytes = bundle.to_bytes().unwrap();
+
+        assert_eq!(&bytes[0..4], MAGIC);
+        assert_eq!(bytes[4], FORMAT_VERSION);
+        let manifest_len = u32::from_le_bytes([bytes[5], bytes[6], bytes[7], bytes[8]]) as usize;
+        let manifest = std::str::from_utf8(&bytes[HEADER_LEN..HEADER_LEN + manifest_len]).unwrap();
+        assert_eq!(
+            manifest,
+            r#"{"post":{"content":"hello","kind":"short","parent":null,"embed":null,"attachments":null},"files":[{"name":"a.txt","content_type":"text/plain","size":2}]}"#
+        );
+        // Heap is the raw file bytes, verbatim.
+        assert_eq!(&bytes[HEADER_LEN + manifest_len..], b"hi");
+        assert_eq!(bundle.create_id().unwrap(), "11PMFD92YZWX5QCTP1T9FF6YH4");
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -6,6 +6,7 @@ pub mod feed;
 pub mod file;
 pub mod follow;
 pub mod last_read;
+pub mod locked_post;
 pub mod mute;
 pub mod post;
 pub mod tag;

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -325,13 +325,35 @@ impl Validatable for PubkyAppPost {
     }
 
     fn validate(&self, id: Option<&str>) -> Result<(), String> {
+        self.validate_with_attachments_source(id, false)
+    }
+}
+
+impl PubkyAppPost {
+    /// Validates the guarded payload of a [`crate::PubkyAppLockedPost`]. With
+    /// `has_bundle_files`, the bundle's files (not yet written, so no URIs)
+    /// satisfy the "must have content/embed/attachments" rule.
+    pub fn validate_in_lock_bundle(&self, has_bundle_files: bool) -> Result<(), String> {
+        self.validate_with_attachments_source(None, has_bundle_files)
+    }
+
+    fn validate_with_attachments_source(
+        &self,
+        id: Option<&str>,
+        has_bundle_files: bool,
+    ) -> Result<(), String> {
         // Validate the post ID
         if let Some(id) = id {
             self.validate_id(id)?;
         }
 
-        // Validate that post has meaningful content (at least one of: content, embed, or attachments)
-        if self.content.trim().is_empty() && self.embed.is_none() && self.attachments.is_none() {
+        // Validate that post has meaningful content (at least one of: content,
+        // embed, attachments, or bundle-packed files).
+        if self.content.trim().is_empty()
+            && self.embed.is_none()
+            && self.attachments.is_none()
+            && !has_bundle_files
+        {
             return Err(
                 "Validation Error: Post must have content, an embed, or attachments".into(),
             );

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -359,6 +359,37 @@ impl Validatable for PubkyAppPost {
             }
         }
 
+        // Validate lock URL if present, for every kind (including collections,
+        // which return early below). Missing or null locks keep posts unlocked.
+        // Reuses the attachment URL limit and protocol allowlist for consistency.
+        if let Some(ref lock_url) = self.lock {
+            if lock_url.trim().is_empty() {
+                return Err("Validation Error: Lock URL cannot be empty".into());
+            }
+            if lock_url.chars().count() > VALIDATION_LIMITS.post_attachment_url_max_length {
+                return Err(format!(
+                    "Validation Error: Lock URL exceeds maximum length (max: {} characters)",
+                    VALIDATION_LIMITS.post_attachment_url_max_length
+                ));
+            }
+            let parsed = Url::parse(lock_url)
+                .map_err(|_| format!("Validation Error: Invalid lock URL format: {lock_url}"))?;
+            if !VALIDATION_LIMITS
+                .post_allowed_attachment_protocols
+                .contains(&parsed.scheme())
+            {
+                let allowed = VALIDATION_LIMITS
+                    .post_allowed_attachment_protocols
+                    .iter()
+                    .map(|p| format!("{p}://"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                return Err(format!(
+                    "Validation Error: Lock URL must use one of the allowed protocols: {allowed}"
+                ));
+            }
+        }
+
         if matches!(self.kind, PubkyAppPostKind::Collection) {
             if self.parent.is_some() || self.embed.is_some() {
                 return Err(
@@ -469,12 +500,6 @@ impl Validatable for PubkyAppPost {
                 "Validation Error: Post content exceeds maximum length for {} kind (max: {} characters)",
                 kind_name, max_length
             ));
-        }
-
-        // Validate lock URL format if present. Missing or null locks keep posts unlocked.
-        if let Some(ref lock_url) = self.lock {
-            Url::parse(lock_url)
-                .map_err(|_| format!("Validation Error: Invalid lock URL format: {lock_url}"))?;
         }
 
         // Validate parent URI format if present
@@ -861,6 +886,70 @@ mod tests {
         assert!(post.lock.is_none());
         let id = post.create_id();
         assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_collection_post_rejects_invalid_lock_url() {
+        let content = collection_envelope_json("My collection", None, &[]);
+        let post = PubkyAppPost::new_with_lock(
+            content,
+            PubkyAppPostKind::Collection,
+            None,
+            None,
+            None,
+            Some("not a url".to_string()),
+        );
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid lock URL format"));
+    }
+
+    #[test]
+    fn test_collection_post_accepts_valid_lock_url() {
+        let content = collection_envelope_json("My collection", None, &[]);
+        let lock = format!("pubky://{TEST_PUBKY_ID}/pub");
+        let post = PubkyAppPost::new_with_lock(
+            content,
+            PubkyAppPostKind::Collection,
+            None,
+            None,
+            None,
+            Some(lock.clone()),
+        );
+        let id = post.create_id();
+        assert_eq!(post.lock.as_deref(), Some(lock.as_str()));
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_validate_disallowed_scheme_lock_url() {
+        let post = PubkyAppPost::new_with_lock(
+            "Visible preview".to_string(),
+            PubkyAppPostKind::Short,
+            None,
+            None,
+            None,
+            Some("javascript:alert(1)".to_string()),
+        );
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("allowed protocols"));
+    }
+
+    #[test]
+    fn test_validate_empty_lock_url_rejected() {
+        let post = PubkyAppPost::new_with_lock(
+            "Visible preview".to_string(),
+            PubkyAppPostKind::Short,
+            None,
+            None,
+            None,
+            Some("".to_string()),
+        );
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_err());
     }
 
     #[test]

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -3,7 +3,7 @@ use crate::{
     limits::VALIDATION_LIMITS,
     traits::{HasIdPath, TimestampId, Validatable},
     types::PubkyId,
-    APP_PATH, PUBLIC_PATH,
+    APP_PATH, PROTOCOL, PUBLIC_PATH,
 };
 use serde::{Deserialize, Serialize};
 use std::{fmt, str::FromStr};
@@ -361,7 +361,8 @@ impl Validatable for PubkyAppPost {
 
         // Validate lock URL if present, for every kind (including collections,
         // which return early below). Missing or null locks keep posts unlocked.
-        // Reuses the attachment URL limit and protocol allowlist for consistency.
+        // Lock servers live on the Pubky network, so the URL must be `pubky://`
+        // with a host; the length cap is shared with attachment URLs.
         if let Some(ref lock_url) = self.lock {
             if lock_url.trim().is_empty() {
                 return Err("Validation Error: Lock URL cannot be empty".into());
@@ -374,25 +375,16 @@ impl Validatable for PubkyAppPost {
             }
             let parsed = Url::parse(lock_url)
                 .map_err(|_| format!("Validation Error: Invalid lock URL format: {lock_url}"))?;
-            // Reject opaque URLs like `pubky:lock-id` that have a valid scheme
-            // but no authority and so point at no resolvable lock server.
+            if parsed.scheme() != PROTOCOL.trim_end_matches("://") {
+                return Err(format!(
+                    "Validation Error: Lock URL must use the {PROTOCOL} scheme: {lock_url}"
+                ));
+            }
+            // Reject opaque URLs like `pubky:lock-id` that carry the scheme but
+            // no authority and so point at no resolvable lock server.
             if parsed.host().is_none() {
                 return Err(format!(
                     "Validation Error: Lock URL must include a host: {lock_url}"
-                ));
-            }
-            if !VALIDATION_LIMITS
-                .post_allowed_attachment_protocols
-                .contains(&parsed.scheme())
-            {
-                let allowed = VALIDATION_LIMITS
-                    .post_allowed_attachment_protocols
-                    .iter()
-                    .map(|p| format!("{p}://"))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                return Err(format!(
-                    "Validation Error: Lock URL must use one of the allowed protocols: {allowed}"
                 ));
             }
         }
@@ -844,20 +836,20 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_https_lock_url() {
-        let lock_url = "https://locks.example.com/session/0034A0X7NJ52G".to_string();
+    fn test_validate_non_pubky_lock_url_rejected() {
         let post = PubkyAppPost::new_with_lock(
             "Visible preview".to_string(),
             PubkyAppPostKind::Short,
             None,
             None,
             None,
-            Some(lock_url.clone()),
+            Some("https://locks.example.com/session/0034A0X7NJ52G".to_string()),
         );
 
         let id = post.create_id();
-        assert_eq!(post.lock.as_deref(), Some(lock_url.as_str()));
-        assert!(post.validate(Some(&id)).is_ok());
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("must use the pubky:// scheme"));
     }
 
     #[test]
@@ -927,22 +919,6 @@ mod tests {
         let id = post.create_id();
         assert_eq!(post.lock.as_deref(), Some(lock.as_str()));
         assert!(post.validate(Some(&id)).is_ok());
-    }
-
-    #[test]
-    fn test_validate_disallowed_scheme_lock_url() {
-        let post = PubkyAppPost::new_with_lock(
-            "Visible preview".to_string(),
-            PubkyAppPostKind::Short,
-            None,
-            None,
-            None,
-            Some("ftp://files.example.com/lock".to_string()),
-        );
-        let id = post.create_id();
-        let result = post.validate(Some(&id));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("allowed protocols"));
     }
 
     #[test]

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -374,6 +374,13 @@ impl Validatable for PubkyAppPost {
             }
             let parsed = Url::parse(lock_url)
                 .map_err(|_| format!("Validation Error: Invalid lock URL format: {lock_url}"))?;
+            // Reject opaque URLs like `pubky:lock-id` that have a valid scheme
+            // but no authority and so point at no resolvable lock server.
+            if parsed.host().is_none() {
+                return Err(format!(
+                    "Validation Error: Lock URL must include a host: {lock_url}"
+                ));
+            }
             if !VALIDATION_LIMITS
                 .post_allowed_attachment_protocols
                 .contains(&parsed.scheme())
@@ -930,12 +937,28 @@ mod tests {
             None,
             None,
             None,
-            Some("javascript:alert(1)".to_string()),
+            Some("ftp://files.example.com/lock".to_string()),
         );
         let id = post.create_id();
         let result = post.validate(Some(&id));
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("allowed protocols"));
+    }
+
+    #[test]
+    fn test_validate_hostless_lock_url_rejected() {
+        let post = PubkyAppPost::new_with_lock(
+            "Visible preview".to_string(),
+            PubkyAppPostKind::Short,
+            None,
+            None,
+            None,
+            Some("pubky:lock-id".to_string()),
+        );
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("must include a host"));
     }
 
     #[test]

--- a/src/models/post.rs
+++ b/src/models/post.rs
@@ -184,6 +184,9 @@ pub struct PubkyAppPost {
     pub embed: Option<PubkyAppPostEmbed>,
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
     pub attachments: Option<Vec<String>>,
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lock: Option<String>,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -223,6 +226,11 @@ impl PubkyAppPost {
         self.attachments.clone()
     }
 
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
+    pub fn lock(&self) -> Option<String> {
+        self.lock.clone()
+    }
+
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = fromJson))]
     pub fn from_json(js_value: &JsValue) -> Result<Self, String> {
         Self::import_json(js_value)
@@ -248,12 +256,25 @@ impl PubkyAppPost {
         embed: Option<PubkyAppPostEmbed>,
         attachments: Option<Vec<String>>,
     ) -> Self {
+        Self::new_with_lock(content, kind, parent, embed, attachments, None)
+    }
+
+    /// Creates a new lockable `PubkyAppPost` instance and sanitizes it.
+    pub fn new_with_lock(
+        content: String,
+        kind: PubkyAppPostKind,
+        parent: Option<String>,
+        embed: Option<PubkyAppPostEmbed>,
+        attachments: Option<Vec<String>>,
+        lock: Option<String>,
+    ) -> Self {
         let post = PubkyAppPost {
             content,
             kind,
             parent,
             embed,
             attachments,
+            lock,
         };
         post.sanitize()
     }
@@ -291,12 +312,15 @@ impl Validatable for PubkyAppPost {
                 .collect()
         });
 
+        let lock = self.lock.map(|uri_str| sanitize_url(&uri_str));
+
         PubkyAppPost {
             content,
             kind: self.kind,
             parent,
             embed,
             attachments,
+            lock,
         }
     }
 
@@ -445,6 +469,12 @@ impl Validatable for PubkyAppPost {
                 "Validation Error: Post content exceeds maximum length for {} kind (max: {} characters)",
                 kind_name, max_length
             ));
+        }
+
+        // Validate lock URL format if present. Missing or null locks keep posts unlocked.
+        if let Some(ref lock_url) = self.lock {
+            Url::parse(lock_url)
+                .map_err(|_| format!("Validation Error: Invalid lock URL format: {lock_url}"))?;
         }
 
         // Validate parent URI format if present
@@ -765,6 +795,75 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_pubky_lock_url() {
+        let expected_lock = format!("pubky://{TEST_PUBKY_ID}/pub");
+        let post = PubkyAppPost::new_with_lock(
+            "Visible preview".to_string(),
+            PubkyAppPostKind::Short,
+            None,
+            None,
+            None,
+            Some(expected_lock.clone()),
+        );
+
+        let id = post.create_id();
+        assert_eq!(post.lock.as_deref(), Some(expected_lock.as_str()));
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_validate_https_lock_url() {
+        let lock_url = "https://locks.example.com/session/0034A0X7NJ52G".to_string();
+        let post = PubkyAppPost::new_with_lock(
+            "Visible preview".to_string(),
+            PubkyAppPostKind::Short,
+            None,
+            None,
+            None,
+            Some(lock_url.clone()),
+        );
+
+        let id = post.create_id();
+        assert_eq!(post.lock.as_deref(), Some(lock_url.as_str()));
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
+    fn test_validate_invalid_lock_url() {
+        let post = PubkyAppPost::new_with_lock(
+            "Visible preview".to_string(),
+            PubkyAppPostKind::Short,
+            None,
+            None,
+            None,
+            Some("not a url".to_string()),
+        );
+
+        let id = post.create_id();
+        let result = post.validate(Some(&id));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid lock URL format"));
+    }
+
+    #[test]
+    fn test_missing_lock_deserializes_unlocked() {
+        let post_json = r#"
+        {
+            "content": "Hello World!",
+            "kind": "short",
+            "parent": null,
+            "embed": null,
+            "attachments": null
+        }
+        "#;
+
+        let post: PubkyAppPost = serde_json::from_str(post_json).unwrap();
+        assert!(post.lock.is_none());
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+    }
+
+    #[test]
     fn test_try_from_valid() {
         let post_json = r#"
         {
@@ -918,6 +1017,7 @@ mod tests {
                 parent: None,
                 embed: None,
                 attachments: Some(vec![invalid_url.to_string()]),
+                lock: None,
             };
 
             let id = post.create_id();
@@ -936,6 +1036,7 @@ mod tests {
             parent: None,
             embed: None,
             attachments: Some(vec!["not a valid url".to_string()]),
+            lock: None,
         };
 
         let id = post.create_id();
@@ -988,6 +1089,7 @@ mod tests {
             parent: None,
             embed: None,
             attachments: Some(vec!["   ".to_string()]), // Whitespace only
+            lock: None,
         };
 
         let id = post.create_id();
@@ -1161,6 +1263,7 @@ mod tests {
             parent: None,
             embed: None,
             attachments: None,
+            lock: None,
         };
         let id = post.create_id();
         let result = post.validate(Some(&id));
@@ -1228,6 +1331,7 @@ mod tests {
                 uri: "pubky://x/pub/pubky.app/posts/01".to_string(),
             }),
             attachments: None,
+            lock: None,
         };
         let id = post.create_id();
         let result = post.validate(Some(&id));
@@ -1249,6 +1353,7 @@ mod tests {
             parent: None,
             embed: None,
             attachments: None,
+            lock: None,
         };
         assert_eq!(post.kind(), "Unknown");
     }
@@ -1782,6 +1887,7 @@ mod tests {
             parent: None,
             embed: None,
             attachments: None,
+            lock: None,
         };
         assert_eq!(post.kind(), "Collection");
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,8 @@
 use crate::{
     constants::{APP_PATH, PROTOCOL, PUBLIC_PATH},
     traits::{HasIdPath, HasPath},
-    PubkyAppBlob, PubkyAppBookmark, PubkyAppFeed, PubkyAppFile, PubkyAppFollow, PubkyAppMute,
-    PubkyAppPost, PubkyAppTag, PubkyAppUser,
+    PubkyAppBlob, PubkyAppBookmark, PubkyAppFeed, PubkyAppFile, PubkyAppFollow, PubkyAppLockedPost,
+    PubkyAppMute, PubkyAppPost, PubkyAppTag, PubkyAppUser,
 };
 
 #[cfg(target_arch = "wasm32")]
@@ -25,6 +25,13 @@ pub fn user_uri_builder(user_id: String) -> String {
 pub fn post_uri_builder(author_id: String, post_id: String) -> String {
     let post_path = PubkyAppPost::create_path(&post_id);
     [PROTOCOL, &author_id, &post_path].concat()
+}
+
+/// Builds a locked-post bundle URI: "pubky://<author_id>/priv/pubky.app/posts/<locked_post_id>"
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = lockedPostUriBuilder))]
+pub fn locked_post_uri_builder(author_id: String, locked_post_id: String) -> String {
+    let path = PubkyAppLockedPost::create_path(&locked_post_id);
+    [PROTOCOL, &author_id, &path].concat()
 }
 
 /// Builds a Follow URI of the form "pubky://<author_id>/pub/pubky.app/follows/<follow_id>"

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -260,8 +260,9 @@ impl PubkySpecsBuilder {
         parent: Option<String>,
         embed: Option<PubkyAppPostEmbed>,
         attachments: Option<Vec<String>>,
+        lock: Option<String>,
     ) -> Result<PostResult, String> {
-        let post = PubkyAppPost::new(content, kind, parent, embed, attachments);
+        let post = PubkyAppPost::new_with_lock(content, kind, parent, embed, attachments, lock);
         let post_id = post.create_id();
         post.validate(Some(&post_id))?;
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -137,6 +137,16 @@ result_struct!(BookmarkResult, bookmark, PubkyAppBookmark);
 result_struct!(MuteResult, mute, PubkyAppMute);
 result_struct!(LastReadResult, last_read, PubkyAppLastRead);
 result_struct!(BlobResult, blob, PubkyAppBlob);
+result_struct!(LockedPostResult, locked_post, PubkyAppLockedPost);
+
+/// Raw file input for [`PubkySpecsBuilder::create_locked_post`]: the display
+/// `name`, MIME `content_type`, and raw `data` bytes (a JS `Uint8Array`).
+#[derive(serde::Deserialize)]
+struct LockedFileInput {
+    name: String,
+    content_type: String,
+    data: Vec<u8>,
+}
 
 #[wasm_bindgen]
 impl PubkySpecsBuilder {
@@ -330,6 +340,41 @@ impl PubkySpecsBuilder {
         let meta = Meta::from_object(Some(&post_id), self.pubky_id.clone(), path);
 
         Ok(PostResult { post, meta })
+    }
+
+    /// Builds a `PubkyAppLockedPost` — the private, single-blob bundle that
+    /// packs the full unlocked `post` together with all of its attachment
+    /// `files` (raw bytes, no base64) into one content-addressed binary
+    /// artifact. `files` is an array of `{ name, content_type, data }`, where
+    /// `data` is a `Uint8Array`.
+    ///
+    /// The returned `meta` carries the content-hash `id` and the recommended
+    /// `/priv/pubky.app/posts/:id` path. Get the bytes to upload via
+    /// `result.lockedPost.toBytes()`.
+    #[wasm_bindgen(js_name = createLockedPost)]
+    pub fn create_locked_post(
+        &self,
+        post: PubkyAppPost,
+        files: JsValue,
+    ) -> Result<LockedPostResult, String> {
+        let raw_files: Vec<LockedFileInput> = if files.is_null() || files.is_undefined() {
+            Vec::new()
+        } else {
+            from_value(files).map_err(|e| e.to_string())?
+        };
+        let files_vec: Vec<LockedFile> = raw_files
+            .into_iter()
+            .map(|f| LockedFile::new(f.name, f.content_type, f.data))
+            .collect();
+
+        let locked_post = PubkyAppLockedPost::new(post, files_vec);
+        let id = locked_post.create_id()?;
+        locked_post.validate(Some(&id))?;
+
+        let path = PubkyAppLockedPost::create_path(&id);
+        let meta = Meta::from_object(Some(&id), self.pubky_id.clone(), path);
+
+        Ok(LockedPostResult { locked_post, meta })
     }
 
     // -----------------------------------------------------------------------------


### PR DESCRIPTION
Stacks on `feat/locks` (#133). Adds `PubkyAppLockedPost`: the private bundle holding a locked post's full unlocked content plus its attachment files, stored at `/priv/pubky.app/posts/:id` and released by the lock server after it verifies access.

Every choice below exists to satisfy one requirement, so the rationale is the design.

### Why a separate bundle, not a `kind = lock`

The public teaser keeps its real `kind` (short/long/collection/video/...) and just carries the optional `lock` URL from #133. That is required, not cosmetic: Nexus indexes by `kind`, so a `kind = lock` would drop a locked article out of article streams and a locked collection off the collections page. "What is it?" (`kind`) and "is it gated?" (`lock`) are independent axes and must stay separate. The gated payload is this bundle.

### Why raw bytes, not base64-in-JSON

Pubky already stores files as raw bytes. Base64-inlining them in JSON costs ~33% on the wire and at rest, and forces a full decode before you can even read the manifest. So the bundle is a binary container:

```text
magic "PALP" (4) | version (1) | manifest_len: u32 LE (4) | manifest JSON | file bytes...
```

`manifest = { post, files: [{ name, content_type, size }] }`; file bytes follow concatenated and are sliced back by `size`. The manifest is the index, so there is no per-file framing.

### Why a custom container, not zip

The bundle is content-addressed (ID = Crockford-Base32 of the first half of `blake3` over the exact stored bytes) so a client can verify an untrusted lock server returned the right artifact. zip defeats that: its timestamps, entry order, and compression are non-deterministic, so identical content yields different bytes across languages. zip also adds a compression dependency to the wasm build for ~0 gain on already-compressed media. A binary serde codec would be a new dependency for ~40 lines, so the framing is hand-rolled. Revisit zip-as-blob only if an external reader (checkstep) must parse the payload without this spec.

### Why a new validation path

`post.validate_in_lock_bundle` lets attachment-only media posts validate while their attachments live in the bundle (not yet written, so no URIs), instead of synthesizing placeholder attachment URLs. Invariants: the packed post must not set its own `attachments` (the bundle owns them, rebuilt on unlock) and must not itself carry a `lock`. File count and total size reuse the existing attachment/blob limits.

### Verification

- [x] `cargo test` (230 unit + doctest)
- [x] `cargo clippy --lib` (clean)
- [x] `cargo check --target wasm32-unknown-unknown`

JS: `createLockedPost(post, files)` with `files = [{ name, content_type, data: Uint8Array }]`; read back via `PubkyAppLockedPost.fromBytes(bytes)`, upload `result.lockedPost.toBytes()`.
