### PR TITLE
feat: add compatibility URI admission

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub use types::PubkyId;
 pub use uri::{
     base_uri_builder, blob_uri_builder, bookmark_uri_builder, feed_uri_builder, file_uri_builder,
     follow_uri_builder, last_read_uri_builder, mute_uri_builder, post_uri_builder,
-    tag_uri_builder, user_uri_builder, CompatParsedUri, ParsedUri, PubkyPath, Resource,
+    tag_uri_builder, user_uri_builder, ExtendedParsedUri, ParsedUri, PubkyPath, Resource,
     is_pubky_scheme, try_parse_pubky_path,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,13 @@ pub use models::tag::PubkyAppTag;
 pub use models::user::{PubkyAppUser, PubkyAppUserLink};
 pub use models::PubkyAppObject;
 pub use types::PubkyId;
-pub use uri::*;
+#[doc(inline)]
+pub use uri::{
+    base_uri_builder, blob_uri_builder, bookmark_uri_builder, feed_uri_builder, file_uri_builder,
+    follow_uri_builder, last_read_uri_builder, mute_uri_builder, post_uri_builder,
+    tag_uri_builder, user_uri_builder, CompatParsedUri, ParsedUri, PubkyPath, Resource,
+    is_pubky_scheme, try_parse_pubky_path,
+};
 
 // Our WASM module
 #[cfg(target_arch = "wasm32")]

--- a/src/models/post/content/collection.rs
+++ b/src/models/post/content/collection.rs
@@ -114,7 +114,8 @@ fn validate_collection_envelope(envelope: &PubkyAppCollectionContent) -> Result<
         })?;
         if !VALIDATION_LIMITS
             .post_allowed_attachment_protocols
-            .contains(&parsed.scheme())
+            .iter()
+            .any(|&protocol| parsed.scheme().eq_ignore_ascii_case(protocol))
         {
             let allowed = VALIDATION_LIMITS
                 .post_allowed_attachment_protocols

--- a/src/models/post/mod.rs
+++ b/src/models/post/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
     common::sanitize_url,
+    is_pubky_scheme,
     limits::VALIDATION_LIMITS,
     traits::{HasIdPath, TimestampId, Validatable},
     APP_PATH, PROTOCOL, PUBLIC_PATH,
@@ -334,7 +335,7 @@ impl Validatable for PubkyAppPost {
             }
             let parsed = Url::parse(lock_url)
                 .map_err(|_| format!("Validation Error: Invalid lock URL format: {lock_url}"))?;
-            if parsed.scheme() != PROTOCOL.trim_end_matches("://") {
+            if !is_pubky_scheme(parsed.scheme()) {
                 return Err(format!(
                     "Validation Error: Lock URL must use the {PROTOCOL} scheme: {lock_url}"
                 ));
@@ -425,7 +426,8 @@ impl Validatable for PubkyAppPost {
                 // Ensure the URL uses an allowed protocol
                 if !VALIDATION_LIMITS
                     .post_allowed_attachment_protocols
-                    .contains(&parsed_url.scheme())
+                    .iter()
+                    .any(|&protocol| parsed_url.scheme().eq_ignore_ascii_case(protocol))
                 {
                     let allowed_protocols = VALIDATION_LIMITS
                         .post_allowed_attachment_protocols

--- a/src/uri/compat/mod.rs
+++ b/src/uri/compat/mod.rs
@@ -1,0 +1,6 @@
+//! Compatibility URI admission beyond strict `pubky.app` spec parsing.
+
+mod tag;
+mod parsed;
+
+pub use parsed::CompatParsedUri;

--- a/src/uri/compat/mod.rs
+++ b/src/uri/compat/mod.rs
@@ -3,4 +3,4 @@
 mod tag;
 mod parsed;
 
-pub use parsed::CompatParsedUri;
+pub use parsed::ExtendedParsedUri;

--- a/src/uri/compat/parsed.rs
+++ b/src/uri/compat/parsed.rs
@@ -19,7 +19,6 @@ pub enum CompatParsedUri {
         user_id: PubkyId,
         app: String,
         resource: Resource,
-        tag_id: String,
     },
 }
 
@@ -50,7 +49,38 @@ impl CompatParsedUri {
     pub fn tag_id(&self) -> Option<&str> {
         match self {
             CompatParsedUri::PubkyApp { .. } => None,
-            CompatParsedUri::UniversalTag { tag_id, .. } => Some(tag_id.as_str()),
+            CompatParsedUri::UniversalTag { resource, .. } => match resource {
+                Resource::Tag(id) => Some(id.as_str()),
+                _ => None,
+            },
+        }
+    }
+
+    /// Converts back to a canonical URI string.
+    ///
+    /// For [`CompatParsedUri::PubkyApp`], delegates to [`ParsedUri::try_to_uri_str`].
+    /// For [`CompatParsedUri::UniversalTag`], reconstructs the path from components.
+    /// Query strings, fragments, and scheme casing are not preserved.
+    pub fn try_to_uri_str(&self) -> Result<String, String> {
+        match self {
+            CompatParsedUri::PubkyApp { user_id, resource } => ParsedUri {
+                user_id: user_id.clone(),
+                resource: resource.clone(),
+            }
+            .try_to_uri_str(),
+            CompatParsedUri::UniversalTag { user_id, app, resource } => {
+                let Resource::Tag(tag_id) = resource else {
+                    return Err(format!(
+                        "Universal tag URI must have Tag resource, got {resource}"
+                    ));
+                };
+                Ok(TagPath {
+                    user_id: user_id.clone(),
+                    app: app.clone(),
+                    tag_id: tag_id.clone(),
+                }
+                .to_uri_str())
+            }
         }
     }
 }
@@ -76,8 +106,7 @@ impl TryFrom<&str> for CompatParsedUri {
             return Ok(CompatParsedUri::UniversalTag {
                 user_id: parsed.user_id,
                 app: parsed.app,
-                resource: Resource::Tag(parsed.tag_id.clone()),
-                tag_id: parsed.tag_id,
+                resource: Resource::Tag(parsed.tag_id),
             });
         }
 
@@ -192,5 +221,36 @@ mod tests {
         assert!(matches!(parsed, CompatParsedUri::UniversalTag { .. }));
         assert_eq!(parsed.resource(), &Resource::Tag("ABC123".to_string()));
         assert_eq!(parsed.tag_id(), Some("ABC123"));
+    }
+
+    #[test]
+    fn test_pubky_app_uri_roundtrip() {
+        let uri = format!("pubky://{USER_ID}/pub/pubky.app/posts/0032SSN7Q4EVG");
+        let parsed = CompatParsedUri::try_from(uri.as_str()).expect("post URI should parse");
+        assert_eq!(
+            parsed.try_to_uri_str().expect("roundtrip should succeed"),
+            uri
+        );
+    }
+
+    #[test]
+    fn test_universal_tag_uri_roundtrip() {
+        let uri = format!("pubky://{USER_ID}/pub/mapky/tags/ABC123");
+        let parsed = CompatParsedUri::try_from(uri.as_str()).expect("mapky tag URI should parse");
+        assert_eq!(
+            parsed.try_to_uri_str().expect("roundtrip should succeed"),
+            uri
+        );
+    }
+
+    #[test]
+    fn test_universal_tag_uri_roundtrip_normalizes_input() {
+        let input = format!("PUBKY://{USER_ID}/pub/mapky/tags/ABC123?foo=bar#section");
+        let expected = format!("pubky://{USER_ID}/pub/mapky/tags/ABC123");
+        let parsed = CompatParsedUri::try_from(input.as_str()).expect("URI should parse");
+        assert_eq!(
+            parsed.try_to_uri_str().expect("roundtrip should succeed"),
+            expected
+        );
     }
 }

--- a/src/uri/compat/parsed.rs
+++ b/src/uri/compat/parsed.rs
@@ -1,0 +1,196 @@
+use crate::PubkyId;
+use serde::{Deserialize, Serialize};
+use std::convert::{From, TryFrom};
+
+use super::tag::TagPath;
+use super::super::{ParsedUri, Resource};
+
+/// Parsed URI for ingest boundaries: strict [`super::super::ParsedUri`] paths
+/// plus cross-app universal tag paths.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum CompatParsedUri {
+    /// Standard pubky.app path.
+    PubkyApp {
+        user_id: PubkyId,
+        resource: Resource,
+    },
+    /// Universal tag URI from a different app.
+    UniversalTag {
+        user_id: PubkyId,
+        app: String,
+        resource: Resource,
+        tag_id: String,
+    },
+}
+
+impl CompatParsedUri {
+    pub fn user_id(&self) -> &PubkyId {
+        match self {
+            CompatParsedUri::PubkyApp { user_id, .. }
+            | CompatParsedUri::UniversalTag { user_id, .. } => user_id,
+        }
+    }
+
+    pub fn resource(&self) -> &Resource {
+        match self {
+            CompatParsedUri::PubkyApp { resource, .. }
+            | CompatParsedUri::UniversalTag { resource, .. } => resource,
+        }
+    }
+
+    /// Returns the app name. `"pubky.app"` for [`CompatParsedUri::PubkyApp`] variants.
+    pub fn app(&self) -> &str {
+        match self {
+            CompatParsedUri::PubkyApp { .. } => "pubky.app",
+            CompatParsedUri::UniversalTag { app, .. } => app.as_str(),
+        }
+    }
+
+    /// Returns the tag ID when this is a [`CompatParsedUri::UniversalTag`] with a tag resource.
+    pub fn tag_id(&self) -> Option<&str> {
+        match self {
+            CompatParsedUri::PubkyApp { .. } => None,
+            CompatParsedUri::UniversalTag { tag_id, .. } => Some(tag_id.as_str()),
+        }
+    }
+}
+
+impl From<ParsedUri> for CompatParsedUri {
+    fn from(parsed: ParsedUri) -> Self {
+        CompatParsedUri::PubkyApp {
+            user_id: parsed.user_id,
+            resource: parsed.resource,
+        }
+    }
+}
+
+impl TryFrom<&str> for CompatParsedUri {
+    type Error = String;
+
+    fn try_from(uri: &str) -> Result<Self, Self::Error> {
+        if let Ok(parsed_uri) = ParsedUri::try_from(uri) {
+            return Ok(parsed_uri.into());
+        }
+
+        if let Some(parsed) = TagPath::parse(uri) {
+            return Ok(CompatParsedUri::UniversalTag {
+                user_id: parsed.user_id,
+                app: parsed.app,
+                resource: Resource::Tag(parsed.tag_id.clone()),
+                tag_id: parsed.tag_id,
+            });
+        }
+
+        Err(format!(
+            "URI is not a recognized pubky.app path or universal tag path: {uri}"
+        ))
+    }
+}
+
+impl TryFrom<String> for CompatParsedUri {
+    type Error = String;
+
+    fn try_from(uri: String) -> Result<Self, Self::Error> {
+        CompatParsedUri::try_from(uri.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const USER_ID: &str = "operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo";
+
+    #[test]
+    fn test_parse_standard_post_uri() {
+        let post_id = "0032SSN7Q4EVG";
+        let uri = format!("pubky://{USER_ID}/pub/pubky.app/posts/{post_id}");
+        let parsed = CompatParsedUri::try_from(uri.as_str()).expect("post URI should parse");
+
+        assert!(matches!(parsed, CompatParsedUri::PubkyApp { .. }));
+        assert_eq!(parsed.resource(), &Resource::Post(post_id.to_string()));
+        assert_eq!(parsed.app(), "pubky.app");
+    }
+
+    #[test]
+    fn test_parse_standard_tag_uri() {
+        let tag_id = "8Z8CWH8NVYQY39ZEBFGKQWWEKG";
+        let uri = format!("pubky://{USER_ID}/pub/pubky.app/tags/{tag_id}");
+        let parsed = CompatParsedUri::try_from(uri.as_str()).expect("tag URI should parse");
+
+        assert!(matches!(parsed, CompatParsedUri::PubkyApp { .. }));
+        assert_eq!(parsed.resource(), &Resource::Tag(tag_id.to_string()));
+        assert_eq!(parsed.app(), "pubky.app");
+        assert_eq!(parsed.tag_id(), None);
+    }
+
+    #[test]
+    fn test_parse_universal_tag_uri_mapky() {
+        let tag_id = "ABC123";
+        let uri = format!("pubky://{USER_ID}/pub/mapky/tags/{tag_id}");
+        let parsed =
+            CompatParsedUri::try_from(uri.as_str()).expect("mapky tag URI should parse");
+
+        assert!(matches!(parsed, CompatParsedUri::UniversalTag { .. }));
+        assert_eq!(parsed.user_id(), &PubkyId::try_from(USER_ID).unwrap());
+        assert_eq!(parsed.app(), "mapky");
+        assert_eq!(parsed.resource(), &Resource::Tag(tag_id.to_string()));
+        assert_eq!(parsed.tag_id(), Some(tag_id));
+    }
+
+    #[test]
+    fn test_parse_universal_tag_uri_eventky() {
+        let tag_id = "XYZ789";
+        let uri = format!("pubky://{USER_ID}/pub/eventky.app/tags/{tag_id}");
+        let parsed =
+            CompatParsedUri::try_from(uri.as_str()).expect("eventky tag URI should parse");
+
+        assert!(matches!(parsed, CompatParsedUri::UniversalTag { .. }));
+        assert_eq!(parsed.user_id(), &PubkyId::try_from(USER_ID).unwrap());
+        assert_eq!(parsed.app(), "eventky.app");
+        assert_eq!(parsed.resource(), &Resource::Tag(tag_id.to_string()));
+        assert_eq!(parsed.tag_id(), Some(tag_id));
+    }
+
+    #[test]
+    fn test_reject_universal_non_tag_path() {
+        let uri = format!("pubky://{USER_ID}/pub/eventky.app/posts/123");
+        assert!(CompatParsedUri::try_from(uri.as_str()).is_err());
+    }
+
+    #[test]
+    fn test_reject_non_pubky_scheme() {
+        assert!(CompatParsedUri::try_from("https://example.com/pub/pubky.app/").is_err());
+    }
+
+    #[test]
+    fn test_reject_missing_user_id() {
+        assert!(CompatParsedUri::try_from("pubky:///pub/pubky.app/").is_err());
+    }
+
+    #[test]
+    fn test_uppercase_scheme() {
+        let uri = format!("PUBKY://{USER_ID}/pub/mapky/tags/ABC123");
+        assert!(CompatParsedUri::try_from(uri.as_str()).is_ok());
+    }
+
+    #[test]
+    fn test_universal_tag_uri_with_query_string() {
+        let uri = format!("pubky://{USER_ID}/pub/mapky/tags/ABC123?foo=bar");
+        let parsed = CompatParsedUri::try_from(uri.as_str())
+            .expect("universal tag URI with query should parse");
+        assert!(matches!(parsed, CompatParsedUri::UniversalTag { .. }));
+        assert_eq!(parsed.resource(), &Resource::Tag("ABC123".to_string()));
+        assert_eq!(parsed.tag_id(), Some("ABC123"));
+    }
+
+    #[test]
+    fn test_universal_tag_uri_with_fragment() {
+        let uri = format!("pubky://{USER_ID}/pub/mapky/tags/ABC123#section");
+        let parsed = CompatParsedUri::try_from(uri.as_str())
+            .expect("universal tag URI with fragment should parse");
+        assert!(matches!(parsed, CompatParsedUri::UniversalTag { .. }));
+        assert_eq!(parsed.resource(), &Resource::Tag("ABC123".to_string()));
+        assert_eq!(parsed.tag_id(), Some("ABC123"));
+    }
+}

--- a/src/uri/compat/parsed.rs
+++ b/src/uri/compat/parsed.rs
@@ -8,7 +8,7 @@ use super::super::{ParsedUri, Resource};
 /// Parsed URI for ingest boundaries: strict [`super::super::ParsedUri`] paths
 /// plus cross-app universal tag paths.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub enum CompatParsedUri {
+pub enum ExtendedParsedUri {
     /// Standard pubky.app path.
     PubkyApp {
         user_id: PubkyId,
@@ -22,34 +22,34 @@ pub enum CompatParsedUri {
     },
 }
 
-impl CompatParsedUri {
+impl ExtendedParsedUri {
     pub fn user_id(&self) -> &PubkyId {
         match self {
-            CompatParsedUri::PubkyApp { user_id, .. }
-            | CompatParsedUri::UniversalTag { user_id, .. } => user_id,
+            ExtendedParsedUri::PubkyApp { user_id, .. }
+            | ExtendedParsedUri::UniversalTag { user_id, .. } => user_id,
         }
     }
 
     pub fn resource(&self) -> &Resource {
         match self {
-            CompatParsedUri::PubkyApp { resource, .. }
-            | CompatParsedUri::UniversalTag { resource, .. } => resource,
+            ExtendedParsedUri::PubkyApp { resource, .. }
+            | ExtendedParsedUri::UniversalTag { resource, .. } => resource,
         }
     }
 
-    /// Returns the app name. `"pubky.app"` for [`CompatParsedUri::PubkyApp`] variants.
+    /// Returns the app name. `"pubky.app"` for [`ExtendedParsedUri::PubkyApp`] variants.
     pub fn app(&self) -> &str {
         match self {
-            CompatParsedUri::PubkyApp { .. } => "pubky.app",
-            CompatParsedUri::UniversalTag { app, .. } => app.as_str(),
+            ExtendedParsedUri::PubkyApp { .. } => "pubky.app",
+            ExtendedParsedUri::UniversalTag { app, .. } => app.as_str(),
         }
     }
 
-    /// Returns the tag ID when this is a [`CompatParsedUri::UniversalTag`] with a tag resource.
+    /// Returns the tag ID when this is a [`ExtendedParsedUri::UniversalTag`] with a tag resource.
     pub fn tag_id(&self) -> Option<&str> {
         match self {
-            CompatParsedUri::PubkyApp { .. } => None,
-            CompatParsedUri::UniversalTag { resource, .. } => match resource {
+            ExtendedParsedUri::PubkyApp { .. } => None,
+            ExtendedParsedUri::UniversalTag { resource, .. } => match resource {
                 Resource::Tag(id) => Some(id.as_str()),
                 _ => None,
             },
@@ -58,17 +58,17 @@ impl CompatParsedUri {
 
     /// Converts back to a canonical URI string.
     ///
-    /// For [`CompatParsedUri::PubkyApp`], delegates to [`ParsedUri::try_to_uri_str`].
-    /// For [`CompatParsedUri::UniversalTag`], reconstructs the path from components.
+    /// For [`ExtendedParsedUri::PubkyApp`], delegates to [`ParsedUri::try_to_uri_str`].
+    /// For [`ExtendedParsedUri::UniversalTag`], reconstructs the path from components.
     /// Query strings, fragments, and scheme casing are not preserved.
     pub fn try_to_uri_str(&self) -> Result<String, String> {
         match self {
-            CompatParsedUri::PubkyApp { user_id, resource } => ParsedUri {
+            ExtendedParsedUri::PubkyApp { user_id, resource } => ParsedUri {
                 user_id: user_id.clone(),
                 resource: resource.clone(),
             }
             .try_to_uri_str(),
-            CompatParsedUri::UniversalTag { user_id, app, resource } => {
+            ExtendedParsedUri::UniversalTag { user_id, app, resource } => {
                 let Resource::Tag(tag_id) = resource else {
                     return Err(format!(
                         "Universal tag URI must have Tag resource, got {resource}"
@@ -85,16 +85,16 @@ impl CompatParsedUri {
     }
 }
 
-impl From<ParsedUri> for CompatParsedUri {
+impl From<ParsedUri> for ExtendedParsedUri {
     fn from(parsed: ParsedUri) -> Self {
-        CompatParsedUri::PubkyApp {
+        ExtendedParsedUri::PubkyApp {
             user_id: parsed.user_id,
             resource: parsed.resource,
         }
     }
 }
 
-impl TryFrom<&str> for CompatParsedUri {
+impl TryFrom<&str> for ExtendedParsedUri {
     type Error = String;
 
     fn try_from(uri: &str) -> Result<Self, Self::Error> {
@@ -103,7 +103,7 @@ impl TryFrom<&str> for CompatParsedUri {
         }
 
         if let Some(parsed) = TagPath::parse(uri) {
-            return Ok(CompatParsedUri::UniversalTag {
+            return Ok(ExtendedParsedUri::UniversalTag {
                 user_id: parsed.user_id,
                 app: parsed.app,
                 resource: Resource::Tag(parsed.tag_id),
@@ -116,11 +116,11 @@ impl TryFrom<&str> for CompatParsedUri {
     }
 }
 
-impl TryFrom<String> for CompatParsedUri {
+impl TryFrom<String> for ExtendedParsedUri {
     type Error = String;
 
     fn try_from(uri: String) -> Result<Self, Self::Error> {
-        CompatParsedUri::try_from(uri.as_str())
+        ExtendedParsedUri::try_from(uri.as_str())
     }
 }
 
@@ -134,9 +134,9 @@ mod tests {
     fn test_parse_standard_post_uri() {
         let post_id = "0032SSN7Q4EVG";
         let uri = format!("pubky://{USER_ID}/pub/pubky.app/posts/{post_id}");
-        let parsed = CompatParsedUri::try_from(uri.as_str()).expect("post URI should parse");
+        let parsed = ExtendedParsedUri::try_from(uri.as_str()).expect("post URI should parse");
 
-        assert!(matches!(parsed, CompatParsedUri::PubkyApp { .. }));
+        assert!(matches!(parsed, ExtendedParsedUri::PubkyApp { .. }));
         assert_eq!(parsed.resource(), &Resource::Post(post_id.to_string()));
         assert_eq!(parsed.app(), "pubky.app");
     }
@@ -145,9 +145,9 @@ mod tests {
     fn test_parse_standard_tag_uri() {
         let tag_id = "8Z8CWH8NVYQY39ZEBFGKQWWEKG";
         let uri = format!("pubky://{USER_ID}/pub/pubky.app/tags/{tag_id}");
-        let parsed = CompatParsedUri::try_from(uri.as_str()).expect("tag URI should parse");
+        let parsed = ExtendedParsedUri::try_from(uri.as_str()).expect("tag URI should parse");
 
-        assert!(matches!(parsed, CompatParsedUri::PubkyApp { .. }));
+        assert!(matches!(parsed, ExtendedParsedUri::PubkyApp { .. }));
         assert_eq!(parsed.resource(), &Resource::Tag(tag_id.to_string()));
         assert_eq!(parsed.app(), "pubky.app");
         assert_eq!(parsed.tag_id(), None);
@@ -158,9 +158,9 @@ mod tests {
         let tag_id = "ABC123";
         let uri = format!("pubky://{USER_ID}/pub/mapky/tags/{tag_id}");
         let parsed =
-            CompatParsedUri::try_from(uri.as_str()).expect("mapky tag URI should parse");
+            ExtendedParsedUri::try_from(uri.as_str()).expect("mapky tag URI should parse");
 
-        assert!(matches!(parsed, CompatParsedUri::UniversalTag { .. }));
+        assert!(matches!(parsed, ExtendedParsedUri::UniversalTag { .. }));
         assert_eq!(parsed.user_id(), &PubkyId::try_from(USER_ID).unwrap());
         assert_eq!(parsed.app(), "mapky");
         assert_eq!(parsed.resource(), &Resource::Tag(tag_id.to_string()));
@@ -172,9 +172,9 @@ mod tests {
         let tag_id = "XYZ789";
         let uri = format!("pubky://{USER_ID}/pub/eventky.app/tags/{tag_id}");
         let parsed =
-            CompatParsedUri::try_from(uri.as_str()).expect("eventky tag URI should parse");
+            ExtendedParsedUri::try_from(uri.as_str()).expect("eventky tag URI should parse");
 
-        assert!(matches!(parsed, CompatParsedUri::UniversalTag { .. }));
+        assert!(matches!(parsed, ExtendedParsedUri::UniversalTag { .. }));
         assert_eq!(parsed.user_id(), &PubkyId::try_from(USER_ID).unwrap());
         assert_eq!(parsed.app(), "eventky.app");
         assert_eq!(parsed.resource(), &Resource::Tag(tag_id.to_string()));
@@ -184,31 +184,31 @@ mod tests {
     #[test]
     fn test_reject_universal_non_tag_path() {
         let uri = format!("pubky://{USER_ID}/pub/eventky.app/posts/123");
-        assert!(CompatParsedUri::try_from(uri.as_str()).is_err());
+        assert!(ExtendedParsedUri::try_from(uri.as_str()).is_err());
     }
 
     #[test]
     fn test_reject_non_pubky_scheme() {
-        assert!(CompatParsedUri::try_from("https://example.com/pub/pubky.app/").is_err());
+        assert!(ExtendedParsedUri::try_from("https://example.com/pub/pubky.app/").is_err());
     }
 
     #[test]
     fn test_reject_missing_user_id() {
-        assert!(CompatParsedUri::try_from("pubky:///pub/pubky.app/").is_err());
+        assert!(ExtendedParsedUri::try_from("pubky:///pub/pubky.app/").is_err());
     }
 
     #[test]
     fn test_uppercase_scheme() {
         let uri = format!("PUBKY://{USER_ID}/pub/mapky/tags/ABC123");
-        assert!(CompatParsedUri::try_from(uri.as_str()).is_ok());
+        assert!(ExtendedParsedUri::try_from(uri.as_str()).is_ok());
     }
 
     #[test]
     fn test_universal_tag_uri_with_query_string() {
         let uri = format!("pubky://{USER_ID}/pub/mapky/tags/ABC123?foo=bar");
-        let parsed = CompatParsedUri::try_from(uri.as_str())
+        let parsed = ExtendedParsedUri::try_from(uri.as_str())
             .expect("universal tag URI with query should parse");
-        assert!(matches!(parsed, CompatParsedUri::UniversalTag { .. }));
+        assert!(matches!(parsed, ExtendedParsedUri::UniversalTag { .. }));
         assert_eq!(parsed.resource(), &Resource::Tag("ABC123".to_string()));
         assert_eq!(parsed.tag_id(), Some("ABC123"));
     }
@@ -216,9 +216,9 @@ mod tests {
     #[test]
     fn test_universal_tag_uri_with_fragment() {
         let uri = format!("pubky://{USER_ID}/pub/mapky/tags/ABC123#section");
-        let parsed = CompatParsedUri::try_from(uri.as_str())
+        let parsed = ExtendedParsedUri::try_from(uri.as_str())
             .expect("universal tag URI with fragment should parse");
-        assert!(matches!(parsed, CompatParsedUri::UniversalTag { .. }));
+        assert!(matches!(parsed, ExtendedParsedUri::UniversalTag { .. }));
         assert_eq!(parsed.resource(), &Resource::Tag("ABC123".to_string()));
         assert_eq!(parsed.tag_id(), Some("ABC123"));
     }
@@ -226,7 +226,7 @@ mod tests {
     #[test]
     fn test_pubky_app_uri_roundtrip() {
         let uri = format!("pubky://{USER_ID}/pub/pubky.app/posts/0032SSN7Q4EVG");
-        let parsed = CompatParsedUri::try_from(uri.as_str()).expect("post URI should parse");
+        let parsed = ExtendedParsedUri::try_from(uri.as_str()).expect("post URI should parse");
         assert_eq!(
             parsed.try_to_uri_str().expect("roundtrip should succeed"),
             uri
@@ -236,7 +236,7 @@ mod tests {
     #[test]
     fn test_universal_tag_uri_roundtrip() {
         let uri = format!("pubky://{USER_ID}/pub/mapky/tags/ABC123");
-        let parsed = CompatParsedUri::try_from(uri.as_str()).expect("mapky tag URI should parse");
+        let parsed = ExtendedParsedUri::try_from(uri.as_str()).expect("mapky tag URI should parse");
         assert_eq!(
             parsed.try_to_uri_str().expect("roundtrip should succeed"),
             uri
@@ -247,7 +247,7 @@ mod tests {
     fn test_universal_tag_uri_roundtrip_normalizes_input() {
         let input = format!("PUBKY://{USER_ID}/pub/mapky/tags/ABC123?foo=bar#section");
         let expected = format!("pubky://{USER_ID}/pub/mapky/tags/ABC123");
-        let parsed = CompatParsedUri::try_from(input.as_str()).expect("URI should parse");
+        let parsed = ExtendedParsedUri::try_from(input.as_str()).expect("URI should parse");
         assert_eq!(
             parsed.try_to_uri_str().expect("roundtrip should succeed"),
             expected

--- a/src/uri/compat/tag.rs
+++ b/src/uri/compat/tag.rs
@@ -1,0 +1,135 @@
+use crate::{PubkyId, APP_PATH};
+
+use super::super::path::try_parse_pubky_path;
+
+/// Parsed cross-app tag path: `pubky://<user_id>/pub/<app>/tags/<tag_id>`
+pub(crate) struct TagPath {
+    pub user_id: PubkyId,
+    pub app: String,
+    pub tag_id: String,
+    #[allow(dead_code)]
+    pub uri: String,
+}
+
+impl TagPath {
+    /// Parse a non-`pubky.app` URI when it follows the universal tag shape.
+    pub fn parse(uri: &str) -> Option<Self> {
+        let path = try_parse_pubky_path(uri).ok()?;
+
+        if path.app.is_empty() || path.app == APP_PATH.trim_end_matches('/') {
+            return None;
+        }
+
+        let [resource, tag_id] = path.segments.as_slice() else {
+            return None;
+        };
+
+        if resource != "tags" || tag_id.is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            user_id: path.user_id,
+            app: path.app,
+            tag_id: tag_id.clone(),
+            uri: uri.to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASE_URI: &str =
+        "pubky://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/mapky/tags/ABC123";
+
+    #[test]
+    fn test_parse_mapky() {
+        let parsed = TagPath::parse(BASE_URI).expect("mapky tag URI should parse");
+        assert_eq!(parsed.app, "mapky");
+        assert_eq!(parsed.tag_id, "ABC123");
+        assert_eq!(parsed.uri, BASE_URI);
+    }
+
+    #[test]
+    fn test_parse_eventky() {
+        let uri = "pubky://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/eventky.app/tags/XYZ";
+        let parsed = TagPath::parse(uri).expect("eventky tag URI should parse");
+        assert_eq!(parsed.app, "eventky.app");
+        assert_eq!(parsed.tag_id, "XYZ");
+    }
+
+    #[test]
+    fn test_parse_pubky_app_returns_none() {
+        let uri = "pubky://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/pubky.app/tags/123";
+        assert!(TagPath::parse(uri).is_none());
+    }
+
+    #[test]
+    fn test_parse_not_pubky() {
+        assert!(TagPath::parse("https://example.com/tags/123").is_none());
+    }
+
+    #[test]
+    fn test_parse_no_tags_segment() {
+        let uri = "pubky://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/mapky/events/123";
+        assert!(TagPath::parse(uri).is_none());
+    }
+
+    #[test]
+    fn test_parse_uppercase_scheme() {
+        let uri = "PUBKY://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/mapky/tags/ABC123";
+        assert!(TagPath::parse(uri).is_some());
+    }
+
+    #[test]
+    fn test_parse_mixed_case_scheme() {
+        let uri = "Pubky://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/mapky/tags/XYZ";
+        assert!(TagPath::parse(uri).is_some());
+    }
+
+    #[test]
+    fn test_parse_slash_in_app_returns_none() {
+        let uri = "pubky://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/my/app/tags/ABC";
+        assert!(TagPath::parse(uri).is_none());
+    }
+
+    #[test]
+    fn test_parse_slash_in_tag_returns_none() {
+        let uri = "pubky://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/mapky/tags/ABC/DEF";
+        assert!(TagPath::parse(uri).is_none());
+    }
+
+    #[test]
+    fn test_parse_empty_app_returns_none() {
+        let uri = "pubky://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub//tags/ABC";
+        assert!(TagPath::parse(uri).is_none());
+    }
+
+    #[test]
+    fn test_parse_empty_tag_returns_none() {
+        let uri = "pubky://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/mapky/tags/";
+        assert!(TagPath::parse(uri).is_none());
+    }
+
+    #[test]
+    fn test_parse_query_string_stripped() {
+        let uri = "pubky://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/mapky/tags/ABC123?foo=bar";
+        let parsed = TagPath::parse(uri).expect("URI with query string should parse");
+        assert_eq!(parsed.tag_id, "ABC123");
+    }
+
+    #[test]
+    fn test_parse_fragment_stripped() {
+        let uri = "pubky://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/mapky/tags/ABC123#section";
+        let parsed = TagPath::parse(uri).expect("URI with fragment should parse");
+        assert_eq!(parsed.tag_id, "ABC123");
+    }
+
+    #[test]
+    fn test_parse_empty_tag_after_query_returns_none() {
+        let uri = "pubky://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/mapky/tags/?foo=bar";
+        assert!(TagPath::parse(uri).is_none());
+    }
+}

--- a/src/uri/compat/tag.rs
+++ b/src/uri/compat/tag.rs
@@ -1,4 +1,4 @@
-use crate::{PubkyId, APP_PATH};
+use crate::{PubkyId, APP_PATH, PROTOCOL, PUBLIC_PATH};
 
 use super::super::path::try_parse_pubky_path;
 
@@ -7,8 +7,6 @@ pub(crate) struct TagPath {
     pub user_id: PubkyId,
     pub app: String,
     pub tag_id: String,
-    #[allow(dead_code)]
-    pub uri: String,
 }
 
 impl TagPath {
@@ -32,8 +30,22 @@ impl TagPath {
             user_id: path.user_id,
             app: path.app,
             tag_id: tag_id.clone(),
-            uri: uri.to_string(),
         })
+    }
+
+    /// Reconstructs the canonical URI from parsed components.
+    ///
+    /// Query strings, fragments, and scheme casing from the original input are
+    /// not preserved — only the semantic path is encoded.
+    pub fn to_uri_str(&self) -> String {
+        let path = [
+            PUBLIC_PATH,
+            self.app.as_str(),
+            "/tags/",
+            self.tag_id.as_str(),
+        ]
+        .concat();
+        [PROTOCOL, self.user_id.as_ref(), &path].concat()
     }
 }
 
@@ -49,7 +61,7 @@ mod tests {
         let parsed = TagPath::parse(BASE_URI).expect("mapky tag URI should parse");
         assert_eq!(parsed.app, "mapky");
         assert_eq!(parsed.tag_id, "ABC123");
-        assert_eq!(parsed.uri, BASE_URI);
+        assert_eq!(parsed.to_uri_str(), BASE_URI);
     }
 
     #[test]
@@ -58,6 +70,29 @@ mod tests {
         let parsed = TagPath::parse(uri).expect("eventky tag URI should parse");
         assert_eq!(parsed.app, "eventky.app");
         assert_eq!(parsed.tag_id, "XYZ");
+    }
+
+    #[test]
+    fn test_parse_uppercase_scheme_normalizes_on_to_uri_str() {
+        let uri = "PUBKY://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/mapky/tags/ABC123";
+        let parsed = TagPath::parse(uri).expect("uppercase scheme should parse");
+        assert_eq!(parsed.to_uri_str(), BASE_URI);
+    }
+
+    #[test]
+    fn test_parse_query_string_stripped_from_to_uri_str() {
+        let uri = "pubky://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/mapky/tags/ABC123?foo=bar";
+        let parsed = TagPath::parse(uri).expect("URI with query string should parse");
+        assert_eq!(parsed.tag_id, "ABC123");
+        assert_eq!(parsed.to_uri_str(), BASE_URI);
+    }
+
+    #[test]
+    fn test_parse_fragment_stripped_from_to_uri_str() {
+        let uri = "pubky://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/mapky/tags/ABC123#section";
+        let parsed = TagPath::parse(uri).expect("URI with fragment should parse");
+        assert_eq!(parsed.tag_id, "ABC123");
+        assert_eq!(parsed.to_uri_str(), BASE_URI);
     }
 
     #[test]
@@ -111,20 +146,6 @@ mod tests {
     fn test_parse_empty_tag_returns_none() {
         let uri = "pubky://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/mapky/tags/";
         assert!(TagPath::parse(uri).is_none());
-    }
-
-    #[test]
-    fn test_parse_query_string_stripped() {
-        let uri = "pubky://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/mapky/tags/ABC123?foo=bar";
-        let parsed = TagPath::parse(uri).expect("URI with query string should parse");
-        assert_eq!(parsed.tag_id, "ABC123");
-    }
-
-    #[test]
-    fn test_parse_fragment_stripped() {
-        let uri = "pubky://8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo/pub/mapky/tags/ABC123#section";
-        let parsed = TagPath::parse(uri).expect("URI with fragment should parse");
-        assert_eq!(parsed.tag_id, "ABC123");
     }
 
     #[test]

--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -1,7 +1,9 @@
-//! Pubky URI parsing and construction.
+//! URI parsing and construction for `pubky://` paths.
 //!
-//! Core modules define the `pubky.app` spec. See [`compat`] for admission rules
-//! when ingesting URIs beyond strict spec paths.
+//! - **Build** — `*_uri_builder` functions
+//! - **Parse (strict)** — [`ParsedUri`] for `pubky.app` spec paths
+//! - **Parse (compat)** — [`CompatParsedUri`] for ingest (cross-app tags)
+//! - **Parse (structure)** — [`try_parse_pubky_path`] / [`PubkyPath`] (advanced)
 
 mod builders;
 mod compat;
@@ -10,8 +12,20 @@ mod path;
 mod resource;
 mod scheme;
 
-pub use builders::*;
-pub use compat::CompatParsedUri;
+// Build
+pub use builders::{
+    base_uri_builder, blob_uri_builder, bookmark_uri_builder, feed_uri_builder, file_uri_builder,
+    follow_uri_builder, last_read_uri_builder, mute_uri_builder, post_uri_builder,
+    tag_uri_builder, user_uri_builder,
+};
+
+// Strict
 pub use parsed::ParsedUri;
-pub use path::{try_parse_pubky_path, PubkyPath};
 pub use resource::Resource;
+
+// Compat
+pub use compat::CompatParsedUri;
+
+// Structure (advanced)
+pub use path::{try_parse_pubky_path, PubkyPath};
+pub use scheme::is_pubky_scheme;

--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! - **Build** — `*_uri_builder` functions
 //! - **Parse (strict)** — [`ParsedUri`] for `pubky.app` spec paths
-//! - **Parse (compat)** — [`CompatParsedUri`] for ingest (cross-app tags)
+//! - **Parse (extended)** — [`ExtendedParsedUri`] for ingest (cross-app tags)
 //! - **Parse (structure)** — [`try_parse_pubky_path`] / [`PubkyPath`] (advanced)
 
 mod builders;
@@ -24,7 +24,7 @@ pub use parsed::ParsedUri;
 pub use resource::Resource;
 
 // Compat
-pub use compat::CompatParsedUri;
+pub use compat::ExtendedParsedUri;
 
 // Structure (advanced)
 pub use path::{try_parse_pubky_path, PubkyPath};

--- a/src/uri/mod.rs
+++ b/src/uri/mod.rs
@@ -1,9 +1,17 @@
-//! Pubky URI parsing and construction for `pubky.app` resources.
+//! Pubky URI parsing and construction.
+//!
+//! Core modules define the `pubky.app` spec. See [`compat`] for admission rules
+//! when ingesting URIs beyond strict spec paths.
 
 mod builders;
+mod compat;
 mod parsed;
+mod path;
 mod resource;
+mod scheme;
 
 pub use builders::*;
+pub use compat::CompatParsedUri;
 pub use parsed::ParsedUri;
+pub use path::{try_parse_pubky_path, PubkyPath};
 pub use resource::Resource;

--- a/src/uri/parsed.rs
+++ b/src/uri/parsed.rs
@@ -2,11 +2,9 @@ use crate::{
     traits::{HasIdPath, HasPath},
     PubkyAppBlob, PubkyAppBookmark, PubkyAppFeed, PubkyAppFile, PubkyAppFollow, PubkyAppLastRead,
     PubkyAppMute, PubkyAppPost, PubkyAppTag, PubkyAppUser, PubkyId, APP_PATH, PROTOCOL,
-    PUBLIC_PATH,
 };
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
-use url::Url;
 
 use super::Resource;
 
@@ -41,76 +39,49 @@ impl ParsedUri {
 impl TryFrom<&str> for ParsedUri {
     type Error = String;
     fn try_from(uri: &str) -> Result<Self, Self::Error> {
-        // 0. Validate and sanitize the URL.
-        let parsed_url = Url::parse(uri).map_err(|e| format!("Invalid URL: {}", e))?;
+        let path = super::path::try_parse_pubky_path(uri)?;
 
-        // 1. Validate the scheme (using PROTOCOL without the "://")
-        if parsed_url.scheme() != PROTOCOL.trim_end_matches("://") {
-            return Err(format!(
-                "Invalid URI, must start with '{}': {}",
-                PROTOCOL, uri
-            ));
-        }
-
-        // 2. Extract the user_id from the host.
-        let user_id_str = parsed_url
-            .host_str()
-            .ok_or_else(|| format!("Missing user ID in URI: {}", uri))?;
-        let user_id = PubkyId::try_from(user_id_str)?;
-
-        // 3. Get the path segments.
-        // Expected URI structure:
-        // pubky://<user_id>/<public>/<app>/<resource>[/<id>]
-        let segments: Vec<&str> = parsed_url
-            .path_segments()
-            .ok_or_else(|| format!("Cannot parse path segments from URI: {}", uri))?
-            .collect();
-        if segments.len() < 2 {
-            return Err(format!("Not enough path segments in URI: {}", uri));
-        }
-        if segments[0] != PUBLIC_PATH.trim_matches('/') {
-            return Err(format!(
-                "Expected public path '{}' but got '{}' in URI: {}",
-                PUBLIC_PATH, segments[0], uri
-            ));
-        }
-        if segments[1] != APP_PATH.trim_matches('/') {
+        if path.app != APP_PATH.trim_matches('/') {
             return Err(format!(
                 "Expected app path '{}' but got '{}' in URI: {}",
-                APP_PATH, segments[1], uri
+                APP_PATH.trim_matches('/'),
+                path.app,
+                uri
             ));
         }
 
-        // 4. Determine the resource from the remaining segments.
-        let resource = match segments[2..] {
-            // No extra segments.
-            [] => Resource::Unknown,
-            // A single segment: must exactly match an identifier-less route.
-            [segment] => match segment {
-                PubkyAppUser::PATH_SEGMENT => Resource::User,
-                PubkyAppLastRead::PATH_SEGMENT => Resource::LastRead,
-                _ => Resource::Unknown,
-            },
-            // Two or more segments and the id is not empty.
-            [res_type, id, ..] if !id.is_empty() => {
-                let resource_type = format!("{}/", res_type);
-                match resource_type.as_str() {
-                    PubkyAppPost::PATH_SEGMENT => Resource::Post(id.to_string()),
-                    PubkyAppFollow::PATH_SEGMENT => PubkyId::try_from(id).map(Resource::Follow)?,
-                    PubkyAppMute::PATH_SEGMENT => PubkyId::try_from(id).map(Resource::Mute)?,
-                    PubkyAppBookmark::PATH_SEGMENT => Resource::Bookmark(id.to_string()),
-                    PubkyAppTag::PATH_SEGMENT => Resource::Tag(id.to_string()),
-                    PubkyAppFile::PATH_SEGMENT => Resource::File(id.to_string()),
-                    PubkyAppBlob::PATH_SEGMENT => Resource::Blob(id.to_string()),
-                    PubkyAppFeed::PATH_SEGMENT => Resource::Feed(id.to_string()),
-                    _ => Resource::Unknown,
-                }
-            }
-            // If the identifier is empty or doesn't match the expected pattern.
-            _ => Resource::Unknown,
-        };
+        let resource = resource_from_segments(&path.segments)?;
 
-        Ok(ParsedUri { user_id, resource })
+        Ok(ParsedUri {
+            user_id: path.user_id,
+            resource,
+        })
+    }
+}
+
+fn resource_from_segments(segments: &[String]) -> Result<Resource, String> {
+    match segments {
+        [] => Ok(Resource::Unknown),
+        [segment] => Ok(match segment.as_str() {
+            s if s == PubkyAppUser::PATH_SEGMENT.trim_end_matches('/') => Resource::User,
+            s if s == PubkyAppLastRead::PATH_SEGMENT.trim_end_matches('/') => Resource::LastRead,
+            _ => Resource::Unknown,
+        }),
+        [res_type, id, ..] if !id.is_empty() => {
+            let resource_type = format!("{res_type}/");
+            Ok(match resource_type.as_str() {
+                PubkyAppPost::PATH_SEGMENT => Resource::Post(id.clone()),
+                PubkyAppFollow::PATH_SEGMENT => PubkyId::try_from(id.as_str()).map(Resource::Follow)?,
+                PubkyAppMute::PATH_SEGMENT => PubkyId::try_from(id.as_str()).map(Resource::Mute)?,
+                PubkyAppBookmark::PATH_SEGMENT => Resource::Bookmark(id.clone()),
+                PubkyAppTag::PATH_SEGMENT => Resource::Tag(id.clone()),
+                PubkyAppFile::PATH_SEGMENT => Resource::File(id.clone()),
+                PubkyAppBlob::PATH_SEGMENT => Resource::Blob(id.clone()),
+                PubkyAppFeed::PATH_SEGMENT => Resource::Feed(id.clone()),
+                _ => Resource::Unknown,
+            })
+        }
+        _ => Ok(Resource::Unknown),
     }
 }
 

--- a/src/uri/path.rs
+++ b/src/uri/path.rs
@@ -1,0 +1,85 @@
+use crate::{PubkyId, PROTOCOL, PUBLIC_PATH};
+use url::Url;
+
+use super::scheme::is_pubky_scheme;
+
+/// Generic parsed structure for `pubky://<user_id>/pub/<app>/...`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PubkyPath {
+    pub user_id: PubkyId,
+    pub app: String,
+    /// Path segments after `<app>`.
+    pub segments: Vec<String>,
+}
+
+/// Parse the structural components of a pubky URI without app-specific rules.
+pub fn try_parse_pubky_path(uri: &str) -> Result<PubkyPath, String> {
+    let parsed_url = Url::parse(uri).map_err(|e| format!("Invalid URL: {e}"))?;
+
+    if !is_pubky_scheme(parsed_url.scheme()) {
+        return Err(format!(
+            "Invalid URI, must start with '{PROTOCOL}': {uri}"
+        ));
+    }
+
+    let user_id_str = parsed_url
+        .host_str()
+        .ok_or_else(|| format!("Missing user ID in URI: {uri}"))?;
+    let user_id = PubkyId::try_from(user_id_str)?;
+
+    let segments: Vec<&str> = parsed_url
+        .path_segments()
+        .ok_or_else(|| format!("Cannot parse path segments from URI: {uri}"))?
+        .collect();
+
+    if segments.len() < 2 {
+        return Err(format!("Not enough path segments in URI: {uri}"));
+    }
+    if segments[0] != PUBLIC_PATH.trim_matches('/') {
+        return Err(format!(
+            "Expected public path '{}' but got '{}' in URI: {}",
+            PUBLIC_PATH.trim_matches('/'),
+            segments[0],
+            uri
+        ));
+    }
+
+    Ok(PubkyPath {
+        user_id,
+        app: segments[1].to_string(),
+        segments: segments[2..].iter().map(|segment| segment.to_string()).collect(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const USER_ID: &str = "8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo";
+
+    #[test]
+    fn test_parse_pubky_app_post_path() {
+        let uri = format!("pubky://{USER_ID}/pub/pubky.app/posts/0032SSN7Q4EVG");
+        let path = try_parse_pubky_path(&uri).expect("post path should parse");
+        assert_eq!(path.app, "pubky.app");
+        assert_eq!(path.segments, vec!["posts", "0032SSN7Q4EVG"]);
+    }
+
+    #[test]
+    fn test_parse_foreign_app_tag_path() {
+        let uri = format!("pubky://{USER_ID}/pub/mapky/tags/ABC123");
+        let path = try_parse_pubky_path(&uri).expect("foreign tag path should parse");
+        assert_eq!(path.app, "mapky");
+        assert_eq!(path.segments, vec!["tags", "ABC123"]);
+    }
+
+    #[test]
+    fn test_reject_non_pubky_scheme() {
+        assert!(try_parse_pubky_path("https://example.com/pub/pubky.app/").is_err());
+    }
+
+    #[test]
+    fn test_reject_missing_user_id() {
+        assert!(try_parse_pubky_path("pubky:///pub/pubky.app/").is_err());
+    }
+}

--- a/src/uri/scheme.rs
+++ b/src/uri/scheme.rs
@@ -1,0 +1,19 @@
+use crate::PROTOCOL;
+
+/// Returns true when `scheme` is `pubky` (case-insensitive).
+pub fn is_pubky_scheme(scheme: &str) -> bool {
+    scheme.eq_ignore_ascii_case(PROTOCOL.trim_end_matches("://"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_pubky_scheme() {
+        assert!(is_pubky_scheme("pubky"));
+        assert!(is_pubky_scheme("PUBKY"));
+        assert!(is_pubky_scheme("Pubky"));
+        assert!(!is_pubky_scheme("https"));
+    }
+}


### PR DESCRIPTION
Depends on #139.

## Summary

Homeservers persist tag URIs from apps other than pubky.app (mapky, eventky.app, etc.). Strict `ParsedUri` rejects those. This PR adds extended admission parsing without changing pubky.app spec rules.

- Add `ExtendedParsedUri` (`PubkyApp` | `UniversalTag`) under `uri/compat/`
- Add `TagPath::parse` for `pubky://<user>/pub/<foreign-app>/tags/<tag_id>`
- Strict paths still go through `ParsedUri` first; extended parsing only admits foreign-app tag shapes
- `ParsedUri`, builders, and WASM `parse_uri` stay strict-only

## Follow-up (nexus)

- Replace `HomeserverParsedUri` with `ExtendedParsedUri`
- Map `AppSpec` → `PubkyApp`, keep `UniversalTag` as-is
- Remove local `try_parse_app_tag_path` / `AppTagInfo`

## Test plan

- [x] `cargo test --lib`
- [ ] Nexus ingest with foreign tag URIs (follow-up)