### PR TITLE
RFC: pubky-social-specs v1 (first stable, fully breaking release)

### DIFF
--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -1,0 +1,348 @@
+# RFC: pubky-social-specs v1 (first stable, first breaking release)
+
+> Status: DRAFT, for review. This document is the complete v1 design and rollout plan: the
+> design model by model (v0 shape, v1 shape, why), then migration, then the rollout. Comment
+> inline on the line you disagree with. The companion `v0-vs-v1.md` expands every model change
+> with its full reasoning.
+
+The first stable and first breaking release of the shared social-data layer. Renames the crate
+`pubky-app-specs` to `pubky-social-specs` (`1.0.0`) and moves all data from the single hard-coded
+app path `/pub/pubky.app/<res>` to a versioned, app-neutral epoch `/{pub|priv}/social/v1/<res>`.
+One coordinated break spends the whole budget on what cannot be added additively later; a
+permanent forward-compat contract is designed so v1.x grows additively. A further epoch stays
+reserved for the changes no contract can make additive: re-pinning a text or id function (which
+re-ids data), changing an existing resource's root or per-kind content semantics, or breaking
+the path grammar.
+
+# Part A: Why break now
+
+- `pub/pubky.app/` hard-codes one app's domain as the home of shared data and the parser rejects
+  every other app. A shared spec must classify foreign data, not error on it.
+- The path is the only version signal that survives the `/events/` feed, LIST, and anonymous GET.
+  v0 has none, so v1.x could not evolve without breaking old clients.
+- No privacy tier, no file extensions, GET-per-file bookmarks, and `url::Url` validation that
+  normalizes junk into acceptance while rejecting valid short-form URIs.
+
+# Part B: Design, model by model
+
+## B0. Cross-cutting (applies to every model)
+
+- **Namespace + epoch: `pub/pubky.app/<res>` becomes `{pub|priv}/social/v1/<res>`.** App-neutral
+  (`pubky.app` wrongly signals one app owns shared data), versioned (the path is the only channel
+  that survives events + LIST + anonymous GET), and a bare word with no dot (a dotted directory
+  name like `pubky.app/` reads as an application bundle on macOS when a tree is exported to disk).
+- **Namespace governance.** `social/vN` is owned by this repo: a resource type exists exactly
+  when the released crate parses it, and additions land as ordinary crate-minor PRs here (parser
+  arm + model + data assets + vectors in one change). Reserved: epoch segments `v[0-9]+`, the `_`
+  filename prefix, every current resource segment, and the `ext` member name; unknown segments
+  under `social/vN` parse as a handled `Unknown`, so additions never break deployed readers. A
+  new epoch (`social/v2`) is reserved for changes impossible additively (re-pinned text/id
+  functions, changed root or content semantics, grammar breaks). App namespaces are self-assigned
+  (domain-style names recommended); the parser classifies them foreign, never invalid.
+- **`.json` on every JSON leaf.** The homeserver derives the served type from magic bytes then the
+  path extension; extensionless JSON serves as octet-stream/plaintext.
+- **A privacy tier `/priv/` (owner-only, excluded from `/events/`).** For state whose only reader
+  is the owner's own client. The placement test is the actual reader set, not aspiration.
+- **Forward-compat contract (permanent).** All wire enums are plain string enums (unit
+  variants, `rename_all` lowercase/snake_case), so `#[serde(other)] Unknown` plus
+  `#[non_exhaustive]` is well-defined; no model uses `deny_unknown_fields`; every future field is
+  optional + defaulted + skip-if-none. Degradation semantics are per-position: an `Unknown` in an
+  object's primary enum (`post.kind`) fails validation and readers skip the object; an `Unknown`
+  in a secondary enum (`feed.content`) degrades to "no constraint"; deserialization never crashes.
+  Unknown members are tolerated on read AND preserved on rewrite: every wire model carries an
+  opaque flattened catch-all map, so a client rewriting an object round-trips members it does not
+  understand instead of destroying another client's data (tolerating without preserving would let
+  any older client drop every field added after it shipped). Conformance vectors cover both the
+  unknown-value and the preservation behavior. Preservation fixes typed-rewrite data loss, not
+  concurrency: concurrent writers still clobber whole-file under last-write-wins where that is
+  the documented rule.
+- **Canonical-encoding id rule.** An id is valid iff re-encoding its decoded bytes reproduces the
+  input (closed-form final-char check). v0 accepted dozens of alias spellings per id (lowercase,
+  `O`->`0`, dangling bits), each a distinct homeserver key; that leniency is removed.
+- **Engine-free validation.** `url::Url` (normalizes junk into acceptance), the `mime` crate, and
+  full-Unicode case/trim are replaced by pinned rules (a strict raw-string canonicalizer, a
+  frozen whitespace table, ASCII-only label folding, code-point lengths) that a Rust and a
+  hand-written JS implementation reproduce byte-for-byte.
+- **No silent sanitize-rewrites.** v0 rewrote `[DELETED]` names to "anonymous" and
+  truncated-then-blanked over-long inputs; v1 makes invalid input a validation error.
+
+## B1. User (profile)
+v0 `pub/pubky.app/profile.json` -> v1 `pub/social/v1/profile.json`.
+- `image` accepts pubky/http/https via one shared image validator (cap 300). pubky-app avatars are
+  pubky file URIs; an http-only rule would reject every real avatar.
+- The `[DELETED]` -> "anonymous" name rewrite is removed; the exact literal `[DELETED]` is now a
+  rejected reserved value (the indexer keys tombstones on it, so a user literally named `[DELETED]`
+  must not be storable).
+- Fields and caps otherwise unchanged; profile stays public (identity must be readable).
+
+## B2. Post
+v0 `pub/pubky.app/posts/{id}` (one flat file, overwritten on edit) -> v1
+`{pub|priv}/social/v1/posts/{id}/{editId}.json`, referenced versionlessly as `posts/{id}`.
+- **Per-edit path versioning.** Each edit is a new file; the first version reuses the post id;
+  references use the versionless form so edits never orphan replies or re-key tags. A counter was
+  rejected (races across devices on a substrate with no compare-and-swap). Now-or-never: a
+  `posts/{id}` file and a `posts/{id}/` directory are mutually exclusive on the homeserver.
+- **Kinds renamed** `short`->`note`, `long`->`article` (nature, not length); all seven kinds kept.
+- **`embed`** flattened from `{uri, kind}` to a plain URI string (kind is derivable from the target).
+- **`attachments`** become `Vec<{uri, alt?, name?}>`, always `[]` never null. Objects, not strings,
+  so per-item metadata (alt text now; hash/blurhash later) is additive; ships two committed fields.
+- **`lock`** kept: the value is the lock-FILE URI (`pub/locks.app/<lock_id>.json`), and presence
+  means "locked content" regardless of kind (matches the Locks feature's resolved design).
+- **Dual-root:** posts may live under `/priv/` (drafts, private notes, private collections).
+- The `[DELETED]` content sentinel becomes a rejected reserved value; absence is the tombstone.
+
+## B3. ArticleContent (new)
+v0: pubky-app hand-rolls `{title, body}` JSON inside `long` posts, unspecified, cover smuggled as
+`attachments[0]`. v1: a typed `{title, body, cover_image?}` envelope in `content` when
+`kind == article`. Per-kind content shape is now-or-never; the cover moves into the envelope.
+Articles may carry parent/embed/attachments (an article can be a reply or carry media).
+
+## B4. CollectionContent
+Shape unchanged (`{name, description?, items[], cover_image?}`). `items` now accept any
+reference-tier pubky URI (any resource, any app), not just `posts/` under `pubky.app` (a curated
+list may include foreign resources). Private collections come free from the dual-root post family.
+
+## B5. Tag
+`tags/{id}.json`. Id hashed over the canonicalized target plus a frozen-trimmed, ASCII-folded
+label (v0 used engine `to_lowercase` and `url::Url` normalization, neither reproducible across
+implementations; content-addressed ids must freeze their input functions). Injectivity holds only
+because the label rejects `:`.
+
+## B6. Bookmark
+v0 `pub/pubky.app/bookmarks/{HashId(uri)}` (public, one-way filename, GET-per-file) -> v1
+`priv/social/v1/bookmarks/{filename}.json`.
+- **Private** (reader set is the owner).
+- **Target in the filename, reversibly:** `base64url(canonical target)` up to 187 bytes (the exact
+  substrate maximum), plus a `~ + HashId` overflow form (target in content) for longer targets.
+  Listing bookmarks costs zero GETs for primary-form entries (the overwhelming majority); each
+  overflow entry costs one GET to recover its target. base64url is the only standard encoding that fits the
+  255-char segment at that cap and is `/`-, `%`-free and JS-decodable.
+- Content shrinks to `{created_at}` (plus `target` only in overflow).
+
+## B7. Follow
+`follows/{followeePk}.json`, `{created_at}`. Public (the social graph). Only the cross-cutting
+changes apply; the filename-is-target pattern (one LIST answers "who do I follow") is kept.
+
+## B8. Mute
+`priv/social/v1/mutes/{muteePk}.json`. Moves to `/priv/`; who you muted is sensitive and its only
+reader is the owner (the indexer has zero mute consumers). Shape unchanged.
+
+## B9. LastRead
+`priv/social/v1/last_read.json`, microseconds (was the lone milliseconds outlier). Private.
+
+## B10. File (media), the v0 File + Blob pair collapsed
+v0: two objects, `files/{id}` metadata + `blobs/{hash}` bytes -> v1: ONE content-addressed media
+object `files/{hash}.{ext}`, the raw bytes.
+- `name` relocates to the attachment object (per-reference, so shared bytes can carry different
+  names). The declared MIME is consumed once at upload to pick the extension and is never stored;
+  size and served type come from the bytes and headers. Authoring time is the referencing post's id.
+- Deletes the `src` indirection, the two-PUT dance, and the metadata-per-blob ambiguity. Dual-root.
+- The extension comes from a frozen MIME-to-ext map (`.bin` fallback), path-only, never hashed.
+
+## B11. Feed
+v0 `pub/pubky.app/feeds/{HashId(serde-json config)}` (public) -> v1
+`{priv|pub}/social/v1/feeds/{id}.json`.
+- **Private by default, published by choice** (copy the same file to `/pub/`). Reader set is the
+  owner today; publishing is a deliberate act.
+- **Content-addressed id over a pinned config string** (not serde output, which is field-order
+  fragile and not JS-reproducible). Two users publishing the same config share an id, so future
+  cross-homeserver popularity ranking is additive indexer work.
+- All three enums gain `Unknown` (v0 hard-crashes old clients on any new reach/layout/sort value);
+  `name` gains a cap.
+
+## B12. Settings (new)
+v0: pubky-app's `pub/pubky.app/settings.json` was the only unspec'd homeserver artifact, world-readable
+while exposing the user's privacy posture (`require_pin`, `sign_out_inactive`) to a reader set of
+one. v1: `PubkySocialSettings` at `priv/social/v1/settings.json`, all sections optional, whole-file
+last-write-wins on a microsecond `updated_at`, the dead per-file `version` field dropped. Rewrites
+preserve unknown members via the catch-all map (B0), so an older client editing one field cannot
+destroy a section a newer client wrote; only the concurrent-edit race is lost, by LWW design.
+
+## B13. Parser and `Resource`
+v0 `url::Url`-based, hard-rejects any non-`pubky.app` app path, silently accepts userinfo/`..`/query
+-> v1 one closed grammar: `Foreign` and `UnsupportedVersion` are first-class handled categories
+(never errors), failed id validation yields `Unknown` (never a panic or error), wrong-root is
+unrepresentable. A future `social/v2` reads as "upgrade me," not garbage. The normative grammar
+is Appendix A; the reference crate and its committed conformance vectors are the executable form.
+
+## B14. IDs
+TimestampId (post and edit ids), HashId (tag/media/feed files, 128-bit), PubkyId (host/follow/mute), all
+under the canonical-encoding rule (B0). TimestampId gains a per-session monotonic mint guard (the
+JS runtime mints at ms resolution, so same-ms writes would clobber on path). No id function
+content-addresses a serialized struct, so the Rust/JS byte-identity surface is pure string/byte
+functions.
+
+# Part C: Migration
+
+- **Client-side, opt-in, resumable from the homeserver tree alone, permanent multi-epoch.** A
+  dormant user may migrate years later in one pass; the indexer dual-reads every epoch forever
+  (the permanent v0 parser stays, since the v1 parser classifies `pubky.app` as foreign).
+- **STRICTLY non-destructive.** Migration never deletes any legacy-epoch data. Privacy lost before
+  v1 is already lost; future activity is private. Private-tier legacy public copies are left inert
+  (the indexer stops surfacing them).
+- **Deterministic and total** over real v0 data: each record sources from its highest present
+  epoch, transforms compose in memory writing only the latest, resume is by destination existence,
+  ids/hashes are re-derived not minted.
+- **Deletion** is user-initiated only: deleting a public object (post, file) removes every copy
+  across epochs and both roots (else a surviving legacy copy resurrects on a from-scratch reindex);
+  private-tier deletes touch only the `/priv/` file. Absence is the tombstone: on a dumb blob
+  store the owner's files are the only durable state, so restoring an old backup republishes its
+  contents, accepted by design. Durable per-object tombstone files were considered and rejected
+  (the substrate cannot enforce them against the owner's own writes, and public tombstones would
+  leak deletion metadata forever).
+- The indexer contract: dedup on `(author, resource_type, stable_id)`, tag id-sets for cross-epoch
+  un-tagging, intrinsic-time ranking (decode the post id), tombstone only when no publicly visible
+  copy survives.
+
+# Part D: Rollout and subtasks
+
+Spec crate on a long-lived `v1` branch, one PR per task, CI green on every commit, version
+`1.0.0-alpha.N` until release. Each task is independently mergeable in this order.
+
+**Spine (serialized):**
+- [ ] **S1** rename crate + types (wire-invariant).
+- [ ] **S2** retire the wasm surface; native rlib; single-sourced DATA assets (limits, enum names).
+- [ ] **S3** forward-compat contract (`Unknown` on every wire enum).
+- [ ] **S4** validation core: limits table, canonical id validators, frozen text ops, mint guard.
+- [ ] **S5** path epoch + canonicalizers + parser (atomic).
+- [ ] **S6a** post wire shapes (kinds, embed, attachments, Article envelope, reserved literal).
+- [ ] **S6b** post storage, roots, lifecycle (versioned builders, root rule, publish/unpublish/delete).
+- [ ] **S7** tag + collection (canonical id inputs, reference-tier items).
+- [ ] **S8** media collapse (single bytes object, MIME map, parser ext-strip).
+- [ ] **S9** feed dual-root + user gates.
+- [ ] **S10** private tier + bookmarks + settings.
+- [ ] **S11** legacy_v0 module + cross-epoch normalization (`stable_id`/`resolve_deref`).
+
+**Pure-JS + gate:**
+- [ ] **J1** Rust conformance-vector generator (byte-identity + verdict tiers, fuzzed).
+- [ ] **J2** hand-written pure-JS package (ids, paths, canonicalizers, validation, builders).
+- [ ] **J3** merge-blocking differential CI gate.
+
+**Migrator:**
+- [ ] **M1** transform registry + v0 reader (Rust reference emits semantic vectors).
+- [ ] **M2** engine (epoch discovery, resume, source re-check, abort-if-no-`/priv/`).
+- [ ] **M3** pubky.app `/migrate` route (caps, upgrade flow, live counts, settings import).
+
+**Cross-repo:**
+- [ ] **pubky-nexus:** per-epoch classify/adapt/normalize, permanent v0 parser, tag id-sets,
+  intrinsic-time ranking, multi-epoch tombstones, bookmark-feature retirement, mixed-epoch resync.
+- [ ] **pubky-app:** v1 adoption (new caps, kind strings, own-tree legacy read union so
+  un-migrated users lose nothing, publish UI, media type threading, deletion engine).
+
+**Gates:**
+- [ ] **IN-PRIV** verify the target homeserver runs the `/priv/` tier and permits the write
+  paths. Prerequisite for M2 onward and for any private-tier go-live, not a late release check.
+- [ ] **REL** publish `1.0.0` (crate + npm), merge `v1` to main after nexus dual-read is live.
+
+**Dependencies** (beyond the serialized spine order above): S11 needs S5. J1 needs S5 and
+regenerates as later S tasks land; J2 needs J1; J3 needs J2 and is merge-blocking from then on.
+M1 needs S11; M2 needs M1 and IN-PRIV; M3 needs M2 and J2. Nexus dual-read must be live before
+any client writes v1 data; the pubky-app track needs J2 and that nexus gate. REL is last.
+
+**Acceptance, every task:** its listed artifact lands with the full CI bar green (fmt, clippy
+with warnings denied, tests, doctests, feature checks, regenerate-and-diff on committed data
+assets); from J3 on, additionally the Rust/JS differential gate.
+
+# Part E: Folds in and supersedes
+
+Supersedes the v1 roadmap #12. Resolves: #47 (json extensions), #48 (attachment type array),
+#55 (content hash, deferred to v1.x as a flat optional sibling with the shape pinned here), #120
+(short-form URIs), #141 (reject non-canonical URIs). Mention-prefix cleanup (`pk:`) is handled
+client-side and already shipped.
+
+No open design decisions remain; the destructive migration carve-out was considered and rejected
+in favor of strictly non-destructive migration (Part C).
+
+# Appendix A: the v1 URI grammar (normative)
+
+The reference crate's parser and its committed conformance vectors are the executable
+definition; this is the same grammar in human-readable form.
+
+## A1. URI forms and canonicalization
+
+Accepted input forms: `pubky://<host>[/<path>]` and the SDK short form `pubky<host>[/<path>]`
+(scheme prefix case-sensitive; `Pubky://` is invalid). The canonical output form is always
+`pubky://<host>[/<path>]`.
+
+Canonicalization is raw string work, byte-level, with no engine URL parser anywhere:
+
+- **Host:** exactly 52 z-base32 characters (lowercase alphabet `ybndrfg8ejkmcpqxot1uwisza345h769`),
+  final character `y` or `o` (the canonical-encoding rule: the trailing 4 pad bits must be zero).
+  A `@` or `:` anywhere in the host is invalid (no userinfo, no port).
+- **Path segments** (split on `/`): reject an empty segment (this covers trailing slashes and
+  `//`), `.`, `..`, and any segment containing `%`, `?`, `#`, an ASCII control character, or a
+  frozen-whitespace code point. There is NO percent-decoding, NO case folding, and NO segment
+  normalization: what is stored is what was written.
+- A bare host (`pubky://<host>`) is valid and canonical.
+
+Failures here, plus the root check in A2 step 1, are the only HARD errors (in both cases no
+resource with a visibility can be constructed); every other failure is a handled classification,
+never an error and never a panic.
+
+## A2. Classification
+
+After canonicalization, split the path into segments and classify:
+
+1. An empty path (a bare host) classifies as **User** (public): the URI references the user
+   themselves. Otherwise segment 0 must be `pub` or `priv` (it becomes the resource's
+   visibility); anything else is a hard error.
+2. Segment 1 not `social`: **Foreign** `{namespace, version?, rest}`. Foreign data is valid,
+   classified, and skipped by social readers; it is never an error.
+3. Segment 1 `social`, segment 2 matching `v[0-9]+` but not the supported epoch:
+   **UnsupportedVersion** (a reader's "upgrade me" signal).
+4. Segment 2 not an epoch segment: **Unknown**.
+5. Otherwise dispatch on the remaining segments per the table below. Any non-match, any failed
+   id validation, any wrong-root spelling of a single-root resource, and any `_`-prefixed leaf
+   (reserved client-private names) is **Unknown**.
+
+## A3. Resource dispatch (owner-relative paths under `{root}/social/v1/`)
+
+| Resource | Path remainder | Roots | Leaf rule |
+|---|---|---|---|
+| User | `profile.json` | pub | none |
+| Post (reference) | `posts/{id}` | both | `{id}` = canonical TimestampId |
+| Post (version) | `posts/{id}/{editId}.json` | both | both canonical TimestampIds |
+| File (media) | `files/{hash}.{ext}` | both | strip exactly one extension, case-sensitively, ONLY if it is in the frozen extension set; remainder = canonical HashId; unknown or absent extension is Unknown |
+| Tag | `tags/{id}.json` | pub | `{id}` = canonical HashId |
+| Follow | `follows/{pk}.json` | pub | `{pk}` = canonical host key (as A1) |
+| Mute | `mutes/{pk}.json` | priv | same |
+| Bookmark | `bookmarks/{filename}.json` | priv | FORM check only: every character in the base64url alphabet, or `~` followed by 26 canonical Crockford characters; full round-trip validation is the reader's job |
+| Feed | `feeds/{id}.json` | both | `{id}` = canonical HashId |
+| Settings | `settings.json` | priv | none |
+| LastRead | `last_read.json` | priv | none |
+
+`.json` stripping is exact and single: `follows/<pk>.json.json` leaves `<pk>.json`, which fails
+key validation and classifies Unknown.
+
+## A4. Canonical id encodings
+
+An id is valid iff re-encoding its decoded bytes reproduces the input. Closed form:
+
+- **TimestampId** (post/edit ids): 13 chars of uppercase Crockford base32
+  (`0123456789ABCDEFGHJKMNPQRSTVWXYZ`); final char in `{0,2,4,6,8,A,C,E,G,J,M,P,R,T,W,Y}`
+  (one trailing pad bit, must be zero). Lowercase and the alias letters `O/I/L/U` are invalid.
+- **HashId** (tag/media/feed ids): 26 chars, same alphabet; final char in `{0,4,8,C,G,M,R,W}`
+  (two pad bits).
+- **Host key**: as A1 (52 z-base32, final `y`/`o`).
+
+Time bounds are never checked at parse time; only canonicality is.
+
+## A5. Representative vectors
+
+`<pk>` is any valid host key, `TS` a canonical TimestampId, `H26` a canonical HashId.
+
+| Input | Result |
+|---|---|
+| `pubky<pk>/pub/social/v1/posts/TS` | Public Post reference (short form accepted) |
+| `pubky://<pk>/priv/social/v1/posts/TS/TS.json` | Private Post version |
+| `pubky://<pk>` | User (bare host) |
+| `pubky://<pk>/pub/social/v1/files/H26.svg` | Public File, id `H26` |
+| `pubky://<pk>/pub/social/v1/files/H26.JPG` | Unknown (extension set is case-sensitive) |
+| `pubky://<pk>/pub/social/v1/posts/ts-lowercase` | Unknown (non-canonical id) |
+| `pubky://<pk>/pub/social/v2/posts/TS` | UnsupportedVersion |
+| `pubky://<pk>/pub/pubky.app/posts/TS` | Foreign |
+| `pubky://<pk>/pub/social/v1/mutes/<pk>.json` | Unknown (mutes are priv-rooted) |
+| `Pubky://<pk>/pub/social/v1/profile.json` | hard error (scheme case) |
+| `pubky://user@<pk>/pub/social/v1/profile.json` | hard error (userinfo) |
+| `pubky://<pk>/pub/social/v1/posts/../profile.json` | hard error (dot-dot) |
+| `pubky://<pk>/dav/social/v1/profile.json` | hard error (unknown root) |

--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -17,25 +17,35 @@
 > - **tombstone**: the deletion marker readers act on; in v1, the absence of any public copy.
 > - **pinned / frozen**: committed as a closed-form rule or data asset; never tracks library or Unicode updates.
 
-The first stable and first breaking release of the shared social-data layer: shared means many
-applications read and write the same objects (posts, follows, tags), so the schema can belong to
-no single app. Renames the crate
-`pubky-app-specs` to `pubky-social-specs` (`1.0.0`) and moves all data from the single hard-coded
-app path `/pub/pubky.app/<res>` to a versioned, app-neutral epoch `/{pub|priv}/social/v1/<res>`
-(an epoch is the `vN` path segment; each epoch is a disjoint subtree holding one generation of
-data).
-**What this release promises, and what it does not.** This one coordinated break makes every
-now-or-never change that we are aware of at current time, those that cannot be added additively
-later. A permanent forward-compat contract then makes everything else additive **for the wire
-models**, so v1.x grows without breaking them.
+This is the first stable release of the shared social-data layer, and the first breaking one.
 
-The contract does not extend past the wire models. The path grammar and the id functions are
-outside it, and a future epoch (`social/v2`) stays reserved for exactly the changes no contract
-can make additive: re-pinning a text or id function (which re-ids existing data), changing a
-resource's root (its leading `pub` or `priv` segment) or per-kind content semantics, or breaking
-the path grammar. **This is not a claim that no epoch will ever follow v1**; it is a claim that
-v1.x will not need one, and that when one does come the path already carries the version signal
-that makes coexistence and migration work.
+Shared means many applications read and write the same objects: posts, follows, tags. So the
+schema cannot belong to any single app.
+
+Two things change. The crate `pubky-app-specs` becomes `pubky-social-specs` at `1.0.0`. All data
+moves from the hard-coded app path `/pub/pubky.app/<res>` to a versioned, app-neutral epoch at
+`/{pub|priv}/social/v1/<res>`.
+
+An epoch is the `vN` path segment. Each epoch is a disjoint subtree holding one generation of
+data, so two epochs can coexist without either one knowing about the other.
+
+**What this release promises, and what it does not.** This one coordinated break makes every
+now-or-never change we are aware of at current time, meaning the ones that cannot be added
+additively later. A permanent forward-compat contract then makes everything else additive **for
+the wire models**, so v1.x grows without breaking them.
+
+The contract stops at the wire models. The path grammar and the id functions sit outside it.
+
+A future epoch, `social/v2`, stays reserved for the changes no contract can make additive:
+
+- re-pinning a text or id function, which re-ids existing data
+- changing a resource's root, its leading `pub` or `priv` segment
+- changing per-kind content semantics
+- breaking the path grammar
+
+**This is not a claim that no epoch will ever follow v1.** It is a claim that v1.x will not need
+one, and that when one does come, the path already carries the version signal that makes
+coexistence and migration work.
 
 # Part A: Why break now
 
@@ -50,60 +60,89 @@ that makes coexistence and migration work.
 
 ## B0. Cross-cutting (applies to every model)
 
-- **Namespace + epoch: `pub/pubky.app/<res>` becomes `{pub|priv}/social/v1/<res>`.** App-neutral
-  (`pubky.app` wrongly signals one app owns shared data), versioned (the path is the only channel
-  that survives events + LIST + anonymous GET), and a bare word with no dot (a dotted directory
-  name like `pubky.app/` reads as an application bundle on macOS when a tree is exported to disk).
-  **Consequence, stated here rather than only under migration: deleting an object means deleting
-  it in every epoch that holds a copy.** Epochs are disjoint subtrees, so a surviving copy in an
-  older one is still publicly readable and a from-scratch reindex would resurrect it. For the
-  v0-to-v1 transition this is bounded, since the cleanup pass (Part C) removes v0 some weeks after
-  migration and leaves a single epoch again. It is not bounded in general: any future epoch
+- **Namespace and epoch: `pub/pubky.app/<res>` becomes `{pub|priv}/social/v1/<res>`.** Three
+  properties, one per part of the new path:
+
+  - `social` is app-neutral. `pubky.app` signals that one app owns shared data, which is false.
+  - `v1` is a version. The path is the only channel that survives the events feed, LIST and
+    anonymous GET, so a version anywhere else is invisible to most readers.
+  - `social` is a bare word with no dot. macOS treats a directory named `pubky.app/` as an
+    application bundle when a tree is exported to disk.
+
+  **This has a consequence for deletion, stated here rather than only under migration: deleting an
+  object means deleting it in every epoch that holds a copy.** Epochs are disjoint subtrees. A
+  surviving copy in an older epoch is still publicly readable, and a from-scratch reindex would
+  resurrect it.
+
+  For the v0-to-v1 transition the problem is bounded. The cleanup pass (Part C) removes v0 some
+  weeks after migration, leaving one epoch again. It is not bounded in general: any future epoch
   reintroduces it for as long as two epochs coexist, and this release does not solve that.
-- **Folder ownership (the composition law).** The specification that defines an object
-  determines its storage namespace, never the application that writes it. An app writing social
-  objects writes them under `social/vN`; its own objects live under its own namespace. Apps
-  therefore compose spec packages, each bringing its capability scopes and path builders (request
-  `/pub/social/v1/:rw` alongside your app scopes; use each package's builders for its paths).
+- **Folder ownership, the composition law.** The specification that defines an object determines
+  its storage namespace. The application that writes it does not.
+
+  So an app writing social objects writes them under `social/vN`, and its own objects live under
+  its own namespace. Apps compose spec packages, and each package brings its own capability scopes
+  and path builders: request `/pub/social/v1/:rw` alongside your app scopes, and use each
+  package's builders for its paths.
+
   **Apps SHOULD request the narrowest scope they use, not the whole namespace.** Capabilities are
-  path prefixes (a trailing-slash scope covers descendants, a slash-less one is exact-match), so an
-  app that only tags requests `/pub/social/v1/tags/:rw` and a consent screen can then say which
-  data is at stake. This does not bound what a granted app may do inside its scope: any write
-  capability over a directory is total there, which is unchanged from v0 and is a homeserver-level
-  concern (`pubky/pubky-homeserver#544`), not something this spec can enforce.
-  Consequence: tags are social objects, so the one canonical v1 write location is
-  `pub/social/v1/tags/`; indexers reading `tags/` directories inside other app namespaces is a
-  legacy read rule, not a v1 write model.
-- **App namespaces SHOULD carry an epoch too** (`pub/<app>/v1/...`). Nothing can be mandated for
-  foreign namespaces (no enforcement point exists), but the recommendation is free and buys an
-  app the same migration mechanics this spec built for itself: old and new data coexist in
-  disjoint subtrees, and the path is the only version signal that survives the events feed,
-  LIST, and anonymous GET. The parser already anticipates this: `Foreign` classification surfaces the segment after the
-  namespace verbatim. For an app following the convention, that segment IS its version, so an
+  path prefixes. A scope with a trailing slash covers everything below it; a scope without one is
+  exact-match. An app that only tags therefore requests `/pub/social/v1/tags/:rw`, and a consent
+  screen can say which data is at stake.
+
+  That narrows what an app can reach, not what it can do once inside. Any write capability over a
+  directory is total within it. This is unchanged from v0 and is a homeserver concern
+  (`pubky/pubky-homeserver#544`) rather than something this spec can enforce.
+
+  Tags follow from the law directly. A tag is a social object, so the one canonical v1 write
+  location is `pub/social/v1/tags/`. An indexer reading `tags/` directories inside other app
+  namespaces is applying a legacy read rule, not a v1 write model.
+- **App namespaces SHOULD carry an epoch too**, as `pub/<app>/v1/...`. Nothing here can be
+  mandated for a foreign namespace, because no enforcement point exists. The recommendation is
+  free, and it buys an app the same migration mechanics this spec built for itself: old and new
+  data coexist in disjoint subtrees, and the version survives the events feed, LIST and anonymous
+  GET.
+
+  The parser already anticipates it. A `Foreign` classification surfaces the segment after the
+  namespace verbatim, so for an app following the convention that segment is its version, and an
   indexer can version-route conforming app data with a single match.
-- **Namespace governance.** `social/vN` is owned by this repo: a resource type exists exactly
-  when the released crate parses it, and additions land as ordinary crate-minor PRs here (parser
-  arm + model + data assets + vectors in one change). Reserved: epoch segments `v[0-9]+`, the `_`
-  filename prefix, every current resource segment, and the `ext` member name; unknown segments
-  under `social/vN` parse as a handled `Resource::Unknown` (a valid classification readers
-  skip, never an error; distinct from the `Unknown` enum variant of the forward-compat contract
-  below), so additions never break deployed readers. A
-  new epoch (`social/v2`) is reserved for changes impossible additively (re-pinned text/id
-  functions, changed root or content semantics, grammar breaks). App namespaces are self-assigned
-  (reversed-domain form recommended: `app.locks`, `app.eventky`, not `locks.app`, for the same
-  reason the social segment is a bare word: a directory ending in `.app` is treated as an
-  application bundle by macOS when a tree is exported to disk); the parser classifies them
-  foreign, never invalid.
+- **Namespace governance.** This repo owns `social/vN`. A resource type exists exactly when the
+  released crate parses it, and additions land as ordinary crate-minor PRs here, with the parser
+  arm, the model, the data assets and the vectors in one change.
+
+  These are reserved:
+
+  - epoch segments matching `v[0-9]+`
+  - the `_` filename prefix
+  - every current resource segment
+  - the `ext` member name
+
+  An unknown segment under `social/vN` parses as `Resource::Unknown`. That is a valid
+  classification a reader skips, not an error, so additions never break deployed readers. It is a
+  different thing from the `Unknown` enum variant in the forward-compat contract below, which is
+  about values inside an object rather than segments in a path.
+
+  A new epoch (`social/v2`) is reserved for changes that cannot be made additively: re-pinned text
+  or id functions, a changed root, changed content semantics, or a grammar break.
+
+  App namespaces are self-assigned and the parser classifies them foreign, never invalid. Use the
+  reversed-domain form, `app.locks` and `app.eventky` rather than `locks.app`, for the same reason
+  the social segment is a bare word: macOS treats a directory ending in `.app` as an application
+  bundle when a tree is exported to disk.
 - **`.json` on every JSON leaf.** The homeserver derives the served type from magic bytes then the
   path extension; extensionless JSON serves as octet-stream/plaintext.
-- **A privacy tier `/priv/` (owner-only, excluded from `/events/`).** For state whose only
-  reader is the owner's own client; placement follows the ACTUAL reader set, not aspiration.
-  The leading path segment is the ROOT (`pub` or `priv`); the parser reports it as the
-  resource's visibility. The content family (posts, files, feeds) is dual-root: an object may
-  live under either root, and publish is a deterministic root migration. One rule here is
-  now-or-never, THE ROOT RULE: a public-rooted object must never reference a priv-root pubky
-  URI; private objects may reference both roots. (A public-to-private reference dangles for
-  every reader but the owner and leaks the path's existence through the 401-vs-404 oracle.)
+- **A privacy tier at `/priv/`**, owner-only and excluded from `/events/`. It holds state whose
+  only reader is the owner's own client. Placement follows the reader set a resource actually has,
+  not the one we would like it to have.
+
+  The leading path segment is the root, either `pub` or `priv`, and the parser reports it as the
+  resource's visibility. Posts, files and feeds are dual-root: each may live under either root,
+  and publishing is a deterministic move between them.
+
+  **The root rule is now-or-never: a public-rooted object must never reference a priv-root pubky
+  URI.** Private objects may reference both roots. A public-to-private reference dangles for every
+  reader except the owner, and it leaks the private path's existence through the difference
+  between a 401 and a 404.
   **Why the root sits inside a reference at all, since it makes references root-specific:** a
   pubky reference is also a fetch address, and the root is the segment that says who may read it.
   A root-less reference would need resolving against both roots, which costs the reader a probe
@@ -112,17 +151,25 @@ that makes coexistence and migration work.
   files, feeds), not only for feeds: the object is written under the other root and the original
   stays. The only reference that must change is a same-owner media URI inside a published object,
   where publish rewrites the `priv` prefix to `pub` (B2).
-  **Building on today's `/priv/` is deliberate, and a future rework of it is expected.** Private
-  data is closed-world: nothing public references it and the indexer never reads it, so moving it
-  to a different private mechanism later is a sweep over the owner's own files, not a
-  network-wide migration. That is what makes the private tier cheap to place now and expensive to
-  defer, and it is not true of anything public, which is where this release spends its care. If
-  the eventual mechanism is not client-side encrypted the homeserver could perform that move
-  itself; if it is, the same client-side migration machinery this release builds covers it.
-- **Scheme tiers (reference field values), distinct from the path grammar.** Appendix A governs PATHS
-  (where objects live); reference FIELD VALUES (parent, embed, targets, images) are validated by
-  per-field scheme tiers: pubky-only, pubky+web, or the universal tier (any scheme-shaped URI
-  via a pinned opaque gate: lowercased scheme, rest verbatim). Per-field tiers (each model section gives the rationale):
+  **Building on today's `/priv/` is deliberate, and a rework of it is expected.**
+
+  Private data is closed-world. Nothing public references it, and the indexer never reads it. So
+  moving it to a different private mechanism later is a sweep over the owner's own files rather
+  than a network-wide migration.
+
+  That asymmetry is why the private tier is cheap to place now and expensive to defer. It does not
+  hold for anything public, which is where this release spends its care.
+
+  If the eventual mechanism is not client-side encrypted, the homeserver could perform the move
+  itself. If it is, the client-side migration machinery this release builds already covers it.
+- **Scheme tiers, which govern reference values rather than paths.** Appendix A governs where
+  objects live. This governs what a reference field may contain: `parent`, `embed`, targets,
+  images.
+
+  Each field is assigned one of three tiers: pubky-only, pubky and web, or universal. The
+  universal tier accepts any scheme-shaped URI through a pinned opaque gate that lowercases the
+  scheme and keeps the rest verbatim. Appendix A5 is the normative statement of what each gate
+  accepts; each model section gives the rationale for its own field.
 
   | Field | Tier |
   |---|---|
@@ -135,49 +182,73 @@ that makes coexistence and migration work.
   | `attachments[].uri` | pubky+web |
   | `user.image`, `article.cover_image`, `collection.cover_image` | pubky+web |
   | `user.links[].url` | web-only |
-- **Forward-compat contract (permanent).** All wire enums (an enum as stored in JSON; "wire"
-  throughout means the stored byte form) are plain string enums (unit
-  variants, `rename_all` lowercase/snake_case), so `#[serde(other)] Unknown` plus
-  `#[non_exhaustive]` is well-defined; no model uses `deny_unknown_fields`; every future field is
-  optional + defaulted + skip-if-none. Degradation semantics are per-position: an `Unknown` in an
-  object's primary enum (`post.kind`) fails validation and readers skip the object; an `Unknown`
-  in a secondary enum (`feed.content`) degrades to "no constraint"; deserialization never crashes.
-  Unknown members are tolerated on read AND preserved on rewrite: every wire model carries an
-  opaque catch-all map (serde flatten: it absorbs every member the model does not declare), so a
-  client rewriting an object round-trips members it does not
-  understand instead of destroying another client's data (tolerating without preserving would let
-  any older client drop every field added after it shipped). Conformance vectors (committed input and expected-output files every implementation must
-  reproduce) cover both the unknown-value and the preservation behavior. Preservation fixes exactly one failure mode: a client deserializing into its own older types
-  and writing back, silently destroying fields it never modeled. It does not fix concurrency:
-  concurrent writers still clobber whole files under last-write-wins where that is the
-  documented rule. Two companion rules keep extensibility bounded. (1) TOTAL object size is
-  capped: 512 KiB for posts, 64 KiB for every other JSON resource, measured on stored bytes,
-  checked before parsing on read and after building on write. Unknown members made per-field
-  validation stop bounding size, and a total cap cannot be added later without a break, so it
-  ships now. (2) A conforming rewrite fetches the current object from the HOMESERVER, never
-  from an indexer view (views can be stale or partial; Part C2 rule 5). The caps cover JSON resources only
-  (media bytes keep their own media-size bound), and the wedge case is pinned: if a rewrite
-  cannot fit the cap while preserving unknown members, the writer fails the write and surfaces
-  it, never silently drops members; the user may explicitly discard extensions.
-  The indexer side:   unknown members are carried verbatim into object views, so any client can read an extension
-  through the shared index before the indexer understands it, but they are never validated,
-  queried, or indexed; queryability requires an adopted projection (the indexer explicitly promoting the member into
-  its queryable schema). The extension ladder:
-  readable (carried) -> queryable (projection) -> validated (spec field). Deliberate extensions
-  SHOULD nest under the reserved `ext` member (`"ext": {"badge": {...}}`), one greppable home
-  whose meaning is pinned once: everything under `ext` is third-party data the base spec never
-  validates; treat it as hostile input (escape before rendering, validate against the
-  extension's own rules before interpreting; Part C2 rules 8 and 9).
-- **Canonical-encoding id rule.** An id is valid if and only if re-encoding its decoded bytes reproduces the
-  input (closed-form final-char check). v0 accepted dozens of alias spellings per id (lowercase,
-  `O`->`0`, dangling bits), each a distinct homeserver key; that leniency is removed.
-- **Engine-free validation.** `url::Url` (normalizes junk into acceptance), the `mime` crate, and
-  full-Unicode case/trim are replaced by pinned rules (a strict raw-string canonicalizer, a
-  frozen whitespace table (a committed code-point list that never tracks Unicode updates),
-  ASCII-only label folding, code-point lengths) that a Rust and a
-  hand-written JS implementation reproduce byte-for-byte.
-- **No silent sanitize-rewrites.** v0 rewrote `[DELETED]` names to "anonymous" and
-  truncated-then-blanked over-long inputs; v1 makes invalid input a validation error.
+- **Forward-compat contract, permanent.** Three mechanisms let v1.x grow without breaking a
+  deployed reader, and two rules keep that growth bounded.
+
+  **Unknown enum values never crash a reader.** Every wire enum is a plain string enum with unit
+  variants and `rename_all`, so `#[serde(other)] Unknown` plus `#[non_exhaustive]` is well
+  defined. No model uses `deny_unknown_fields`, and every future field is optional, defaulted and
+  skip-if-none. What happens on an unknown value depends on where it sits:
+
+  - in an object's primary enum, such as `post.kind`, validation fails and the reader skips that
+    object
+  - in a secondary enum, such as `feed.content`, it degrades to "no constraint"
+
+  Deserialization itself never fails.
+
+  **Unknown members are preserved on rewrite, not merely tolerated on read.** Every wire model
+  carries an opaque catch-all map, a serde flatten that absorbs any member the model does not
+  declare. A client rewriting an object round-trips members it does not understand instead of
+  destroying another client's data. Tolerating without preserving would let any older client drop
+  every field added after it shipped.
+
+  Preservation fixes exactly one failure: a client deserializing into its own older types and
+  writing back, silently destroying fields it never modeled. It does not fix concurrency.
+  Concurrent writers still clobber whole files under last-write-wins wherever that is the
+  documented rule.
+
+  **Conformance vectors cover both behaviours.** These are committed input and expected-output
+  files that every implementation must reproduce.
+
+  Two rules bound the growth. The first: **total object size is capped**, at 512 KiB for posts and
+  64 KiB for every other JSON resource, measured on stored bytes, checked before parsing on read
+  and after building on write. Unknown members stopped per-field validation from bounding size,
+  and a total cap cannot be added later without a break, so it ships now. The caps cover JSON
+  resources only; media bytes keep their own size bound.
+
+  The second: **a conforming rewrite fetches the current object from the homeserver**, never from
+  an indexer view, because a view can be stale or partial (Part C2 rule 5).
+
+  One wedge case is pinned. If a rewrite cannot fit the cap while preserving unknown members, the
+  writer fails the write and surfaces it. It never silently drops members. The user may then
+  explicitly discard extensions.
+
+  **On the indexer side**, unknown members are carried verbatim into object views, so any client
+  can read an extension through the shared index before the indexer understands it. They are
+  never validated, queried or indexed. Queryability requires an adopted projection, meaning the
+  indexer explicitly promoting the member into its queryable schema. That gives an extension three
+  stages: readable when carried, queryable when projected, validated when it becomes a spec field.
+
+  **Deliberate extensions SHOULD nest under the reserved `ext` member**, as `"ext": {"badge":
+  {...}}`. It is one greppable home whose meaning is pinned once: everything under `ext` is
+  third-party data the base spec never validates. Treat it as hostile input, so escape before
+  rendering and validate against the extension's own rules before interpreting (Part C2 rules 8
+  and 9).
+
+- **Canonical-encoding id rule.** An id is valid if and only if re-encoding its decoded bytes
+  reproduces the input exactly. The check is closed-form, on the final character.
+
+  v0 accepted dozens of alias spellings for one id: lowercase, `O` for `0`, dangling bits. Each
+  alias was a distinct key on the homeserver. That leniency is removed.
+- **Engine-free validation.** Three dependencies leave the normative surface: `url::Url`, which
+  normalizes junk into acceptance; the `mime` crate; and full-Unicode case and trim operations.
+
+  Pinned rules replace them: a strict raw-string canonicalizer, a frozen whitespace table,
+  ASCII-only label folding, and code-point lengths. A frozen table is a committed list of code
+  points that never tracks Unicode updates. The Rust crate and the hand-written JS package
+  reproduce all of it byte-for-byte.
+- **No silent sanitize-rewrites.** v0 rewrote `[DELETED]` names to "anonymous", and it truncated
+  over-long input and then blanked it. In v1 invalid input is a validation error.
 
 A migrated user's tree at a glance (`<pk>` a host key, `TS` a TimestampId, `H26` a HashId):
 
@@ -382,75 +453,110 @@ functions.
 
 # Part C: Migration
 
-- **Client-side, opt-in, resumable from the homeserver tree alone, permanent multi-epoch.** A
-  dormant user may migrate years later in one pass; the indexer dual-reads every epoch forever
-  (the permanent v0 parser stays, since the v1 parser classifies `pubky.app` as foreign).
-  **"Forever" is cheaper than it reads, on two counts.** The v0 parser is FROZEN, not maintained:
-  it ships with committed conformance vectors and never changes again, so the recurring cost is
-  running its tests rather than tracking anything. And the v0 population drains rather than
-  accumulates, because the cleanup pass removes v0 a few weeks after each user migrates. What
-  remains years out is dormant accounts that have not been opened since, which is precisely the
-  population opt-in migration exists to serve and precisely the one a cutoff date would strand.
-  A staged upgrade tool ("your data is too old, run this first") remains available as a later
-  option if the maintenance ever proves real; it is additive and needs no decision now.
-- **STRICTLY non-destructive.** Migration never deletes any legacy-epoch data. Privacy lost before
-  v1 is already lost; future activity is private. Private-tier legacy public copies are left inert
-  (the indexer stops surfacing them). Copying rather than moving buys three things: clients still
-  on v0 keep working, a bad migration is recoverable because the source survives, and a good one
-  can be verified against its source before anything is discarded.
-- **It therefore roughly doubles a user's stored social data**, against a homeserver that enforces
-  a per-user quota. Raising the quota is a prerequisite for the migrator going live, not a
-  follow-up (release gate `QUOTA`).
-- **Legacy cleanup is a separate, later, user-confirmed pass**, never part of migration itself.
-  It ships once the migrator has run clean on real data, asks the user before removing anything,
-  and deletes a legacy object only after verifying its v1 counterpart exists and parses. The delay
-  is the point: it puts distance between "did the migration work" and "throw away the original",
-  and it gives anything still reading v0 paths a window to move.
-  **This applies to v0 only, and it is one-time.** v0 was never published as a stable target, so
-  removing it breaks no promise. From v1 onward the rule is the opposite: migration to a future
-  epoch never deletes the epoch it came from, because that epoch was promised stable.
-- **Deterministic and total** over real v0 data: each record sources from its highest present
-  epoch, transforms compose in memory writing only the latest, ids/hashes are re-derived not
-  minted.
-- **Resume compares source against destination**, never merely the destination's existence.
-  Existence proves bytes landed, not that they are correct or current, so an existence check
-  cannot distinguish a good file from one a buggy run wrote, and skips it forever. Comparison
-  also picks up a source edited after it was migrated, which an existence check silently drops.
-  Supporting machinery: a client-private `_migrated` marker records the transform revision, so a
-  shipped migrator fix triggers a re-run; a malformed object is skipped and reported rather than
-  blocking the tree; and the homeserver's quota error is surfaced as a typed failure.
-- **Known failure mode: post-migration writes from a legacy client are not visible.** Once a
-  record exists in both epochs the indexer serves the highest one it understands, so a v0 client
-  editing an already-migrated record writes successfully to a path that still exists and no reader
-  ever sees the change. Nothing errors. Comparison-based resume recovers it on the next run, which
-  narrows the window without closing it; the legacy cleanup pass closes it for good, because a
-  removed epoch has nothing left to write to.
-- **Deletion spans epochs, and that rule is NOT migration-scoped** (Part C2, rules 11 to 13): a
-  migrated post lives at BOTH `pub/pubky.app/posts/{id}` and `pub/social/v1/posts/{id}/...`, so
-  deleting a public object removes every copy in every epoch and both roots, or a from-scratch
-  reindex resurrects it from the missed legacy copy. Absence is the tombstone: on a dumb blob
-  store the owner's files are the only durable state, so restoring an old backup republishes its
-  contents, accepted by design. Durable per-object tombstone files were considered and rejected
-  (the substrate cannot enforce them against the owner's own writes, and public tombstones would
-  leak deletion metadata forever).
-- The indexer contract: dedup on `(author, resource_type, stable_id)`, tag id-sets (each tag edge keeps the set of ids asserting it across epochs, so un-tagging
-  removes all of them), intrinsic-time ranking (decode the post id), tombstone only when no publicly visible
-  copy survives.
+Migration is client-side, opt-in, and resumable from the homeserver tree alone. A dormant user may
+migrate years later in one pass, and the indexer reads every epoch for as long as any exist. The v0
+parser therefore stays permanently, because the v1 parser classifies `pubky.app` as foreign.
+
+**"Permanently" is cheaper than it sounds, on two counts.** The v0 parser is frozen rather than
+maintained: it ships with committed conformance vectors and never changes again, so the recurring
+cost is running its tests. And the v0 population drains rather than accumulates, because the
+cleanup pass below removes v0 a few weeks after each user migrates.
+
+What remains years out is dormant accounts nobody has opened since. That is precisely the
+population opt-in migration exists to serve, and precisely the one a cutoff date would strand. A
+staged upgrade tool, telling a user their data is too old and to run something first, stays
+available as a later option if the maintenance ever proves real. It is additive and needs no
+decision now.
+
+## Migration itself never deletes
+
+Migration copies. It never removes legacy-epoch data, and privacy lost before v1 is already lost,
+so the copies it leaves behind change nothing about what was already public. Legacy public copies
+of now-private types are left inert, and the indexer stops surfacing them.
+
+Copying rather than moving buys three things:
+
+- clients still on v0 keep working
+- a bad migration is recoverable, because the source survives
+- a good one can be verified against its source before anything is discarded
+
+**It therefore roughly doubles a user's stored social data**, against a homeserver that enforces a
+per-user quota. Raising that quota is a prerequisite for the migrator going live rather than a
+follow-up. It is release gate `QUOTA`.
+
+## Legacy cleanup is a separate, later pass
+
+Cleanup is never part of migration. It ships once the migrator has run clean on real data, it asks
+the user before removing anything, and it deletes a legacy object only after verifying that the v1
+counterpart exists and parses.
+
+The delay is the point. It puts distance between "did the migration work" and "throw away the
+original", and it gives anything still reading v0 paths a window to move.
+
+**This applies to v0 only, and it happens once.** v0 was never published as a stable target, so
+removing it breaks no promise. From v1 onward the rule is the opposite: migrating to a future epoch
+never deletes the epoch it came from, because that epoch was promised stable.
+
+## Determinism and resume
+
+Migration is deterministic and total over real v0 data. Each record sources from its highest
+present epoch, transforms compose in memory and write only the latest result, and ids and hashes
+are re-derived rather than minted.
+
+**Resume compares source against destination, never merely the destination's existence.** Existence
+proves that bytes landed. It does not prove they are correct, or current. So an existence check
+cannot tell a good file from one a buggy run wrote, and skips it forever. Comparison also picks up
+a source edited after it was migrated, which an existence check drops silently.
+
+Three supporting mechanisms:
+
+- a client-private `_migrated` marker records the transform revision, so a shipped migrator fix
+  triggers a re-run
+- a malformed object is skipped and reported rather than blocking the tree
+- the homeserver's quota error surfaces as a typed failure
+
+## Known failure mode: writes from a legacy client go unseen
+
+Once a record exists in both epochs, the indexer serves the highest one it understands. So a v0
+client editing an already-migrated record writes successfully, to a path that still exists, and no
+reader ever sees the change. Nothing errors.
+
+Comparison-based resume recovers it on the next run, which narrows the window without closing it.
+The cleanup pass closes it for good, because a removed epoch has nothing left to write to.
+
+## Deletion spans epochs, and that rule is not migration-scoped
+
+See Part C2, rules 11 to 13. A migrated post lives at both `pub/pubky.app/posts/{id}` and
+`pub/social/v1/posts/{id}/...`, so deleting a public object removes every copy, in every epoch and
+both roots. Leave one behind and a from-scratch reindex resurrects it.
+
+Absence is the tombstone. On a dumb blob store the owner's files are the only durable state, so
+restoring an old backup republishes its contents. That is accepted by design.
+
+Durable per-object tombstone files were considered and rejected. The substrate cannot enforce them
+against the owner's own writes, and public tombstones would leak deletion metadata forever.
+
+## The indexer contract
+
+- dedup on `(author, resource_type, stable_id)`
+- tag id-sets: each tag edge keeps the set of ids asserting it across epochs, so un-tagging removes
+  all of them
+- intrinsic-time ranking, by decoding the post id
+- tombstone only when no publicly visible copy survives
 
 # Part C2: Client conformance
 
-Everything above defines what a VALID OBJECT is, and almost all of it is enforced by the shipped
-artifacts: the crate and the JS package carry the types, the validators, the builders and the size
-checks, so a conforming implementation cannot produce an invalid object even by accident. Of the
-normative statements in this document, roughly 106 are of that kind.
+Everything above defines what a valid object is, and almost all of it is enforced by the shipped
+artifacts. The crate and the JS package carry the types, the validators, the builders and the size
+checks. A conforming implementation cannot produce an invalid object even by accident.
 
-This section collects the exception: rules a pure-function library CANNOT enforce, because they
-need I/O, ordering, or state the library never sees. They bind clients, they are normative, and
-they are gathered here rather than scattered so an implementer has one checklist. The model
-sections above reference this section rather than restating it.
+This section collects the exception: rules a pure-function library cannot enforce, because they
+need I/O, ordering, or state the library never sees. They bind clients and they are normative.
+They are gathered here rather than scattered so an implementer has one checklist, and the model
+sections above reference this section instead of restating it.
 
-A separate class, rules addressed to the shared indexer, is marked inline in Part B and Part C as
-"the indexer contract"; those bind nexus, not clients.
+Rules addressed to the shared indexer are a separate class, marked inline in Part B and Part C as
+the indexer contract. Those bind nexus, not clients.
 
 ## Read behaviour
 
@@ -466,12 +572,12 @@ A separate class, rules addressed to the shared indexer, is marked inline in Par
 
 ## Write behaviour, read-modify-write
 
-5. **Read the current object from the HOMESERVER before rewriting it, never from an indexer
-   view.** Indexer views can be stale or partial, and writing back from one destroys whatever the
+5. **Read the current object from the homeserver before rewriting it, never from an indexer
+   view.** An indexer view can be stale or partial. Writing back from one destroys whatever the
    view omitted.
 6. **GET a tag address before PUTting it.** Tag addresses converge by construction, so a blind PUT
    destroys another app's enrichment of the same statement. Preservation protects
-   read-modify-write; it cannot protect write-without-read.
+   read-modify-write. It cannot protect a write that never read.
 7. **Fail loudly when the size cap and preservation conflict.** If a rewrite cannot fit the cap
    while preserving unknown members, the writer FAILS the write and surfaces it. It never
    silently drops members. The user MAY then explicitly discard extensions.
@@ -489,13 +595,14 @@ A separate class, rules addressed to the shared indexer, is marked inline in Par
     validation and the ordered plan; the client performs the writes (B11).
 11. **Deletion is user-initiated only.** Nothing in this spec deletes an object on a user's behalf.
 12. **Deleting a public object removes every copy, in every epoch and both roots.** A migrated post
-    exists at both its legacy and its `social/v1` path; leaving either one behind means a
-    from-scratch reindex resurrects it. This is a PERMANENT client rule, not a migration-only one:
-    it applies for as long as two epochs coexist.
+    exists at both its legacy path and its `social/v1` path. Leave either behind and a
+    from-scratch reindex resurrects it. This is a permanent client rule rather than a
+    migration-only one, and it applies for as long as two epochs coexist.
 13. **Private-tier deletes touch only the `/priv/` file.**
 14. **Un-migrated users must keep reading their own legacy tree.** A client that has adopted v1
     reads the union of v1 and legacy paths for its own user, so opting out of migration costs the
-    user nothing. Stated here because it is normative client behaviour, not a rollout task.
+    user nothing. It is stated here because it is normative client behaviour rather than a
+    rollout task.
 
 ## Presentation
 
@@ -509,9 +616,8 @@ A separate class, rules addressed to the shared indexer, is marked inline in Par
 
 ## What is NOT in this section
 
-Migration conformance is Part C, and the reviewer's carve-out for it stands: those rules bind a
-migrating client for the duration of a migration. Rule 12 is the one that looks like migration and
-is not, which is why it moved here.
+Migration conformance is Part C. Those rules bind a migrating client for the duration of a
+migration. Rule 12 is the one that looks like migration and is not, which is why it moved here.
 
 # Part D: Rollout and subtasks
 

--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -102,11 +102,13 @@ v0 `pub/pubky.app/posts/{id}` (one flat file, overwritten on edit) -> v1
   `posts/{id}` file and a `posts/{id}/` directory are mutually exclusive on the homeserver.
 - **Kinds renamed** `short`->`note`, `long`->`article` (nature, not length); all seven kinds kept.
 - **`embed`** flattened from `{uri, kind}` to a plain URI string (kind is derivable from the
-  target), and it accepts external http/https targets: quoting a map location or an article is
-  first-class, and the indexer attaches the post to the same External Resource nodes it builds
+  target), and it accepts ANY external URI, the same universal tier as tags: http/https through
+  the strict web gate, and any other scheme-shaped identifier (`nostr:`, `geo:`, `ipfs:`,
+  `did:`, OSM object URLs) through a pinned opaque gate (lowercased scheme + rest verbatim, no
+  engine parsing). The indexer attaches the post to the same External Resource nodes it builds
   for external tag targets. `parent` stays pubky-only (a reply is a social-graph edge with
-  thread semantics that exist only between posts). This also keeps migration total: v0 accepted
-  arbitrary embed URLs, so real v0 posts can carry them.
+  thread semantics that exist only between posts). This also keeps migration total: v0's
+  `Url::parse` accepted arbitrary schemes, so real v0 data can carry them.
 - **`attachments`** become `Vec<{uri, alt?, name?}>`, always `[]` never null. Objects, not strings,
   so per-item metadata (alt text now; hash/blurhash later) is additive; ships two committed fields.
 - **`lock`** kept: the value is the lock-FILE URI (`pub/locks.app/<lock_id>.json`), and presence
@@ -131,8 +133,10 @@ list may include foreign resources). Private collections come free from the dual
 label (v0 used engine `to_lowercase` and `url::Url` normalization, neither reproducible across
 implementations; content-addressed ids must freeze their input functions). Injectivity holds only
 because the label rejects `:`. One write location, any target: every app writes tags at the
-author's `pub/social/v1/tags/`, and the target may be any public resource (social objects, other
-apps' objects, external URIs). A logical tag therefore has exactly one possible address:
+author's `pub/social/v1/tags/`, and the target may be any public resource: social objects, other
+apps' objects, or ANY external URI (http/https via the strict web gate; other schemes, `nostr:`,
+`geo:`, `ipfs:`, `did:`, via a pinned opaque gate that lowercases the scheme and keeps the rest
+verbatim). v0 accepted these via `Url::parse`, so this also keeps migration total. A logical tag therefore has exactly one possible address:
 re-tagging self-overwrites idempotently, apps on the same account converge on the same file, and
 the indexer reads one namespace with no writing-app dimension (reading `tags/` directories in
 other app namespaces survives only as a legacy rule; migrating those files is the owning app's

--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -72,7 +72,10 @@ or `priv` segment) or per-kind content semantics, or breaking the path grammar.
   below), so additions never break deployed readers. A
   new epoch (`social/v2`) is reserved for changes impossible additively (re-pinned text/id
   functions, changed root or content semantics, grammar breaks). App namespaces are self-assigned
-  (domain-style names recommended); the parser classifies them foreign, never invalid.
+  (reversed-domain form recommended: `app.locks`, `app.eventky`, not `locks.app`, for the same
+  reason the social segment is a bare word: a directory ending in `.app` is treated as an
+  application bundle by macOS when a tree is exported to disk); the parser classifies them
+  foreign, never invalid.
 - **`.json` on every JSON leaf.** The homeserver derives the served type from magic bytes then the
   path extension; extensionless JSON serves as octet-stream/plaintext.
 - **A privacy tier `/priv/` (owner-only, excluded from `/events/`).** For state whose only
@@ -195,7 +198,7 @@ v0 `pub/pubky.app/posts/{id}` (one flat file, overwritten on edit) -> v1
   migrate): v0's `Url::parse` accepted arbitrary schemes, so real v0 data can carry them.
 - **`attachments`** become `Vec<{uri, alt?, name?}>`, always `[]` never null. Objects, not strings,
   so per-item metadata (alt text now; hash/blurhash later) is additive; ships two committed fields.
-- **`lock`** kept: the value is the lock-FILE URI (`pub/locks.app/<lock_id>.json`), and presence
+- **`lock`** kept: the value is the lock-FILE URI (`pub/app.locks/<lock_id>.json`, illustrative), and presence
   means "locked content" regardless of kind (matches the Locks feature's resolved design).
 - **Dual-root:** posts may live under `/priv/` (drafts, private notes, private collections).
 - **The post is a reusable envelope (adopted from review).** The crate exports the shared

--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -57,7 +57,16 @@ the path grammar.
 - **`.json` on every JSON leaf.** The homeserver derives the served type from magic bytes then the
   path extension; extensionless JSON serves as octet-stream/plaintext.
 - **A privacy tier `/priv/` (owner-only, excluded from `/events/`).** For state whose only reader
-  is the owner's own client. The placement test is the actual reader set, not aspiration.
+  is the owner's own client. The placement test is the actual reader set, not aspiration. The
+  content family (posts, files, feeds) is dual-root: publish is a deterministic root migration,
+  and THE ROOT RULE is now-or-never: a public-rooted object must never reference a priv-root
+  pubky URI (such a reference dangles for every reader but the owner and leaks path existence
+  through the 401-vs-404 oracle); private objects may reference both roots.
+- **Reference tiers (field values), distinct from the path grammar.** Appendix A governs PATHS
+  (where objects live); reference FIELD VALUES (parent, embed, targets, images) are validated by
+  per-field scheme tiers: pubky-only, pubky+web, or the universal tier (any scheme-shaped URI
+  via a pinned opaque gate: lowercased scheme, rest verbatim). Each model section names its
+  fields' tiers.
 - **Forward-compat contract (permanent).** All wire enums are plain string enums (unit
   variants, `rename_all` lowercase/snake_case), so `#[serde(other)] Unknown` plus
   `#[non_exhaustive]` is well-defined; no model uses `deny_unknown_fields`; every future field is
@@ -89,7 +98,9 @@ v0 `pub/pubky.app/profile.json` -> v1 `pub/social/v1/profile.json`.
   removed with NO replacement rule; `[DELETED]` is an ordinary legal name. **Required nexus
   upgrade (gates v1 indexing):** the indexer currently keys deletion on that literal; it must key
   on a real flag (`deleted` on the indexed row / UserView) before indexing any v1 data. How a
-  deleted account is displayed then becomes pure client presentation.
+  deleted account is displayed then becomes pure client presentation (the indexer may
+  transitionally keep emitting the old literal at its view layer for old clients; storage and
+  query logic never key on it).
 - Fields and caps otherwise unchanged; profile stays public (identity must be readable).
 
 ## B2. Post
@@ -103,9 +114,9 @@ v0 `pub/pubky.app/posts/{id}` (one flat file, overwritten on edit) -> v1
 - **Kinds renamed** `short`->`note`, `long`->`article` (nature, not length); all seven kinds kept.
 - **`embed`** flattened from `{uri, kind}` to a plain URI string (kind is derivable from the
   target), and it accepts ANY external URI, the same universal tier as tags: http/https through
-  the strict web gate, and any other scheme-shaped identifier (`nostr:`, `geo:`, `ipfs:`,
-  `did:`, OSM object URLs) through a pinned opaque gate (lowercased scheme + rest verbatim, no
-  engine parsing). The indexer attaches the post to the same External Resource nodes it builds
+  the strict web gate (an OSM object URL is an ordinary https reference), and any other
+  scheme-shaped identifier (`nostr:`, `geo:`, `ipfs:`, `did:`) through a pinned opaque gate
+  (lowercased scheme + rest verbatim, no engine parsing). The indexer attaches the post to the same External Resource nodes it builds
   for external tag targets. `parent` stays pubky-only (a reply is a social-graph edge with
   thread semantics that exist only between posts). This also keeps migration total: v0's
   `Url::parse` accepted arbitrary schemes, so real v0 data can carry them.
@@ -156,8 +167,10 @@ statement (preservation protects read-modify-write, not write-without-read).
 ## B6. Bookmark
 v0 `pub/pubky.app/bookmarks/{HashId(uri)}` (public, one-way filename, GET-per-file) -> v1
 `priv/social/v1/bookmarks/{filename}.json`.
-- **Private** (reader set is the owner).
-- **Target in the filename, reversibly.** Primary form: `base64url(canonical target)` for
+- **Private** (reader set is the owner). Targets take the universal tier: any public pubky
+  resource or any external URI, same domain as tags.
+- **Target in the filename, reversibly.** Primary form: unpadded `base64url(canonical target)`
+  (no `=`; the parser's form check accepts alphabet characters only) for
   targets up to 187 bytes. The math: 187 bytes encode to 250 base64url characters, and 250 +
   `.json` (5) = 255, the homeserver's per-segment maximum, so 187 is the largest cap ANY
   reversible encoding allows (base64url is the densest standard encoding that is also `/`- and
@@ -255,8 +268,10 @@ Spec crate on a long-lived `v1` branch, one PR per task, CI green on every commi
 - [ ] **S3** forward-compat contract (`Unknown` on every wire enum).
 - [ ] **S4** validation core: limits table, canonical id validators, frozen text ops, mint guard.
 - [ ] **S5** path epoch + canonicalizers + parser (atomic).
-- [ ] **S6a** post wire shapes (kinds, embed, attachments, Article envelope, reserved literal).
-- [ ] **S6b** post storage, roots, lifecycle (versioned builders, root rule, publish/unpublish/delete).
+- [ ] **S6a** post wire shapes on the generic envelope (`PostEnvelope<K>` + kind trait + social
+  alias; kinds, embed, attachments, Article envelope).
+- [ ] **S6b** post storage, roots, lifecycle on the envelope, namespace-parameterized (versioned
+  builders, root rule, publish/unpublish/delete).
 - [ ] **S7** tag + collection (canonical id inputs, reference-tier items).
 - [ ] **S8** media collapse (single bytes object, MIME map, parser ext-strip).
 - [ ] **S9** feed dual-root + user gates.
@@ -274,7 +289,8 @@ Spec crate on a long-lived `v1` branch, one PR per task, CI green on every commi
 - [ ] **M3** pubky.app `/migrate` route (caps, upgrade flow, live counts, settings import).
 
 **Cross-repo:**
-- [ ] **pubky-nexus:** per-epoch classify/adapt/normalize, permanent v0 parser, tag id-sets,
+- [ ] **pubky-nexus:** per-epoch classify/adapt/normalize, permanent v0 parser, the deletion
+  flag (deletion keyed on real state, never name/content literals; gates v1 indexing), tag id-sets,
   intrinsic-time ranking, multi-epoch tombstones, bookmark-feature retirement, mixed-epoch resync.
 - [ ] **pubky-app:** v1 adoption (new caps, kind strings, own-tree legacy read union so
   un-migrated users lose nothing, publish UI, media type threading, deletion engine).
@@ -307,7 +323,9 @@ in favor of strictly non-destructive migration (Part C).
 # Appendix A: the v1 URI grammar (normative)
 
 The reference crate's parser and its committed conformance vectors are the executable
-definition; this is the same grammar in human-readable form.
+definition; this is the same grammar in human-readable form. Scope: this appendix governs PATHS
+(where objects live and how path URIs classify); reference FIELD VALUES inside objects go
+through the per-field scheme tiers described in Part B, not this grammar.
 
 ## A1. URI forms and canonicalization
 

--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -125,7 +125,12 @@ list may include foreign resources). Private collections come free from the dual
 `tags/{id}.json`. Id hashed over the canonicalized target plus a frozen-trimmed, ASCII-folded
 label (v0 used engine `to_lowercase` and `url::Url` normalization, neither reproducible across
 implementations; content-addressed ids must freeze their input functions). Injectivity holds only
-because the label rejects `:`.
+because the label rejects `:`. One write location, any target: every app writes tags at the
+author's `pub/social/v1/tags/`, and the target may be any public resource (social objects, other
+apps' objects, external URIs). A logical tag therefore has exactly one possible address:
+re-tagging self-overwrites idempotently, apps on the same account converge on the same file, and
+the indexer reads one namespace with no writing-app dimension (reading `tags/` directories in
+other app namespaces survives only as a legacy rule).
 
 ## B6. Bookmark
 v0 `pub/pubky.app/bookmarks/{HashId(uri)}` (public, one-way filename, GET-per-file) -> v1

--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -79,7 +79,16 @@ the path grammar.
   any older client drop every field added after it shipped). Conformance vectors cover both the
   unknown-value and the preservation behavior. Preservation fixes typed-rewrite data loss, not
   concurrency: concurrent writers still clobber whole-file under last-write-wins where that is
-  the documented rule.
+  the documented rule. Two companion rules keep extensibility bounded and coherent: TOTAL object
+  size is capped (posts 512 KiB, every other JSON resource 64 KiB, measured on stored bytes,
+  checked before parsing on read and after building on write), because per-field validation
+  stopped bounding size the moment unknown members became legal, and a total cap cannot be added
+  later without a break; and a conforming rewrite fetches the current object from the
+  HOMESERVER, never from an indexer view (views can be stale or partial). The indexer side:
+  unknown members are carried verbatim into object views, so any client can read an extension
+  through the shared index before the indexer understands it, but they are never validated,
+  queried, or indexed; queryability requires an adopted projection. The extension ladder:
+  readable (carried) -> queryable (projection) -> validated (spec field).
 - **Canonical-encoding id rule.** An id is valid iff re-encoding its decoded bytes reproduces the
   input (closed-form final-char check). v0 accepted dozens of alias spellings per id (lowercase,
   `O`->`0`, dangling bits), each a distinct homeserver key; that leniency is removed.

--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -39,6 +39,13 @@ the path grammar.
   Consequence: tags are social objects, so the one canonical v1 write location is
   `pub/social/v1/tags/`; indexers reading `tags/` directories inside other app namespaces is a
   legacy read rule, not a v1 write model.
+- **App namespaces SHOULD carry an epoch too** (`pub/<app>/v1/...`). Nothing can be mandated for
+  foreign namespaces (no enforcement point exists), but the recommendation is free and buys an
+  app the same migration mechanics this spec built for itself: old and new data coexist in
+  disjoint subtrees, and the path is the only version signal that survives the events feed,
+  LIST, and anonymous GET. The parser already anticipates this: `Foreign` classification
+  extracts the version whenever the segment after the namespace matches `v[0-9]+`, so indexers
+  version-route conforming app data with zero extra work.
 - **Namespace governance.** `social/vN` is owned by this repo: a resource type exists exactly
   when the released crate parses it, and additions land as ordinary crate-minor PRs here (parser
   arm + model + data assets + vectors in one change). Reserved: epoch segments `v[0-9]+`, the `_`

--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -17,7 +17,9 @@
 > - **tombstone**: the deletion marker readers act on; in v1, the absence of any public copy.
 > - **pinned / frozen**: committed as a closed-form rule or data asset; never tracks library or Unicode updates.
 
-The first stable and first breaking release of the shared social-data layer. Renames the crate
+The first stable and first breaking release of the shared social-data layer: shared means many
+applications read and write the same objects (posts, follows, tags), so the schema can belong to
+no single app. Renames the crate
 `pubky-app-specs` to `pubky-social-specs` (`1.0.0`) and moves all data from the single hard-coded
 app path `/pub/pubky.app/<res>` to a versioned, app-neutral epoch `/{pub|priv}/social/v1/<res>`
 (an epoch is the `vN` path segment; each epoch is a disjoint subtree holding one generation of
@@ -130,7 +132,7 @@ or `priv` segment) or per-kind content semantics, or breaking the path grammar.
   whose meaning is pinned once: everything under `ext` is third-party data the base spec never
   validates; treat it as hostile input (escape before rendering, validate against the
   extension's own rules before interpreting).
-- **Canonical-encoding id rule.** An id is valid iff re-encoding its decoded bytes reproduces the
+- **Canonical-encoding id rule.** An id is valid if and only if re-encoding its decoded bytes reproduces the
   input (closed-form final-char check). v0 accepted dozens of alias spellings per id (lowercase,
   `O`->`0`, dangling bits), each a distinct homeserver key; that leniency is removed.
 - **Engine-free validation.** `url::Url` (normalizes junk into acceptance), the `mime` crate, and
@@ -465,7 +467,7 @@ key validation and classifies Unknown.
 
 ## A4. Canonical id encodings
 
-An id is valid iff re-encoding its decoded bytes reproduces the input. Closed form:
+An id is valid if and only if re-encoding its decoded bytes reproduces the input. Closed form:
 
 - **TimestampId** (post/edit ids): 13 chars of uppercase Crockford base32
   (`0123456789ABCDEFGHJKMNPQRSTVWXYZ`); final char in `{0,2,4,6,8,A,C,E,G,J,M,P,R,T,W,Y}`

--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -47,6 +47,27 @@ A future epoch, `social/v2`, stays reserved for the changes no contract can make
 one, and that when one does come, the path already carries the version signal that makes
 coexistence and migration work.
 
+**What a third-party reader can rely on.** The promise above is what an outside integrator
+integrates against, so it is worth stating from their side. It is the same promise for every
+resource; no resource gets a second, stabler address than the one the epoch already gives it.
+
+- A path under `social/v1/` keeps its shape for the life of v1. The shape may grow optional
+  fields; it never removes one, retypes one, or changes what one means.
+- A reader must ignore fields it does not know. That is the reader's half of the contract, and a
+  reader that rejects unknown fields breaks on the next additive release rather than on ours.
+- A shape change needs a different path. `social/v2` is a disjoint subtree, so it never overwrites
+  `social/v1`, and a reader pinned to the v1 path never receives a shape it did not agree to.
+
+**The limit, stated plainly.** When a later epoch exists, the v1 copy survives, because migrating
+away from a promised-stable epoch never deletes it. It stops being current, though, from the
+moment the owner's client starts writing v2. A reader that needs current data resolves the highest
+epoch it understands and falls back, which is the rule the indexer follows (Part C). A reader that
+only ever wants a shape it already parses can stay pinned to v1 and accept that it may be reading
+a snapshot.
+
+None of this covers `pub/pubky.app/`. v0 was never published as a stable target, and the cleanup
+pass removes it once the owner agrees (Part C).
+
 # Part A: Why break now
 
 - `pub/pubky.app/` hard-codes one app's domain as the home of shared data and the parser rejects
@@ -95,8 +116,15 @@ coexistence and migration work.
   (`pubky/pubky-homeserver#544`) rather than something this spec can enforce.
 
   Tags follow from the law directly. A tag is a social object, so the one canonical v1 write
-  location is `pub/social/v1/tags/`. An indexer reading `tags/` directories inside other app
-  namespaces is applying a legacy read rule, not a v1 write model.
+  location is `pub/social/v1/tags/`. **Write a tag there and any conforming indexer counts it.**
+  That guarantee is what the write location buys an app author, and it is the reason the location
+  is fixed rather than advisory.
+
+  What an indexer additionally chooses to read is its own policy. This spec neither requires nor
+  forbids an indexer ingesting social objects it finds in other namespaces; that decision belongs
+  to the indexer, and the same applies to any other resource type. What the spec does not do is
+  promise on the indexer's behalf: an app writing social objects outside `social/vN` has no
+  guarantee that anyone indexes them.
 - **App namespaces SHOULD carry an epoch too**, as `pub/<app>/v1/...`. Nothing here can be
   mandated for a foreign namespace, because no enforcement point exists. The recommendation is
   free, and it buys an app the same migration mechanics this spec built for itself: old and new
@@ -278,6 +306,8 @@ v0 `pub/pubky.app/profile.json` -> v1 `pub/social/v1/profile.json`.
   transitionally keep emitting the old literal at its view layer for old clients; storage and
   query logic never key on it).
 - Fields and caps otherwise unchanged; profile stays public (identity must be readable).
+- Third-party readers: profile is the resource outside apps integrate against most, and it carries
+  the ordinary v1 stability promise, no more and no less (B0).
 
 ## B2. Post
 v0 `pub/pubky.app/posts/{id}` (one flat file, overwritten on edit) -> v1
@@ -314,9 +344,12 @@ v0 `pub/pubky.app/posts/{id}` (one flat file, overwritten on edit) -> v1
   (closed kind set, wire bytes unchanged). App specs specialize it with their own kinds in their
   own namespaces (a Mapky review, an Eventky event), where social readers classify them as
   foreign data. The envelope fixes reference semantics uniformly (a reply edge means the same
-  thing everywhere); the specialization owns its kind vocabulary and content validation. This
-  makes the incubation path usable at launch: a schema proves itself in an app namespace before
-  being proposed for `social/vN`.
+  thing everywhere); the specialization owns its kind vocabulary and content validation.
+
+  The envelope is a library convenience, not a governance mechanism. This spec defines no process
+  for admitting a foreign kind into `social/vN`, and it does not need one: additions here are
+  ordinary crate-minor PRs, and a kind this spec has not defined simply lives in its own namespace
+  where readers classify it as foreign and skip it.
 - The `[DELETED]` content sentinel dies with no replacement (same flag rule as B1); absence is
   the tombstone (the deletion marker readers act on), synthesized by the indexer from real
   deletion state, never from content strings.

--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -101,7 +101,12 @@ v0 `pub/pubky.app/posts/{id}` (one flat file, overwritten on edit) -> v1
   rejected (races across devices on a substrate with no compare-and-swap). Now-or-never: a
   `posts/{id}` file and a `posts/{id}/` directory are mutually exclusive on the homeserver.
 - **Kinds renamed** `short`->`note`, `long`->`article` (nature, not length); all seven kinds kept.
-- **`embed`** flattened from `{uri, kind}` to a plain URI string (kind is derivable from the target).
+- **`embed`** flattened from `{uri, kind}` to a plain URI string (kind is derivable from the
+  target), and it accepts external http/https targets: quoting a map location or an article is
+  first-class, and the indexer attaches the post to the same External Resource nodes it builds
+  for external tag targets. `parent` stays pubky-only (a reply is a social-graph edge with
+  thread semantics that exist only between posts). This also keeps migration total: v0 accepted
+  arbitrary embed URLs, so real v0 posts can carry them.
 - **`attachments`** become `Vec<{uri, alt?, name?}>`, always `[]` never null. Objects, not strings,
   so per-item metadata (alt text now; hash/blurhash later) is additive; ships two committed fields.
 - **`lock`** kept: the value is the lock-FILE URI (`pub/locks.app/<lock_id>.json`), and presence

--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -88,7 +88,11 @@ the path grammar.
   unknown members are carried verbatim into object views, so any client can read an extension
   through the shared index before the indexer understands it, but they are never validated,
   queried, or indexed; queryability requires an adopted projection. The extension ladder:
-  readable (carried) -> queryable (projection) -> validated (spec field).
+  readable (carried) -> queryable (projection) -> validated (spec field). Deliberate extensions
+  SHOULD nest under the reserved `ext` member (`"ext": {"badge": {...}}`), one greppable home
+  whose meaning is pinned once: everything under `ext` is third-party data the base spec never
+  validates; treat it as hostile input (escape before rendering, validate against the
+  extension's own rules before interpreting).
 - **Canonical-encoding id rule.** An id is valid iff re-encoding its decoded bytes reproduces the
   input (closed-form final-char check). v0 accepted dozens of alias spellings per id (lowercase,
   `O`->`0`, dangling bits), each a distinct homeserver key; that leniency is removed.

--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -70,14 +70,17 @@ the path grammar.
 v0 `pub/pubky.app/profile.json` -> v1 `pub/social/v1/profile.json`.
 - `image` accepts pubky/http/https via one shared image validator (cap 300). pubky-app avatars are
   pubky file URIs; an http-only rule would reject every real avatar.
-- The `[DELETED]` -> "anonymous" name rewrite is removed; the exact literal `[DELETED]` is now a
-  rejected reserved value (the indexer keys tombstones on it, so a user literally named `[DELETED]`
-  must not be storable).
+- The `[DELETED]` magic string dies entirely: v0's silent `[DELETED]` -> "anonymous" rewrite is
+  removed with NO replacement rule; `[DELETED]` is an ordinary legal name. **Required nexus
+  upgrade (gates v1 indexing):** the indexer currently keys deletion on that literal; it must key
+  on a real flag (`deleted` on the indexed row / UserView) before indexing any v1 data. How a
+  deleted account is displayed then becomes pure client presentation.
 - Fields and caps otherwise unchanged; profile stays public (identity must be readable).
 
 ## B2. Post
 v0 `pub/pubky.app/posts/{id}` (one flat file, overwritten on edit) -> v1
-`{pub|priv}/social/v1/posts/{id}/{editId}.json`, referenced versionlessly as `posts/{id}`.
+`{pub|priv}/social/v1/posts/{id}/{editId}.json`, referenced versionlessly as `posts/{id}`;
+`{id}` and `{editId}` are both canonical TimestampIds (Appendix A3, A4).
 - **Per-edit path versioning.** Each edit is a new file; the first version reuses the post id;
   references use the versionless form so edits never orphan replies or re-key tags. A counter was
   rejected (races across devices on a substrate with no compare-and-swap). Now-or-never: a
@@ -89,7 +92,8 @@ v0 `pub/pubky.app/posts/{id}` (one flat file, overwritten on edit) -> v1
 - **`lock`** kept: the value is the lock-FILE URI (`pub/locks.app/<lock_id>.json`), and presence
   means "locked content" regardless of kind (matches the Locks feature's resolved design).
 - **Dual-root:** posts may live under `/priv/` (drafts, private notes, private collections).
-- The `[DELETED]` content sentinel becomes a rejected reserved value; absence is the tombstone.
+- The `[DELETED]` content sentinel dies with no replacement (same flag rule as B1); absence is
+  the tombstone, synthesized by the indexer from real deletion state, never from content strings.
 
 ## B3. ArticleContent (new)
 v0: pubky-app hand-rolls `{title, body}` JSON inside `long` posts, unspecified, cover smuggled as
@@ -112,11 +116,13 @@ because the label rejects `:`.
 v0 `pub/pubky.app/bookmarks/{HashId(uri)}` (public, one-way filename, GET-per-file) -> v1
 `priv/social/v1/bookmarks/{filename}.json`.
 - **Private** (reader set is the owner).
-- **Target in the filename, reversibly:** `base64url(canonical target)` up to 187 bytes (the exact
-  substrate maximum), plus a `~ + HashId` overflow form (target in content) for longer targets.
-  Listing bookmarks costs zero GETs for primary-form entries (the overwhelming majority); each
-  overflow entry costs one GET to recover its target. base64url is the only standard encoding that fits the
-  255-char segment at that cap and is `/`-, `%`-free and JS-decodable.
+- **Target in the filename, reversibly.** Primary form: `base64url(canonical target)` for
+  targets up to 187 bytes. The math: 187 bytes encode to 250 base64url characters, and 250 +
+  `.json` (5) = 255, the homeserver's per-segment maximum, so 187 is the largest cap ANY
+  reversible encoding allows (base64url is the densest standard encoding that is also `/`- and
+  `%`-free and natively JS-decodable). Longer targets use the overflow form `~ + HashId(target)`
+  with the target kept in content. Listing costs zero GETs for primary-form entries (the
+  overwhelming majority); each overflow entry costs one GET to recover its target.
 - Content shrinks to `{created_at}` (plus `target` only in overflow).
 
 ## B7. Follow
@@ -184,7 +190,10 @@ functions.
   epoch, transforms compose in memory writing only the latest, resume is by destination existence,
   ids/hashes are re-derived not minted.
 - **Deletion** is user-initiated only: deleting a public object (post, file) removes every copy
-  across epochs and both roots (else a surviving legacy copy resurrects on a from-scratch reindex);
+  across epochs and both roots. Cross-epoch copies exist because migration copies and never
+  deletes: a migrated post lives at BOTH `pub/pubky.app/posts/{id}` and
+  `pub/social/v1/posts/{id}/...`, and a delete that missed the legacy copy would resurrect the
+  post on a from-scratch reindex;
   private-tier deletes touch only the `/priv/` file. Absence is the tombstone: on a dumb blob
   store the owner's files are the only durable state, so restoring an old backup republishes its
   contents, accepted by design. Durable per-object tombstone files were considered and rejected

--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -228,6 +228,7 @@ Spec crate on a long-lived `v1` branch, one PR per task, CI green on every commi
   intrinsic-time ranking, multi-epoch tombstones, bookmark-feature retirement, mixed-epoch resync.
 - [ ] **pubky-app:** v1 adoption (new caps, kind strings, own-tree legacy read union so
   un-migrated users lose nothing, publish UI, media type threading, deletion engine).
+  - [ ] **moderation:** mixed epoch support by both nexus and homeserver syncronization services as well as by checkstep-request services
 
 **Gates:**
 - [ ] **IN-PRIV** verify the target homeserver runs the `/priv/` tier and permits the write

--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -84,7 +84,11 @@ the path grammar.
   checked before parsing on read and after building on write), because per-field validation
   stopped bounding size the moment unknown members became legal, and a total cap cannot be added
   later without a break; and a conforming rewrite fetches the current object from the
-  HOMESERVER, never from an indexer view (views can be stale or partial). The indexer side:
+  HOMESERVER, never from an indexer view (views can be stale or partial). The caps cover JSON resources only
+  (media bytes keep their own media-size bound), and the wedge case is pinned: if a rewrite
+  cannot fit the cap while preserving unknown members, the writer fails the write and surfaces
+  it, never silently drops members; the user may explicitly discard extensions. The indexer
+  side:
   unknown members are carried verbatim into object views, so any client can read an extension
   through the shared index before the indexer understands it, but they are never validated,
   queried, or indexed; queryability requires an adopted projection. The extension ladder:
@@ -181,7 +185,10 @@ statement (preservation protects read-modify-write, not write-without-read).
 v0 `pub/pubky.app/bookmarks/{HashId(uri)}` (public, one-way filename, GET-per-file) -> v1
 `priv/social/v1/bookmarks/{filename}.json`.
 - **Private** (reader set is the owner). Targets take the universal tier: any public pubky
-  resource or any external URI, same domain as tags.
+  resource or any external URI, same domain as tags. Honest cost, for review: going private
+  retires the indexer's bookmark-derived public features, including collection-follows
+  (following a collection was modeled as a bookmark on it); an explicit follow/subscribe
+  resource is the deferred replacement candidate.
 - **Target in the filename, reversibly.** Primary form: unpadded `base64url(canonical target)`
   (no `=`; the parser's form check accepts alphabet characters only) for
   targets up to 187 bytes. The math: 187 bytes encode to 250 base64url characters, and 250 +
@@ -307,7 +314,7 @@ Spec crate on a long-lived `v1` branch, one PR per task, CI green on every commi
   intrinsic-time ranking, multi-epoch tombstones, bookmark-feature retirement, mixed-epoch resync.
 - [ ] **pubky-app:** v1 adoption (new caps, kind strings, own-tree legacy read union so
   un-migrated users lose nothing, publish UI, media type threading, deletion engine).
-  - [ ] **moderation:** mixed epoch support by both nexus and homeserver syncronization services as well as by checkstep-request services
+  - [ ] **moderation:** mixed epoch support by both nexus and homeserver synchronization services as well as by checkstep-request services
 
 **Gates:**
 - [ ] **IN-PRIV** verify the target homeserver runs the `/priv/` tier and permits the write

--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -24,12 +24,18 @@ no single app. Renames the crate
 app path `/pub/pubky.app/<res>` to a versioned, app-neutral epoch `/{pub|priv}/social/v1/<res>`
 (an epoch is the `vN` path segment; each epoch is a disjoint subtree holding one generation of
 data).
-The strategy has three parts. First, this one coordinated break makes every now-or-never
-change, those that cannot be added additively later. Second, a permanent forward-compat contract
-makes everything else additive, so v1.x grows without breaking. Third, a future epoch
-(`social/v2`) stays reserved for the few changes no contract can make additive: re-pinning a
-text or id function (which re-ids existing data), changing a resource's root (its leading `pub`
-or `priv` segment) or per-kind content semantics, or breaking the path grammar.
+**What this release promises, and what it does not.** This one coordinated break makes every
+now-or-never change that we are aware of at current time, those that cannot be added additively
+later. A permanent forward-compat contract then makes everything else additive **for the wire
+models**, so v1.x grows without breaking them.
+
+The contract does not extend past the wire models. The path grammar and the id functions are
+outside it, and a future epoch (`social/v2`) stays reserved for exactly the changes no contract
+can make additive: re-pinning a text or id function (which re-ids existing data), changing a
+resource's root (its leading `pub` or `priv` segment) or per-kind content semantics, or breaking
+the path grammar. **This is not a claim that no epoch will ever follow v1**; it is a claim that
+v1.x will not need one, and that when one does come the path already carries the version signal
+that makes coexistence and migration work.
 
 # Part A: Why break now
 
@@ -48,11 +54,23 @@ or `priv` segment) or per-kind content semantics, or breaking the path grammar.
   (`pubky.app` wrongly signals one app owns shared data), versioned (the path is the only channel
   that survives events + LIST + anonymous GET), and a bare word with no dot (a dotted directory
   name like `pubky.app/` reads as an application bundle on macOS when a tree is exported to disk).
+  **Consequence, stated here rather than only under migration: deleting an object means deleting
+  it in every epoch that holds a copy.** Epochs are disjoint subtrees, so a surviving copy in an
+  older one is still publicly readable and a from-scratch reindex would resurrect it. For the
+  v0-to-v1 transition this is bounded, since the cleanup pass (Part C) removes v0 some weeks after
+  migration and leaves a single epoch again. It is not bounded in general: any future epoch
+  reintroduces it for as long as two epochs coexist, and this release does not solve that.
 - **Folder ownership (the composition law).** The specification that defines an object
   determines its storage namespace, never the application that writes it. An app writing social
   objects writes them under `social/vN`; its own objects live under its own namespace. Apps
   therefore compose spec packages, each bringing its capability scopes and path builders (request
   `/pub/social/v1/:rw` alongside your app scopes; use each package's builders for its paths).
+  **Apps SHOULD request the narrowest scope they use, not the whole namespace.** Capabilities are
+  path prefixes (a trailing-slash scope covers descendants, a slash-less one is exact-match), so an
+  app that only tags requests `/pub/social/v1/tags/:rw` and a consent screen can then say which
+  data is at stake. This does not bound what a granted app may do inside its scope: any write
+  capability over a directory is total there, which is unchanged from v0 and is a homeserver-level
+  concern (`pubky/pubky-homeserver#544`), not something this spec can enforce.
   Consequence: tags are social objects, so the one canonical v1 write location is
   `pub/social/v1/tags/`; indexers reading `tags/` directories inside other app namespaces is a
   legacy read rule, not a v1 write model.
@@ -86,6 +104,21 @@ or `priv` segment) or per-kind content semantics, or breaking the path grammar.
   now-or-never, THE ROOT RULE: a public-rooted object must never reference a priv-root pubky
   URI; private objects may reference both roots. (A public-to-private reference dangles for
   every reader but the owner and leaks the path's existence through the 401-vs-404 oracle.)
+  **Why the root sits inside a reference at all, since it makes references root-specific:** a
+  pubky reference is also a fetch address, and the root is the segment that says who may read it.
+  A root-less reference would need resolving against both roots, which costs the reader a probe
+  and costs validation the ability to reject a public-to-private reference statically.
+  **Publish is a copy, not a move, and that is the rule for the whole content family** (posts,
+  files, feeds), not only for feeds: the object is written under the other root and the original
+  stays. The only reference that must change is a same-owner media URI inside a published object,
+  where publish rewrites the `priv` prefix to `pub` (B2).
+  **Building on today's `/priv/` is deliberate, and a future rework of it is expected.** Private
+  data is closed-world: nothing public references it and the indexer never reads it, so moving it
+  to a different private mechanism later is a sweep over the owner's own files, not a
+  network-wide migration. That is what makes the private tier cheap to place now and expensive to
+  defer, and it is not true of anything public, which is where this release spends its care. If
+  the eventual mechanism is not client-side encrypted the homeserver could perform that move
+  itself; if it is, the same client-side migration machinery this release builds covers it.
 - **Scheme tiers (reference field values), distinct from the path grammar.** Appendix A governs PATHS
   (where objects live); reference FIELD VALUES (parent, embed, targets, images) are validated by
   per-field scheme tiers: pubky-only, pubky+web, or the universal tier (any scheme-shaped URI
@@ -96,7 +129,7 @@ or `priv` segment) or per-kind content semantics, or breaking the path grammar.
   | `post.parent` | pubky-only |
   | `post.embed` | universal |
   | `post.lock` | pubky-only |
-  | `collection.items[]` | pubky-only |
+  | `collection.items[].uri` | universal |
   | tag target | universal |
   | bookmark target | universal |
   | `attachments[].uri` | pubky+web |
@@ -122,7 +155,7 @@ or `priv` segment) or per-kind content semantics, or breaking the path grammar.
   checked before parsing on read and after building on write. Unknown members made per-field
   validation stop bounding size, and a total cap cannot be added later without a break, so it
   ships now. (2) A conforming rewrite fetches the current object from the HOMESERVER, never
-  from an indexer view (views can be stale or partial). The caps cover JSON resources only
+  from an indexer view (views can be stale or partial; Part C2 rule 5). The caps cover JSON resources only
   (media bytes keep their own media-size bound), and the wedge case is pinned: if a rewrite
   cannot fit the cap while preserving unknown members, the writer fails the write and surfaces
   it, never silently drops members; the user may explicitly discard extensions.
@@ -134,7 +167,7 @@ or `priv` segment) or per-kind content semantics, or breaking the path grammar.
   SHOULD nest under the reserved `ext` member (`"ext": {"badge": {...}}`), one greppable home
   whose meaning is pinned once: everything under `ext` is third-party data the base spec never
   validates; treat it as hostile input (escape before rendering, validate against the
-  extension's own rules before interpreting).
+  extension's own rules before interpreting; Part C2 rules 8 and 9).
 - **Canonical-encoding id rule.** An id is valid if and only if re-encoding its decoded bytes reproduces the
   input (closed-form final-char check). v0 accepted dozens of alias spellings per id (lowercase,
   `O`->`0`, dangling bits), each a distinct homeserver key; that leniency is removed.
@@ -162,8 +195,6 @@ A migrated user's tree at a glance (`<pk>` a host key, `TS` a TimestampId, `H26`
           bookmarks/<b64u>.json   target readable from the filename
           mutes/<pk3>.json
           feeds/H26.json
-          settings.json
-          last_read.json
 
 ## B1. User (profile)
 v0 `pub/pubky.app/profile.json` -> v1 `pub/social/v1/profile.json`.
@@ -172,7 +203,7 @@ v0 `pub/pubky.app/profile.json` -> v1 `pub/social/v1/profile.json`.
 - The `[DELETED]` magic string dies entirely: v0's silent `[DELETED]` -> "anonymous" rewrite is
   removed with NO replacement rule; `[DELETED]` is an ordinary legal name. **Required upgrade in nexus, the shared indexer (gates v1 indexing):** the indexer currently keys deletion on that literal; it must key
   on a real flag (`deleted` on the indexed row / UserView) before indexing any v1 data. How a
-  deleted account is displayed then becomes pure client presentation (the indexer may
+  deleted account is displayed then becomes pure client presentation (Part C2 rule 15; the indexer may
   transitionally keep emitting the old literal at its view layer for old clients; storage and
   query logic never key on it).
 - Fields and caps otherwise unchanged; profile stays public (identity must be readable).
@@ -201,6 +232,11 @@ v0 `pub/pubky.app/posts/{id}` (one flat file, overwritten on edit) -> v1
 - **`lock`** kept: the value is the lock-FILE URI (`pub/app.locks/<lock_id>.json`, illustrative), and presence
   means "locked content" regardless of kind (matches the Locks feature's resolved design).
 - **Dual-root:** posts may live under `/priv/` (drafts, private notes, private collections).
+  Publishing copies the post to `/pub/` and **rewrites the `priv` prefix to `pub` on same-owner
+  media references only** (`attachments[].uri` and a content envelope's `cover_image`), because a
+  private draft's image must itself be private or it leaks before the post does. Any OTHER
+  reference still pointing at a priv URI fails the root rule at publish: publish the referenced
+  object first, or remove the reference. Cross-owner priv references are invalid outright.
 - **The post is a reusable envelope (adopted from review).** The crate exports the shared
   mechanics, versioned storage, ids, parent/embed/attachments/lock, preservation, path helpers,
   as a generic layer (`PostEnvelope<K>`), with the social post as its first specialization
@@ -222,9 +258,19 @@ v0: pubky-app hand-rolls `{title, body}` JSON inside `long` posts, unspecified, 
 Articles may carry parent/embed/attachments (an article can be a reply or carry media).
 
 ## B4. CollectionContent
-Shape unchanged (`{name, description?, items[], cover_image?}`). `items` now accept any
-pubky URI (any resource, any app; the pubky-only scheme tier of B0), not just `posts/` under `pubky.app` (a curated
-list may include foreign resources). Private collections come free from the dual-root post family.
+`{name, description?, items[], cover_image?}`, with two changes to `items`.
+
+**`items` join the universal tier.** Any scheme-shaped URI, the same gate as tags, bookmarks and
+`post.embed` (A5), not just `posts/` under `pubky.app` and not just pubky URIs. A curated list of
+OSM locations or `nostr:` events is a collection of those things, not a collection of posts about
+them, and collections were the last reference field still narrowed to pubky-only.
+
+**`items` become objects, `{uri, note?}`, not bare strings.** Same move `attachments` makes in B2
+and for the same reason: per-item metadata is additive once the item is an object and a wire break
+afterwards, so the cheap shape now is the one that forecloses. `note` is the one committed field;
+anything further is additive under the forward-compat contract.
+
+Private collections come free from the dual-root post family.
 
 ## B5. Tag
 `tags/{id}.json`. Id = `HashId("{target}:{label}")`, the target canonicalized, the label
@@ -239,7 +285,7 @@ verbatim). v0 accepted these via `Url::parse`, so this also keeps migration tota
 re-tagging self-overwrites idempotently, apps on the same account converge on the same file, and
 the indexer reads one namespace with no writing-app dimension (reading `tags/` directories in
 other app namespaces survives only as a legacy rule; migrating those files is the owning app's
-job). Because addresses converge, a tag writer SHOULD GET the address first and preserve unknown
+job). Because addresses converge (Part C2 rule 6), a tag writer SHOULD GET the address first and preserve unknown
 members if a file exists: a blind PUT would destroy another app's enrichment of the same
 statement (preservation protects read-modify-write, not write-without-read).
 
@@ -269,8 +315,19 @@ changes apply; the filename-is-target pattern (one LIST answers "who do I follow
 `priv/social/v1/mutes/{muteePk}.json`. Moves to `/priv/`; who you muted is sensitive and its only
 reader is the owner (the indexer has zero mute consumers). Shape unchanged.
 
-## B9. LastRead
-`priv/social/v1/last_read.json`, microseconds (was the lone milliseconds outlier). Private.
+## B9. LastRead, and B12. Settings: both leave this spec
+v0 kept `last_read` and `settings.json` under `pub/pubky.app/`, world-readable. Neither is social
+data, so neither lands in `social/v1`: they move to the writing app's own namespace
+(`priv/app.pubky/v1/` for pubky-app) and out of this library entirely, model definition included.
+
+The placement test is normally the ACTUAL reader set. Device state like `require_pin` fails it
+outright. But `language` PASSES it, and still leaves, so a second test outranks the first: **whose
+specification defines the object.** Preferences general to any application are not social data
+however portable they are, and this spec does not own them. Whoever writes an object owns its
+schema unless a shared spec claims it.
+
+Accepted cost: a second social client starts your unread count from scratch. Migration still
+carries the v0 values into the new location (M3), so no user loses settings.
 
 ## B10. File (media), the v0 File + Blob pair collapsed
 v0: two objects, `files/{id}` metadata + `blobs/{hash}` bytes -> v1: ONE content-addressed media
@@ -279,6 +336,11 @@ object `files/{hash}.{ext}`, the raw bytes.
   names). The declared MIME is consumed once at upload to pick the extension and is never stored;
   size and served type come from the bytes and headers. Authoring time is the referencing post's id.
 - Deletes the `src` indirection, the two-PUT dance, and the metadata-per-blob ambiguity. Dual-root.
+- **Media is immutable by identity.** The path IS the content hash, so changing the bytes produces
+  a different object at a different path and every referrer must be repointed. v0's `files/{id}`
+  was a mutable pointer to `blobs/{hash}`, letting bytes be swapped under a stable reference; v1
+  drops that indirection deliberately. In practice "editing an image" is uploading a different
+  image, and the referencing post is edited too, which is cheap under per-edit versioning.
 - The extension comes from a frozen MIME-to-ext map (`.bin` fallback), path-only, never hashed.
 
 ## B11. Feed
@@ -286,6 +348,12 @@ v0 `pub/pubky.app/feeds/{HashId(serde-json config)}` (public) -> v1
 `{priv|pub}/social/v1/feeds/{id}.json`.
 - **Private by default, published by choice** (copy the same file to `/pub/`). Reader set is the
   owner today; publishing is a deliberate act.
+- **What the crate provides, and what the caller does.** The crate performs no I/O: it exposes the
+  path builders, the validation, and the ordered plan of operations for publish, unpublish and
+  delete. The caller executes that plan against the homeserver. This is the same shape the
+  migrator engine uses, where all I/O goes through an injected client. The boundary is also the
+  general one: the artifact enforces the model, the client is responsible for conformance
+  behaviour that a pure function cannot observe.
 - **Content-addressed id over a pinned config string** (not serde output, which is field-order
   fragile and not JS-reproducible). Six fixed segments: reach, layout, sort, content filter,
   tags, and domain tags. Two users publishing the same config share an id, so future
@@ -295,14 +363,6 @@ v0 `pub/pubky.app/feeds/{HashId(serde-json config)}` (public) -> v1
   participates in the id (two feeds differing only in domain filter are different feeds).
 - All three enums gain `Unknown` (v0 hard-crashes old clients on any new reach/layout/sort value);
   `name` gains a cap.
-
-## B12. Settings (new)
-v0: pubky-app's `pub/pubky.app/settings.json` was the only unspec'd homeserver artifact, world-readable
-while exposing the user's privacy posture (`require_pin`, `sign_out_inactive`) to a reader set of
-one. v1: `PubkySocialSettings` at `priv/social/v1/settings.json`, all sections optional, whole-file
-last-write-wins on a microsecond `updated_at`, the dead per-file `version` field dropped. Rewrites
-preserve unknown members via the catch-all map (B0), so an older client editing one field cannot
-destroy a section a newer client wrote; only the concurrent-edit race is lost, by last-write-wins design.
 
 ## B13. Parser and `Resource`
 v0 `url::Url`-based, hard-rejects any non-`pubky.app` app path, silently accepts userinfo/`..`/query
@@ -314,7 +374,9 @@ is Appendix A; the reference crate and its committed conformance vectors are the
 ## B14. IDs
 TimestampId (post and edit ids), HashId (tag/media/feed files, 128-bit), PubkyId (host/follow/mute), all
 under the canonical-encoding rule (B0). TimestampId gains a per-session monotonic mint guard (the
-JS runtime mints at ms resolution, so same-ms writes would clobber on path). No id function
+JS runtime mints at ms resolution, so same-ms writes would clobber on path). **The guard
+constrains MINTING only.** Copying, publishing and migration reuse an id that already exists and
+never mint, so none of them is affected by it. No id function
 content-addresses a serialized struct, so the Rust/JS byte-identity surface is pure string/byte
 functions.
 
@@ -323,17 +385,50 @@ functions.
 - **Client-side, opt-in, resumable from the homeserver tree alone, permanent multi-epoch.** A
   dormant user may migrate years later in one pass; the indexer dual-reads every epoch forever
   (the permanent v0 parser stays, since the v1 parser classifies `pubky.app` as foreign).
+  **"Forever" is cheaper than it reads, on two counts.** The v0 parser is FROZEN, not maintained:
+  it ships with committed conformance vectors and never changes again, so the recurring cost is
+  running its tests rather than tracking anything. And the v0 population drains rather than
+  accumulates, because the cleanup pass removes v0 a few weeks after each user migrates. What
+  remains years out is dormant accounts that have not been opened since, which is precisely the
+  population opt-in migration exists to serve and precisely the one a cutoff date would strand.
+  A staged upgrade tool ("your data is too old, run this first") remains available as a later
+  option if the maintenance ever proves real; it is additive and needs no decision now.
 - **STRICTLY non-destructive.** Migration never deletes any legacy-epoch data. Privacy lost before
   v1 is already lost; future activity is private. Private-tier legacy public copies are left inert
-  (the indexer stops surfacing them).
+  (the indexer stops surfacing them). Copying rather than moving buys three things: clients still
+  on v0 keep working, a bad migration is recoverable because the source survives, and a good one
+  can be verified against its source before anything is discarded.
+- **It therefore roughly doubles a user's stored social data**, against a homeserver that enforces
+  a per-user quota. Raising the quota is a prerequisite for the migrator going live, not a
+  follow-up (release gate `QUOTA`).
+- **Legacy cleanup is a separate, later, user-confirmed pass**, never part of migration itself.
+  It ships once the migrator has run clean on real data, asks the user before removing anything,
+  and deletes a legacy object only after verifying its v1 counterpart exists and parses. The delay
+  is the point: it puts distance between "did the migration work" and "throw away the original",
+  and it gives anything still reading v0 paths a window to move.
+  **This applies to v0 only, and it is one-time.** v0 was never published as a stable target, so
+  removing it breaks no promise. From v1 onward the rule is the opposite: migration to a future
+  epoch never deletes the epoch it came from, because that epoch was promised stable.
 - **Deterministic and total** over real v0 data: each record sources from its highest present
-  epoch, transforms compose in memory writing only the latest, resume is by destination existence,
-  ids/hashes are re-derived not minted.
-- **Deletion** is user-initiated only. Because migration copies and never deletes, a migrated
-  post lives at BOTH `pub/pubky.app/posts/{id}` and `pub/social/v1/posts/{id}/...`; deleting a
-  public object therefore removes every copy across epochs and both roots, or a from-scratch
-  reindex would resurrect it from the missed legacy copy;
-  private-tier deletes touch only the `/priv/` file. Absence is the tombstone: on a dumb blob
+  epoch, transforms compose in memory writing only the latest, ids/hashes are re-derived not
+  minted.
+- **Resume compares source against destination**, never merely the destination's existence.
+  Existence proves bytes landed, not that they are correct or current, so an existence check
+  cannot distinguish a good file from one a buggy run wrote, and skips it forever. Comparison
+  also picks up a source edited after it was migrated, which an existence check silently drops.
+  Supporting machinery: a client-private `_migrated` marker records the transform revision, so a
+  shipped migrator fix triggers a re-run; a malformed object is skipped and reported rather than
+  blocking the tree; and the homeserver's quota error is surfaced as a typed failure.
+- **Known failure mode: post-migration writes from a legacy client are not visible.** Once a
+  record exists in both epochs the indexer serves the highest one it understands, so a v0 client
+  editing an already-migrated record writes successfully to a path that still exists and no reader
+  ever sees the change. Nothing errors. Comparison-based resume recovers it on the next run, which
+  narrows the window without closing it; the legacy cleanup pass closes it for good, because a
+  removed epoch has nothing left to write to.
+- **Deletion spans epochs, and that rule is NOT migration-scoped** (Part C2, rules 11 to 13): a
+  migrated post lives at BOTH `pub/pubky.app/posts/{id}` and `pub/social/v1/posts/{id}/...`, so
+  deleting a public object removes every copy in every epoch and both roots, or a from-scratch
+  reindex resurrects it from the missed legacy copy. Absence is the tombstone: on a dumb blob
   store the owner's files are the only durable state, so restoring an old backup republishes its
   contents, accepted by design. Durable per-object tombstone files were considered and rejected
   (the substrate cannot enforce them against the owner's own writes, and public tombstones would
@@ -341,6 +436,82 @@ functions.
 - The indexer contract: dedup on `(author, resource_type, stable_id)`, tag id-sets (each tag edge keeps the set of ids asserting it across epochs, so un-tagging
   removes all of them), intrinsic-time ranking (decode the post id), tombstone only when no publicly visible
   copy survives.
+
+# Part C2: Client conformance
+
+Everything above defines what a VALID OBJECT is, and almost all of it is enforced by the shipped
+artifacts: the crate and the JS package carry the types, the validators, the builders and the size
+checks, so a conforming implementation cannot produce an invalid object even by accident. Of the
+normative statements in this document, roughly 106 are of that kind.
+
+This section collects the exception: rules a pure-function library CANNOT enforce, because they
+need I/O, ordering, or state the library never sees. They bind clients, they are normative, and
+they are gathered here rather than scattered so an implementer has one checklist. The model
+sections above reference this section rather than restating it.
+
+A separate class, rules addressed to the shared indexer, is marked inline in Part B and Part C as
+"the indexer contract"; those bind nexus, not clients.
+
+## Read behaviour
+
+1. **Skip what you do not recognise.** An unknown segment under `social/vN` parses as
+   `Resource::Unknown`, foreign namespaces parse as `Foreign`, and both are valid classifications
+   that a social reader SKIPS. Neither is an error.
+2. **Skip objects whose primary enum is `Unknown`.** An unrecognised `post.kind` fails validation;
+   the reader skips that object rather than failing the batch.
+3. **Treat an `Unknown` secondary enum as no constraint.** An unrecognised `feed.content` value
+   degrades to "no filter", it does not empty the feed.
+4. **Complete the bookmark filename check.** The parser performs a FORM check only (A3). Full
+   round-trip validation, decode then re-encode and compare, is the reader's job.
+
+## Write behaviour, read-modify-write
+
+5. **Read the current object from the HOMESERVER before rewriting it, never from an indexer
+   view.** Indexer views can be stale or partial, and writing back from one destroys whatever the
+   view omitted.
+6. **GET a tag address before PUTting it.** Tag addresses converge by construction, so a blind PUT
+   destroys another app's enrichment of the same statement. Preservation protects
+   read-modify-write; it cannot protect write-without-read.
+7. **Fail loudly when the size cap and preservation conflict.** If a rewrite cannot fit the cap
+   while preserving unknown members, the writer FAILS the write and surfaces it. It never
+   silently drops members. The user MAY then explicitly discard extensions.
+
+## Extensions
+
+8. **Nest deliberate extensions under `ext`.** The catch-all preserves members wherever they sit,
+   but `ext` is the one greppable home whose meaning is pinned.
+9. **Treat everything under `ext` as hostile input.** Escape before rendering; validate against the
+   extension's own rules before interpreting. The base spec never validates it.
+
+## Multi-object operations
+
+10. **Publish is a copy, and the client executes it.** The crate supplies the paths, the
+    validation and the ordered plan; the client performs the writes (B11).
+11. **Deletion is user-initiated only.** Nothing in this spec deletes an object on a user's behalf.
+12. **Deleting a public object removes every copy, in every epoch and both roots.** A migrated post
+    exists at both its legacy and its `social/v1` path; leaving either one behind means a
+    from-scratch reindex resurrects it. This is a PERMANENT client rule, not a migration-only one:
+    it applies for as long as two epochs coexist.
+13. **Private-tier deletes touch only the `/priv/` file.**
+14. **Un-migrated users must keep reading their own legacy tree.** A client that has adopted v1
+    reads the union of v1 and legacy paths for its own user, so opting out of migration costs the
+    user nothing. Stated here because it is normative client behaviour, not a rollout task.
+
+## Presentation
+
+15. **A deleted account's display is client policy.** The spec removes the `[DELETED]` sentinel and
+    puts nothing in its place; how a deleted account renders is the client's decision.
+
+## Capabilities
+
+16. **Request the narrowest scope you use** (B0), and use each spec package's own path builders
+    rather than hand-built strings.
+
+## What is NOT in this section
+
+Migration conformance is Part C, and the reviewer's carve-out for it stands: those rules bind a
+migrating client for the duration of a migration. Rule 12 is the one that looks like migration and
+is not, which is why it moved here.
 
 # Part D: Rollout and subtasks
 
@@ -357,10 +528,11 @@ Spec crate on a long-lived `v1` branch, one PR per task, CI green on every commi
   alias; kinds, embed, attachments, Article envelope).
 - [ ] **S6b** post storage, roots, lifecycle on the envelope, namespace-parameterized (versioned
   builders, root rule, publish/unpublish/delete).
-- [ ] **S7** tag + collection (canonical id inputs, reference-tier items).
+- [ ] **S7** tag + collection (canonical id inputs; collection items become `{uri, note?}`
+  objects on the universal tier).
 - [ ] **S8** media collapse (single bytes object, MIME map, parser ext-strip).
 - [ ] **S9** feed dual-root + the user profile field gates (image, links).
-- [ ] **S10** private tier + bookmarks + settings.
+- [ ] **S10** private tier + bookmarks.
 - [ ] **S11** legacy_v0 module + cross-epoch normalization (`stable_id`/`resolve_deref`).
 
 **Pure-JS + gate:**
@@ -370,20 +542,29 @@ Spec crate on a long-lived `v1` branch, one PR per task, CI green on every commi
 
 **Migrator:**
 - [ ] **M1** transform registry + v0 reader (Rust reference emits semantic vectors).
-- [ ] **M2** engine (epoch discovery, resume, source re-check, abort-if-no-`/priv/`).
-- [ ] **M3** pubky.app `/migrate` route (caps, upgrade flow, live counts, settings import).
+- [ ] **M2** engine (epoch discovery, compare-based resume, abort-if-no-`/priv/`). Acceptance
+  includes two mismatch cases: a destination that exists but does not match its source, and a
+  source edited after it was migrated. Both must be re-migrated, not skipped.
+- [ ] **M3** pubky.app `/migrate` route (caps, upgrade flow, live counts, and the import of
+  `settings` and `last_read` into `priv/app.pubky/v1/`, including the `last_read` ms-to-us
+  conversion, which is app-owned rather than a shared transform).
+- [ ] **M4** legacy cleanup pass: user-confirmed, verify-then-delete per object, shipped after
+  M3 has run clean on real data. Gated on confidence, not on a calendar date.
 
 **Cross-repo:**
 - [ ] **pubky-nexus:** per-epoch classify/adapt/normalize, permanent v0 parser, the deletion
   flag (deletion keyed on real state, never name/content literals; gates v1 indexing), tag id-sets,
   intrinsic-time ranking, multi-epoch tombstones, bookmark-feature retirement, mixed-epoch resync.
-- [ ] **pubky-app:** v1 adoption (new caps, kind strings, own-tree legacy read union so
-  un-migrated users lose nothing, publish UI, media type threading, deletion engine).
+- [ ] **pubky-app:** v1 adoption (new caps, kind strings, own-tree legacy read union per Part C2
+  rule 14, publish UI, media type threading, deletion engine).
   - [ ] **moderation:** mixed epoch support by both nexus and homeserver synchronization services as well as by checkstep-request services
 
 **Release gates:**
 - [ ] **IN-PRIV** verify the target homeserver runs the `/priv/` tier and permits the write
   paths. Prerequisite for M2 onward and for any private-tier go-live, not a late release check.
+- [ ] **QUOTA** raise the per-user storage quota before the migrator goes live. Migration copies,
+  so it roughly doubles stored social data; shipping M3 first means users hit the quota partway
+  through a migration.
 - [ ] **REL** release `1.0.0` (crate + npm), merge `v1` to main after nexus dual-read is live.
 
 **Dependencies** (beyond the serialized spine order above): S11 needs S5. J1 needs S5 and
@@ -462,8 +643,6 @@ After canonicalization, split the path into segments and classify:
 | Mute | `mutes/{pk}.json` | priv | same |
 | Bookmark | `bookmarks/{filename}.json` | priv | FORM check only: every character in the base64url alphabet, or `~` followed by 26 canonical Crockford characters; full round-trip validation is the reader's job |
 | Feed | `feeds/{id}.json` | both | `{id}` = canonical HashId |
-| Settings | `settings.json` | priv | none |
-| LastRead | `last_read.json` | priv | none |
 
 `.json` stripping is exact and single: `follows/<pk>.json.json` leaves `<pk>.json`, which fails
 key validation and classifies Unknown.
@@ -481,7 +660,62 @@ An id is valid if and only if re-encoding its decoded bytes reproduces the input
 
 Time bounds are never checked at parse time; only canonicality is.
 
-## A5. Representative vectors
+## A5. Reference-field gates: what is accepted, and what is not
+
+Appendix A1 to A4 govern PATHS. This section governs reference FIELD VALUES, and it is the
+normative statement of what those gates accept: the mentions in B0, B2 and B5 are summaries of
+this, not independent rules.
+
+**Not every valid URI is accepted, and that is deliberate.** These gates are engine-free by
+design, so their behaviour is defined by the rules below rather than by whatever a URL library
+does this year. `url::Url` and WHATWG `new URL()` are outside the normative surface entirely;
+their verdicts agree today but cannot be pinned across engine versions, and since the stored value
+is the raw string, full parsing buys nothing. A client MAY parse with its engine as an advisory
+warning.
+
+Three gates, dispatched on the value's prefix.
+
+**Pubky gate** (`pubky` prefix). The `pubky*` scheme space is reserved; see A1.
+
+**Web gate** (`http://`, `https://`):
+1. Trim with the frozen whitespace set.
+2. Reject any remaining ASCII control character or frozen-whitespace code point. This is stricter
+   than WHATWG, which silently strips embedded tabs and newlines; here they are a rejection.
+3. Require `http://` or `https://` followed by at least one non-`/` character.
+4. Apply the field's length cap.
+
+**Opaque gate** (everything else: `nostr:`, `geo:`, `ipfs:`, `magnet:`, `did:`, any scheme-shaped
+value):
+1. Trim with the frozen whitespace set; reject remaining ASCII control or frozen-whitespace code
+   points.
+2. Require a `:` at position 1 or later with at least one character after it. The scheme must be
+   RFC 3986 shaped: first character ASCII alphabetic, remainder ASCII alphanumeric or `+`, `.`,
+   `-`. Uppercase is accepted on input.
+3. Canonical form is the ASCII-lowercased scheme, then `:`, then the remainder VERBATIM. The
+   remainder is opaque: no percent-decoding, no query or fragment parsing, no structural rules.
+   The value is an identifier this spec carries, not a location it resolves.
+4. Apply the field's length cap.
+
+**What this means for an application author**, stated plainly because it is the practical
+consequence:
+
+- The opaque gate is MORE permissive than a URI parser in one direction: it accepts any
+  scheme-shaped value without understanding the scheme, including schemes that do not exist yet.
+- It is LESS permissive in another: it performs no normalisation, so anything a parser would
+  repair into acceptance is rejected here, and anything a parser would rewrite is stored as
+  written.
+- Identity is spelling-sensitive beyond the scheme fold. `http://x.com` and `http://x.com/` are
+  two distinct canonical values, as are two spellings of one `nostr:` event. This is an accepted
+  and documented fork: authoring clients SHOULD submit the target's own canonical spelling, and
+  SHOULD lowercase scheme and host for web URIs before submitting.
+- Structure inside the remainder is never validated. A malformed query string in an `https` value
+  is accepted; a percent-sequence is neither decoded nor checked.
+
+Both implementations reproduce these gates byte-for-byte, and the committed conformance vectors
+cover them, including the rejection cases (embedded tab, embedded newline, control characters,
+a scheme with a leading digit, a bare scheme with no remainder, and over-cap values).
+
+## A6. Representative vectors
 
 `<pk>` is any valid host key, `TS` a canonical TimestampId, `H26` a canonical HashId.
 

--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -130,7 +130,10 @@ author's `pub/social/v1/tags/`, and the target may be any public resource (socia
 apps' objects, external URIs). A logical tag therefore has exactly one possible address:
 re-tagging self-overwrites idempotently, apps on the same account converge on the same file, and
 the indexer reads one namespace with no writing-app dimension (reading `tags/` directories in
-other app namespaces survives only as a legacy rule).
+other app namespaces survives only as a legacy rule; migrating those files is the owning app's
+job). Because addresses converge, a tag writer SHOULD GET the address first and preserve unknown
+members if a file exists: a blind PUT would destroy another app's enrichment of the same
+statement (preservation protects read-modify-write, not write-without-read).
 
 ## B6. Bookmark
 v0 `pub/pubky.app/bookmarks/{HashId(uri)}` (public, one-way filename, GET-per-file) -> v1

--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -282,8 +282,12 @@ v0 `pub/pubky.app/feeds/{HashId(serde-json config)}` (public) -> v1
 - **Private by default, published by choice** (copy the same file to `/pub/`). Reader set is the
   owner today; publishing is a deliberate act.
 - **Content-addressed id over a pinned config string** (not serde output, which is field-order
-  fragile and not JS-reproducible). Two users publishing the same config share an id, so future
+  fragile and not JS-reproducible). Six fixed segments: reach, layout, sort, content filter,
+  tags, and domain tags. Two users publishing the same config share an id, so future
   cross-homeserver popularity ranking is additive indexer work.
+- Tracks current v0 (#143): the `wot` and `me` reach values and the optional `domain_tags`
+  filter (same folding and cap rules as tags) are part of the v1 model, and `domain_tags`
+  participates in the id (two feeds differing only in domain filter are different feeds).
 - All three enums gain `Unknown` (v0 hard-crashes old clients on any new reach/layout/sort value);
   `name` gains a cap.
 

--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -31,6 +31,14 @@ the path grammar.
   (`pubky.app` wrongly signals one app owns shared data), versioned (the path is the only channel
   that survives events + LIST + anonymous GET), and a bare word with no dot (a dotted directory
   name like `pubky.app/` reads as an application bundle on macOS when a tree is exported to disk).
+- **Folder ownership (the composition law).** The specification that defines an object
+  determines its storage namespace, never the application that writes it. An app writing social
+  objects writes them under `social/vN`; its own objects live under its own namespace. Apps
+  therefore compose spec packages, each bringing its capability scopes and path builders (request
+  `/pub/social/v1/:rw` alongside your app scopes; use each package's builders for its paths).
+  Consequence: tags are social objects, so the one canonical v1 write location is
+  `pub/social/v1/tags/`; indexers reading `tags/` directories inside other app namespaces is a
+  legacy read rule, not a v1 write model.
 - **Namespace governance.** `social/vN` is owned by this repo: a resource type exists exactly
   when the released crate parses it, and additions land as ordinary crate-minor PRs here (parser
   arm + model + data assets + vectors in one change). Reserved: epoch segments `v[0-9]+`, the `_`

--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -4,15 +4,30 @@
 > design model by model (v0 shape, v1 shape, why), then migration, then the rollout. Comment
 > inline on the line you disagree with. The companion `v0-vs-v1.md` expands every model change
 > with its full reasoning.
+>
+> Terms used throughout:
+> - **epoch**: the `vN` path segment; each epoch is a disjoint subtree holding one generation of data (`social/v1` today).
+> - **root**: the leading `pub` or `priv` path segment. The parser reports it as a resource's `visibility`; the `/priv/` root as a feature is the **privacy tier**.
+> - **dual-root**: a resource that may live under either root (posts, files, feeds).
+> - **now-or-never**: a rule only a breaking release can introduce; deferring it means waiting for `social/v2`.
+> - **wire**: the stored/serialized JSON byte form.
+> - **scheme tier**: a reference field's validation class: pubky-only, pubky+web, web-only, or universal (any scheme).
+> - **nexus**: the shared indexer.
+> - **substrate**: the homeserver's dumb blob store (no compare-and-swap, no server-side logic).
+> - **tombstone**: the deletion marker readers act on; in v1, the absence of any public copy.
+> - **pinned / frozen**: committed as a closed-form rule or data asset; never tracks library or Unicode updates.
 
 The first stable and first breaking release of the shared social-data layer. Renames the crate
 `pubky-app-specs` to `pubky-social-specs` (`1.0.0`) and moves all data from the single hard-coded
-app path `/pub/pubky.app/<res>` to a versioned, app-neutral epoch `/{pub|priv}/social/v1/<res>`.
-One coordinated break spends the whole budget on what cannot be added additively later; a
-permanent forward-compat contract is designed so v1.x grows additively. A further epoch stays
-reserved for the changes no contract can make additive: re-pinning a text or id function (which
-re-ids data), changing an existing resource's root or per-kind content semantics, or breaking
-the path grammar.
+app path `/pub/pubky.app/<res>` to a versioned, app-neutral epoch `/{pub|priv}/social/v1/<res>`
+(an epoch is the `vN` path segment; each epoch is a disjoint subtree holding one generation of
+data).
+The strategy has three parts. First, this one coordinated break makes every now-or-never
+change, those that cannot be added additively later. Second, a permanent forward-compat contract
+makes everything else additive, so v1.x grows without breaking. Third, a future epoch
+(`social/v2`) stays reserved for the few changes no contract can make additive: re-pinning a
+text or id function (which re-ids existing data), changing a resource's root (its leading `pub`
+or `priv` segment) or per-kind content semantics, or breaking the path grammar.
 
 # Part A: Why break now
 
@@ -20,7 +35,7 @@ the path grammar.
   every other app. A shared spec must classify foreign data, not error on it.
 - The path is the only version signal that survives the `/events/` feed, LIST, and anonymous GET.
   v0 has none, so v1.x could not evolve without breaking old clients.
-- No privacy tier, no file extensions, GET-per-file bookmarks, and `url::Url` validation that
+- No privacy tier, no file extensions, GET-per-file bookmarks (listing them costs one GET each), and `url::Url` validation that
   normalizes junk into acceptance while rejecting valid short-form URIs.
 
 # Part B: Design, model by model
@@ -43,55 +58,73 @@ the path grammar.
   foreign namespaces (no enforcement point exists), but the recommendation is free and buys an
   app the same migration mechanics this spec built for itself: old and new data coexist in
   disjoint subtrees, and the path is the only version signal that survives the events feed,
-  LIST, and anonymous GET. The parser already anticipates this: `Foreign` classification
-  surfaces the segment after the namespace verbatim; for apps following the convention that
-  segment IS the version, so indexers version-route conforming app data with a single match.
+  LIST, and anonymous GET. The parser already anticipates this: `Foreign` classification surfaces the segment after the
+  namespace verbatim. For an app following the convention, that segment IS its version, so an
+  indexer can version-route conforming app data with a single match.
 - **Namespace governance.** `social/vN` is owned by this repo: a resource type exists exactly
   when the released crate parses it, and additions land as ordinary crate-minor PRs here (parser
   arm + model + data assets + vectors in one change). Reserved: epoch segments `v[0-9]+`, the `_`
   filename prefix, every current resource segment, and the `ext` member name; unknown segments
-  under `social/vN` parse as a handled `Unknown`, so additions never break deployed readers. A
+  under `social/vN` parse as a handled `Resource::Unknown` (a valid classification readers
+  skip, never an error; distinct from the `Unknown` enum variant of the forward-compat contract
+  below), so additions never break deployed readers. A
   new epoch (`social/v2`) is reserved for changes impossible additively (re-pinned text/id
   functions, changed root or content semantics, grammar breaks). App namespaces are self-assigned
   (domain-style names recommended); the parser classifies them foreign, never invalid.
 - **`.json` on every JSON leaf.** The homeserver derives the served type from magic bytes then the
   path extension; extensionless JSON serves as octet-stream/plaintext.
-- **A privacy tier `/priv/` (owner-only, excluded from `/events/`).** For state whose only reader
-  is the owner's own client. The placement test is the actual reader set, not aspiration. The
-  content family (posts, files, feeds) is dual-root: publish is a deterministic root migration,
-  and THE ROOT RULE is now-or-never: a public-rooted object must never reference a priv-root
-  pubky URI (such a reference dangles for every reader but the owner and leaks path existence
-  through the 401-vs-404 oracle); private objects may reference both roots.
-- **Reference tiers (field values), distinct from the path grammar.** Appendix A governs PATHS
+- **A privacy tier `/priv/` (owner-only, excluded from `/events/`).** For state whose only
+  reader is the owner's own client; placement follows the ACTUAL reader set, not aspiration.
+  The leading path segment is the ROOT (`pub` or `priv`); the parser reports it as the
+  resource's visibility. The content family (posts, files, feeds) is dual-root: an object may
+  live under either root, and publish is a deterministic root migration. One rule here is
+  now-or-never, THE ROOT RULE: a public-rooted object must never reference a priv-root pubky
+  URI; private objects may reference both roots. (A public-to-private reference dangles for
+  every reader but the owner and leaks the path's existence through the 401-vs-404 oracle.)
+- **Scheme tiers (reference field values), distinct from the path grammar.** Appendix A governs PATHS
   (where objects live); reference FIELD VALUES (parent, embed, targets, images) are validated by
   per-field scheme tiers: pubky-only, pubky+web, or the universal tier (any scheme-shaped URI
-  via a pinned opaque gate: lowercased scheme, rest verbatim). Each model section names its
-  fields' tiers.
-- **Forward-compat contract (permanent).** All wire enums are plain string enums (unit
+  via a pinned opaque gate: lowercased scheme, rest verbatim). Per-field tiers (each model section gives the rationale):
+
+  | Field | Tier |
+  |---|---|
+  | `post.parent` | pubky-only |
+  | `post.embed` | universal |
+  | `post.lock` | pubky-only |
+  | `collection.items[]` | pubky-only |
+  | tag target | universal |
+  | bookmark target | universal |
+  | `attachments[].uri` | pubky+web |
+  | `user.image`, `article.cover_image`, `collection.cover_image` | pubky+web |
+  | `user.links[].url` | web-only |
+- **Forward-compat contract (permanent).** All wire enums (an enum as stored in JSON; "wire"
+  throughout means the stored byte form) are plain string enums (unit
   variants, `rename_all` lowercase/snake_case), so `#[serde(other)] Unknown` plus
   `#[non_exhaustive]` is well-defined; no model uses `deny_unknown_fields`; every future field is
   optional + defaulted + skip-if-none. Degradation semantics are per-position: an `Unknown` in an
   object's primary enum (`post.kind`) fails validation and readers skip the object; an `Unknown`
   in a secondary enum (`feed.content`) degrades to "no constraint"; deserialization never crashes.
   Unknown members are tolerated on read AND preserved on rewrite: every wire model carries an
-  opaque flattened catch-all map, so a client rewriting an object round-trips members it does not
+  opaque catch-all map (serde flatten: it absorbs every member the model does not declare), so a
+  client rewriting an object round-trips members it does not
   understand instead of destroying another client's data (tolerating without preserving would let
-  any older client drop every field added after it shipped). Conformance vectors cover both the
-  unknown-value and the preservation behavior. Preservation fixes typed-rewrite data loss, not
-  concurrency: concurrent writers still clobber whole-file under last-write-wins where that is
-  the documented rule. Two companion rules keep extensibility bounded and coherent: TOTAL object
-  size is capped (posts 512 KiB, every other JSON resource 64 KiB, measured on stored bytes,
-  checked before parsing on read and after building on write), because per-field validation
-  stopped bounding size the moment unknown members became legal, and a total cap cannot be added
-  later without a break; and a conforming rewrite fetches the current object from the
-  HOMESERVER, never from an indexer view (views can be stale or partial). The caps cover JSON resources only
+  any older client drop every field added after it shipped). Conformance vectors (committed input and expected-output files every implementation must
+  reproduce) cover both the unknown-value and the preservation behavior. Preservation fixes exactly one failure mode: a client deserializing into its own older types
+  and writing back, silently destroying fields it never modeled. It does not fix concurrency:
+  concurrent writers still clobber whole files under last-write-wins where that is the
+  documented rule. Two companion rules keep extensibility bounded. (1) TOTAL object size is
+  capped: 512 KiB for posts, 64 KiB for every other JSON resource, measured on stored bytes,
+  checked before parsing on read and after building on write. Unknown members made per-field
+  validation stop bounding size, and a total cap cannot be added later without a break, so it
+  ships now. (2) A conforming rewrite fetches the current object from the HOMESERVER, never
+  from an indexer view (views can be stale or partial). The caps cover JSON resources only
   (media bytes keep their own media-size bound), and the wedge case is pinned: if a rewrite
   cannot fit the cap while preserving unknown members, the writer fails the write and surfaces
-  it, never silently drops members; the user may explicitly discard extensions. The indexer
-  side:
-  unknown members are carried verbatim into object views, so any client can read an extension
+  it, never silently drops members; the user may explicitly discard extensions.
+  The indexer side:   unknown members are carried verbatim into object views, so any client can read an extension
   through the shared index before the indexer understands it, but they are never validated,
-  queried, or indexed; queryability requires an adopted projection. The extension ladder:
+  queried, or indexed; queryability requires an adopted projection (the indexer explicitly promoting the member into
+  its queryable schema). The extension ladder:
   readable (carried) -> queryable (projection) -> validated (spec field). Deliberate extensions
   SHOULD nest under the reserved `ext` member (`"ext": {"badge": {...}}`), one greppable home
   whose meaning is pinned once: everything under `ext` is third-party data the base spec never
@@ -102,18 +135,37 @@ the path grammar.
   `O`->`0`, dangling bits), each a distinct homeserver key; that leniency is removed.
 - **Engine-free validation.** `url::Url` (normalizes junk into acceptance), the `mime` crate, and
   full-Unicode case/trim are replaced by pinned rules (a strict raw-string canonicalizer, a
-  frozen whitespace table, ASCII-only label folding, code-point lengths) that a Rust and a
+  frozen whitespace table (a committed code-point list that never tracks Unicode updates),
+  ASCII-only label folding, code-point lengths) that a Rust and a
   hand-written JS implementation reproduce byte-for-byte.
 - **No silent sanitize-rewrites.** v0 rewrote `[DELETED]` names to "anonymous" and
   truncated-then-blanked over-long inputs; v1 makes invalid input a validation error.
+
+A migrated user's tree at a glance (`<pk>` a host key, `TS` a TimestampId, `H26` a HashId):
+
+    pubky://<pk>/
+    |-- pub/social/v1/
+    |     profile.json
+    |     posts/TS1/TS1.json      first version (editId reuses the post id)
+    |     posts/TS1/TS2.json      an edit; references still say posts/TS1
+    |     tags/H26.json
+    |     follows/<pk2>.json
+    |     files/H26.jpg
+    |     feeds/H26.json          a published feed (copy of the private file)
+    |-- priv/social/v1/
+          posts/TS3/TS3.json      a draft
+          bookmarks/<b64u>.json   target readable from the filename
+          mutes/<pk3>.json
+          feeds/H26.json
+          settings.json
+          last_read.json
 
 ## B1. User (profile)
 v0 `pub/pubky.app/profile.json` -> v1 `pub/social/v1/profile.json`.
 - `image` accepts pubky/http/https via one shared image validator (cap 300). pubky-app avatars are
   pubky file URIs; an http-only rule would reject every real avatar.
 - The `[DELETED]` magic string dies entirely: v0's silent `[DELETED]` -> "anonymous" rewrite is
-  removed with NO replacement rule; `[DELETED]` is an ordinary legal name. **Required nexus
-  upgrade (gates v1 indexing):** the indexer currently keys deletion on that literal; it must key
+  removed with NO replacement rule; `[DELETED]` is an ordinary legal name. **Required upgrade in nexus, the shared indexer (gates v1 indexing):** the indexer currently keys deletion on that literal; it must key
   on a real flag (`deleted` on the indexed row / UserView) before indexing any v1 data. How a
   deleted account is displayed then becomes pure client presentation (the indexer may
   transitionally keep emitting the old literal at its view layer for old clients; storage and
@@ -126,17 +178,19 @@ v0 `pub/pubky.app/posts/{id}` (one flat file, overwritten on edit) -> v1
 `{id}` and `{editId}` are both canonical TimestampIds (Appendix A3, A4).
 - **Per-edit path versioning.** Each edit is a new file; the first version reuses the post id;
   references use the versionless form so edits never orphan replies or re-key tags. A counter was
-  rejected (races across devices on a substrate with no compare-and-swap). Now-or-never: a
+  rejected (races across devices; the substrate, the homeserver's dumb blob store, has no
+  compare-and-swap). Now-or-never: a
   `posts/{id}` file and a `posts/{id}/` directory are mutually exclusive on the homeserver.
 - **Kinds renamed** `short`->`note`, `long`->`article` (nature, not length); all seven kinds kept.
 - **`embed`** flattened from `{uri, kind}` to a plain URI string (kind is derivable from the
   target), and it accepts ANY external URI, the same universal tier as tags: http/https through
-  the strict web gate (an OSM object URL is an ordinary https reference), and any other
+  the strict web gate (the pinned regex validator for web URLs) (an OpenStreetMap object URL is an ordinary https reference), and any other
   scheme-shaped identifier (`nostr:`, `geo:`, `ipfs:`, `did:`) through a pinned opaque gate
-  (lowercased scheme + rest verbatim, no engine parsing). The indexer attaches the post to the same External Resource nodes it builds
+  (lowercased scheme + rest verbatim, no engine parsing). The indexer attaches the post to the same External Resource
+  nodes (its graph records for non-pubky targets) that it builds
   for external tag targets. `parent` stays pubky-only (a reply is a social-graph edge with
-  thread semantics that exist only between posts). This also keeps migration total: v0's
-  `Url::parse` accepted arbitrary schemes, so real v0 data can carry them.
+  thread semantics that exist only between posts). This also keeps migration total (every real v0 record has a valid v1 image; nothing fails to
+  migrate): v0's `Url::parse` accepted arbitrary schemes, so real v0 data can carry them.
 - **`attachments`** become `Vec<{uri, alt?, name?}>`, always `[]` never null. Objects, not strings,
   so per-item metadata (alt text now; hash/blurhash later) is additive; ships two committed fields.
 - **`lock`** kept: the value is the lock-FILE URI (`pub/locks.app/<lock_id>.json`), and presence
@@ -152,24 +206,27 @@ v0 `pub/pubky.app/posts/{id}` (one flat file, overwritten on edit) -> v1
   makes the incubation path usable at launch: a schema proves itself in an app namespace before
   being proposed for `social/vN`.
 - The `[DELETED]` content sentinel dies with no replacement (same flag rule as B1); absence is
-  the tombstone, synthesized by the indexer from real deletion state, never from content strings.
+  the tombstone (the deletion marker readers act on), synthesized by the indexer from real
+  deletion state, never from content strings.
 
 ## B3. ArticleContent (new)
 v0: pubky-app hand-rolls `{title, body}` JSON inside `long` posts, unspecified, cover smuggled as
-`attachments[0]`. v1: a typed `{title, body, cover_image?}` envelope in `content` when
-`kind == article`. Per-kind content shape is now-or-never; the cover moves into the envelope.
+`attachments[0]`. v1: a typed `{title, body, cover_image?}` content envelope in `content` when
+`kind == article` (a per-kind content schema INSIDE the content string, distinct from the
+`PostEnvelope` mechanics layer of B2). Per-kind content shape is now-or-never; the cover moves into the envelope.
 Articles may carry parent/embed/attachments (an article can be a reply or carry media).
 
 ## B4. CollectionContent
 Shape unchanged (`{name, description?, items[], cover_image?}`). `items` now accept any
-reference-tier pubky URI (any resource, any app), not just `posts/` under `pubky.app` (a curated
+pubky URI (any resource, any app; the pubky-only scheme tier of B0), not just `posts/` under `pubky.app` (a curated
 list may include foreign resources). Private collections come free from the dual-root post family.
 
 ## B5. Tag
-`tags/{id}.json`. Id hashed over the canonicalized target plus a frozen-trimmed, ASCII-folded
+`tags/{id}.json`. Id = `HashId("{target}:{label}")`, the target canonicalized, the label
+frozen-trimmed and ASCII-folded
 label (v0 used engine `to_lowercase` and `url::Url` normalization, neither reproducible across
-implementations; content-addressed ids must freeze their input functions). Injectivity holds only
-because the label rejects `:`. One write location, any target: every app writes tags at the
+implementations; content-addressed ids must freeze their input functions). The `:` join is injective only because labels reject `:`; that restriction may never be
+lifted while the id format stands. One write location, any target: every app writes tags at the
 author's `pub/social/v1/tags/`, and the target may be any public resource: social objects, other
 apps' objects, or ANY external URI (http/https via the strict web gate; other schemes, `nostr:`,
 `geo:`, `ipfs:`, `did:`, via a pinned opaque gate that lowercases the scheme and keeps the rest
@@ -191,10 +248,10 @@ v0 `pub/pubky.app/bookmarks/{HashId(uri)}` (public, one-way filename, GET-per-fi
   resource is the deferred replacement candidate.
 - **Target in the filename, reversibly.** Primary form: unpadded `base64url(canonical target)`
   (no `=`; the parser's form check accepts alphabet characters only) for
-  targets up to 187 bytes. The math: 187 bytes encode to 250 base64url characters, and 250 +
-  `.json` (5) = 255, the homeserver's per-segment maximum, so 187 is the largest cap ANY
-  reversible encoding allows (base64url is the densest standard encoding that is also `/`- and
-  `%`-free and natively JS-decodable). Longer targets use the overflow form `~ + HashId(target)`
+  targets up to 187 bytes. The math: the homeserver caps a path segment at 255 characters, and `.json` takes 5, leaving
+  250. base64url is the densest standard encoding that is also `/`- and `%`-free and natively
+  JS-decodable, and 250 base64url characters carry 187 bytes, so 187 is the largest cap ANY
+  reversible encoding allows. Longer targets use the overflow form `~ + HashId(target)`
   with the target kept in content. Listing costs zero GETs for primary-form entries (the
   overwhelming majority); each overflow entry costs one GET to recover its target.
 - Content shrinks to `{created_at}` (plus `target` only in overflow).
@@ -236,7 +293,7 @@ while exposing the user's privacy posture (`require_pin`, `sign_out_inactive`) t
 one. v1: `PubkySocialSettings` at `priv/social/v1/settings.json`, all sections optional, whole-file
 last-write-wins on a microsecond `updated_at`, the dead per-file `version` field dropped. Rewrites
 preserve unknown members via the catch-all map (B0), so an older client editing one field cannot
-destroy a section a newer client wrote; only the concurrent-edit race is lost, by LWW design.
+destroy a section a newer client wrote; only the concurrent-edit race is lost, by last-write-wins design.
 
 ## B13. Parser and `Resource`
 v0 `url::Url`-based, hard-rejects any non-`pubky.app` app path, silently accepts userinfo/`..`/query
@@ -263,18 +320,17 @@ functions.
 - **Deterministic and total** over real v0 data: each record sources from its highest present
   epoch, transforms compose in memory writing only the latest, resume is by destination existence,
   ids/hashes are re-derived not minted.
-- **Deletion** is user-initiated only: deleting a public object (post, file) removes every copy
-  across epochs and both roots. Cross-epoch copies exist because migration copies and never
-  deletes: a migrated post lives at BOTH `pub/pubky.app/posts/{id}` and
-  `pub/social/v1/posts/{id}/...`, and a delete that missed the legacy copy would resurrect the
-  post on a from-scratch reindex;
+- **Deletion** is user-initiated only. Because migration copies and never deletes, a migrated
+  post lives at BOTH `pub/pubky.app/posts/{id}` and `pub/social/v1/posts/{id}/...`; deleting a
+  public object therefore removes every copy across epochs and both roots, or a from-scratch
+  reindex would resurrect it from the missed legacy copy;
   private-tier deletes touch only the `/priv/` file. Absence is the tombstone: on a dumb blob
   store the owner's files are the only durable state, so restoring an old backup republishes its
   contents, accepted by design. Durable per-object tombstone files were considered and rejected
   (the substrate cannot enforce them against the owner's own writes, and public tombstones would
   leak deletion metadata forever).
-- The indexer contract: dedup on `(author, resource_type, stable_id)`, tag id-sets for cross-epoch
-  un-tagging, intrinsic-time ranking (decode the post id), tombstone only when no publicly visible
+- The indexer contract: dedup on `(author, resource_type, stable_id)`, tag id-sets (each tag edge keeps the set of ids asserting it across epochs, so un-tagging
+  removes all of them), intrinsic-time ranking (decode the post id), tombstone only when no publicly visible
   copy survives.
 
 # Part D: Rollout and subtasks
@@ -294,7 +350,7 @@ Spec crate on a long-lived `v1` branch, one PR per task, CI green on every commi
   builders, root rule, publish/unpublish/delete).
 - [ ] **S7** tag + collection (canonical id inputs, reference-tier items).
 - [ ] **S8** media collapse (single bytes object, MIME map, parser ext-strip).
-- [ ] **S9** feed dual-root + user gates.
+- [ ] **S9** feed dual-root + the user profile field gates (image, links).
 - [ ] **S10** private tier + bookmarks + settings.
 - [ ] **S11** legacy_v0 module + cross-epoch normalization (`stable_id`/`resolve_deref`).
 
@@ -316,10 +372,10 @@ Spec crate on a long-lived `v1` branch, one PR per task, CI green on every commi
   un-migrated users lose nothing, publish UI, media type threading, deletion engine).
   - [ ] **moderation:** mixed epoch support by both nexus and homeserver synchronization services as well as by checkstep-request services
 
-**Gates:**
+**Release gates:**
 - [ ] **IN-PRIV** verify the target homeserver runs the `/priv/` tier and permits the write
   paths. Prerequisite for M2 onward and for any private-tier go-live, not a late release check.
-- [ ] **REL** publish `1.0.0` (crate + npm), merge `v1` to main after nexus dual-read is live.
+- [ ] **REL** release `1.0.0` (crate + npm), merge `v1` to main after nexus dual-read is live.
 
 **Dependencies** (beyond the serialized spine order above): S11 needs S5. J1 needs S5 and
 regenerates as later S tasks land; J2 needs J1; J3 needs J2 and is merge-blocking from then on.
@@ -337,8 +393,8 @@ Supersedes the v1 roadmap #12. Resolves: #47 (json extensions), #48 (attachment 
 (short-form URIs), #141 (reject non-canonical URIs). Mention-prefix cleanup (`pk:`) is handled
 client-side and already shipped.
 
-No open design decisions remain; the destructive migration carve-out was considered and rejected
-in favor of strictly non-destructive migration (Part C).
+No open design decisions remain; a carve-out allowing migration to delete some legacy data was
+considered and rejected: migration is strictly non-destructive (Part C).
 
 # Appendix A: the v1 URI grammar (normative)
 
@@ -389,7 +445,7 @@ After canonicalization, split the path into segments and classify:
 | Resource | Path remainder | Roots | Leaf rule |
 |---|---|---|---|
 | User | `profile.json` | pub | none |
-| Post (reference) | `posts/{id}` | both | `{id}` = canonical TimestampId |
+| Post (versionless reference) | `posts/{id}` | both | `{id}` = canonical TimestampId |
 | Post (version) | `posts/{id}/{editId}.json` | both | both canonical TimestampIds |
 | File (media) | `files/{hash}.{ext}` | both | strip exactly one extension, case-sensitively, ONLY if it is in the frozen extension set; remainder = canonical HashId; unknown or absent extension is Unknown |
 | Tag | `tags/{id}.json` | pub | `{id}` = canonical HashId |

--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -114,6 +114,15 @@ v0 `pub/pubky.app/posts/{id}` (one flat file, overwritten on edit) -> v1
 - **`lock`** kept: the value is the lock-FILE URI (`pub/locks.app/<lock_id>.json`), and presence
   means "locked content" regardless of kind (matches the Locks feature's resolved design).
 - **Dual-root:** posts may live under `/priv/` (drafts, private notes, private collections).
+- **The post is a reusable envelope (adopted from review).** The crate exports the shared
+  mechanics, versioned storage, ids, parent/embed/attachments/lock, preservation, path helpers,
+  as a generic layer (`PostEnvelope<K>`), with the social post as its first specialization
+  (closed kind set, wire bytes unchanged). App specs specialize it with their own kinds in their
+  own namespaces (a Mapky review, an Eventky event), where social readers classify them as
+  foreign data. The envelope fixes reference semantics uniformly (a reply edge means the same
+  thing everywhere); the specialization owns its kind vocabulary and content validation. This
+  makes the incubation path usable at launch: a schema proves itself in an app namespace before
+  being proposed for `social/vN`.
 - The `[DELETED]` content sentinel dies with no replacement (same flag rule as B1); absence is
   the tombstone, synthesized by the indexer from real deletion state, never from content strings.
 

--- a/docs/rfc-v1-social-specs.md
+++ b/docs/rfc-v1-social-specs.md
@@ -44,8 +44,8 @@ the path grammar.
   app the same migration mechanics this spec built for itself: old and new data coexist in
   disjoint subtrees, and the path is the only version signal that survives the events feed,
   LIST, and anonymous GET. The parser already anticipates this: `Foreign` classification
-  extracts the version whenever the segment after the namespace matches `v[0-9]+`, so indexers
-  version-route conforming app data with zero extra work.
+  surfaces the segment after the namespace verbatim; for apps following the convention that
+  segment IS the version, so indexers version-route conforming app data with a single match.
 - **Namespace governance.** `social/vN` is owned by this repo: a resource type exists exactly
   when the released crate parses it, and additions land as ordinary crate-minor PRs here (parser
   arm + model + data assets + vectors in one change). Reserved: epoch segments `v[0-9]+`, the `_`

--- a/docs/v0-vs-v1.md
+++ b/docs/v0-vs-v1.md
@@ -164,7 +164,7 @@ v1: `{pub|priv}/social/v1/posts/{id}/{editId}.json`, referenced versionlessly as
   blurhash, dimensions, `content_type`/`size`) additive. Exactly two optional fields ship;
   nothing speculative.
 - **`lock` is kept with corrected semantics.** The value is the lock FILE URI
-  (`pubky://<creator>/pub/locks.app/<lock_id>.json`), pubky-only; presence means "locked
+  (`pubky://<creator>/pub/app.locks/<lock_id>.json`, illustrative), pubky-only; presence means "locked
   content" regardless of kind. Why: this matches the resolved Locks design (pubky-app #2029);
   earlier drafts (including v0 doc comments) mis-described it as a lock-server URI. The client-owned
   teaser object inside a locked post's `content` stays deliberately client-owned, per the Locks

--- a/docs/v0-vs-v1.md
+++ b/docs/v0-vs-v1.md
@@ -40,12 +40,13 @@ These are listed once here; the per-model sections below only add what is specif
   skip-if-none. Unknown members are tolerated on read AND preserved on rewrite: every wire model
   carries an opaque flattened catch-all map, so a rewriting client round-trips members it does
   not understand (tolerating without preserving would let any older client silently destroy
-  every field added after it shipped). The bound extensibility needs: TOTAL object size is
-  capped (posts 512 KiB, other resources 64 KiB, on stored bytes), rewrites fetch from the
-  homeserver rather than indexer views, and the indexer carries unknown members verbatim in its
-  views (readable by any client) while indexing only adopted projections. Why: v0 has exactly one `Unknown` catch-all (`PostKind`); adding a value to any
+  every field added after it shipped). Why: v0 has exactly one `Unknown` catch-all (`PostKind`); adding a value to any
   feed enum hard-crashes every old client on deserialize. This contract is what turns "break
-  once, then grow additively" from an aspiration into a property.
+  once, then grow additively" from an aspiration into a property. The bound extensibility
+  needs: TOTAL object size is capped (posts 512 KiB, other resources 64 KiB, on stored bytes),
+  rewrites fetch from the homeserver rather than indexer views, and the indexer carries unknown
+  members verbatim in its views (readable by any client) while indexing only adopted
+  projections.
 - **Canonical-encoding id validation.** An encoded id is valid iff re-encoding its decoded
   bytes reproduces the input, with closed-form regexes and final-char sets. Why: v0's validators
   decode Crockford aliases (`O` as `0`, lowercase, a dangling final bit) and z-base32 dangling

--- a/docs/v0-vs-v1.md
+++ b/docs/v0-vs-v1.md
@@ -40,7 +40,10 @@ These are listed once here; the per-model sections below only add what is specif
   skip-if-none. Unknown members are tolerated on read AND preserved on rewrite: every wire model
   carries an opaque flattened catch-all map, so a rewriting client round-trips members it does
   not understand (tolerating without preserving would let any older client silently destroy
-  every field added after it shipped). Why: v0 has exactly one `Unknown` catch-all (`PostKind`); adding a value to any
+  every field added after it shipped). The bound extensibility needs: TOTAL object size is
+  capped (posts 512 KiB, other resources 64 KiB, on stored bytes), rewrites fetch from the
+  homeserver rather than indexer views, and the indexer carries unknown members verbatim in its
+  views (readable by any client) while indexing only adopted projections. Why: v0 has exactly one `Unknown` catch-all (`PostKind`); adding a value to any
   feed enum hard-crashes every old client on deserialize. This contract is what turns "break
   once, then grow additively" from an aspiration into a property.
 - **Canonical-encoding id validation.** An encoded id is valid iff re-encoding its decoded

--- a/docs/v0-vs-v1.md
+++ b/docs/v0-vs-v1.md
@@ -62,10 +62,12 @@ These are listed once here; the per-model sections below only add what is specif
   engine trim/lowercase/Unicode tables differ between Rust and JS and across browser versions
   (verified divergences on U+FEFF, U+0085, full-Unicode case mapping, i64 rounding), and
   content-addressed ids freeze whatever functions feed them. Changing these later re-ids data,
-  an epoch-class break, so they are pinned now, engine-free.
+  a break fixable only by opening a new `social/vN` epoch, so they are pinned now, engine-free.
 - **One URI grammar.** All `pubky://` validation goes through one raw-string
   canonicalizer (accepts the SDK short form, #120; rejects userinfo, `..`, `%`, query, fragment,
-  whitespace, control, #141); web references are gated by a pinned regex; `url::Url` and WHATWG
+  whitespace, control, #141); web references are gated by a pinned regex. Reference field values are validated by per-field
+  scheme tiers: pubky-only, pubky+web, web-only, or universal (any scheme-shaped URI via the
+  pinned opaque gate); `url::Url` and WHATWG
   `new URL()` leave the normative surface entirely. Why: v0's `url::Url` normalizes junk into
   acceptance and rejects valid short forms, and two independent validation surfaces (parser vs
   field validators) had already drifted; engine URL parsers cannot be version-pinned across
@@ -102,7 +104,8 @@ v1: `pub/social/v1/profile.json`, same fields.
   to "anonymous" because the indexer keys its deletion handling on that literal (verified), so a
   user carrying the name would be treated as deleted. v1 removes the rewrite with NO replacement
   rule: `[DELETED]` is an ordinary legal name. The load-bearing requirement moves to the indexer
-  contract instead: **nexus must key deletion on a real flag** (`deleted` on the indexed row)
+  contract instead: **nexus (the shared indexer) must key deletion on a real flag** (`deleted`
+  on the indexed row)
   before indexing v1 data, and display of deleted accounts becomes pure client presentation. A
   magic string survives nowhere in the v1 wire rules.
 - **`links[].url` validated by the pinned web gate instead of `Url::parse` + `sanitize_url`.**
@@ -152,9 +155,7 @@ v1: `{pub|priv}/social/v1/posts/{id}/{editId}.json`, referenced versionlessly as
   first-class (the indexer reuses the External Resource nodes it already builds for external tag
   targets), and they keep migration total: v0's `Url::parse` gate accepted arbitrary embed URLs,
   so real v0 posts can carry them. `parent` stays pubky-only: reply threads are social-graph
-  edges between posts. (The
-  often-cited "casing bug" was a wasm getter wart, not a wire bug; it dies with the wasm
-  surface.)
+  edges between posts.
 - **`attachments` becomes `Vec<{uri, alt?, name?}>`, always present, default `[]` (#48).** Why: v0's
   `Option<Vec<String>>` made every consumer branch on null-vs-empty; and a bare string array can
   never grow per-item metadata without a breaking change. The object form makes alt text (a
@@ -165,8 +166,8 @@ v1: `{pub|priv}/social/v1/posts/{id}/{editId}.json`, referenced versionlessly as
 - **`lock` is kept with corrected semantics.** The value is the lock FILE URI
   (`pubky://<creator>/pub/locks.app/<lock_id>.json`), pubky-only; presence means "locked
   content" regardless of kind. Why: this matches the resolved Locks design (pubky-app #2029);
-  earlier drafts (including v0 doc comments) mis-described it as a lock-server URI. The teaser
-  envelope inside a locked post's `content` stays deliberately client-owned, per the Locks
+  earlier drafts (including v0 doc comments) mis-described it as a lock-server URI. The client-owned
+  teaser object inside a locked post's `content` stays deliberately client-owned, per the Locks
   team's own recorded decision.
 - **Reference fields get one shared cap (1024) and canonicalization.** Why: v0 was a mix
   (attachment URI 200, src 1024, parent/embed/lock effectively uncapped or 200); one
@@ -181,8 +182,9 @@ v1: `{pub|priv}/social/v1/posts/{id}/{editId}.json`, referenced versionlessly as
 
 v0: none. pubky-app hand-rolls `JSON.stringify({title, body})` into `long` posts, unspecified,
 with the cover image smuggled as `attachments[0]` (both verified in the client).
-v1: `PubkySocialArticleContent {title, body, cover_image?}`, a typed envelope in `content` when
-`kind == article`.
+v1: `PubkySocialArticleContent {title, body, cover_image?}`, a typed content envelope in
+`content` when `kind == article` (a per-kind schema inside the content string, distinct from
+the `PostEnvelope` mechanics layer).
 
 - **The envelope exists at all.** Why: an unspec'd JSON convention inside a spec'd field is
   interop debt; any other client rendering articles must reverse-engineer pubky-app. Per-kind
@@ -263,7 +265,7 @@ v1: `priv/social/v1/bookmarks/{filename}.json`.
 - **Moves to `/priv/`.** Why: what you saved is personal state with zero cross-user readers
   (verified: even pubky-app reads bookmark state via nexus, which only surfaces it to the owner);
   world-readable bookmarks are a privacy leak.
-- **The target moves into the filename, reversibly:** `base64url_nopad(canonical target)` for
+- **The target moves into the filename, reversibly (the primary form):** `base64url_nopad(canonical target)` for
   targets up to 187 bytes. Why: LIST returns keys only, so a reversible filename makes "list all
   my bookmarks" ZERO GETs (v0's defining defect, #47's sibling). 187 bytes is the exact
   substrate maximum (250 chars + `.json` = 255), and at that cap base64url is the ONLY standard
@@ -337,7 +339,8 @@ The metadata sidecar is deleted.
   the PUT Content-Type and derives the stored type from magic bytes, then the path extension
   (verified, `file_metadata.rs`); sniff-miss text types (svg, csv, txt, json, html, xml) served
   wrong in v0. The declared type is consumed exactly once, at upload, to derive `{ext}` via a
-  pinned essence regex + single-valued map; it is never stored. The ext is NEVER part of the
+  pinned essence regex (the essence is the bare type/subtype, parameters stripped) +
+  single-valued map; it is never stored. The ext is NEVER part of the
   hash, so the content address and dedup are untouched; `.bin` is the total fallback.
 - **The MIME whitelist gate is removed.** Why: a closed list on world-readable content is a
   forward-compat trap (it already rejected avif, heic, webm audio, opus, wasm); and the Rust

--- a/docs/v0-vs-v1.md
+++ b/docs/v0-vs-v1.md
@@ -355,7 +355,9 @@ The metadata sidecar is deleted.
 ## 11. Feed
 
 v0: `pub/pubky.app/feeds/{HashId(serde_json(config))}`, `{feed: config, name, created_at}`,
-public, enums crash on unknown values.
+public, enums crash on unknown values. (Current v0 also carries the `wot`/`me` reaches and an
+optional `domain_tags` filter, added mid-2026 in #143; v1 includes all three, and `domain_tags`
+joins the id input as its own trailing segment.)
 v1: `{priv|pub}/social/v1/feeds/{id}.json`.
 
 - **Private by default, published by choice (dual-root).** Why: a saved feed is a personal

--- a/docs/v0-vs-v1.md
+++ b/docs/v0-vs-v1.md
@@ -128,8 +128,8 @@ v1: `{pub|priv}/social/v1/posts/{id}/{editId}.json`, referenced versionlessly as
   references, attachments, lock, preservation) ship as a generic crate layer that app specs
   specialize with their own kinds in their own namespaces; the social post is the first
   specialization, wire-identical to the shape described here. Why: the consumers are real
-  (Mapky, Eventky), the layer costs no wire change, and it turns the governance incubation path
-  into something usable at launch.
+  (Mapky, Eventky) and the layer costs no wire change. It is a library convenience; this spec
+  defines no process for admitting a foreign kind into `social/vN`.
 - **Per-edit path versioning.** Storage is one file per edit; the first version reuses the
   post id; every reference (reply, embed, tag, bookmark, collection item) uses the versionless
   form. Why: v0 edits overwrite in place, so nothing distinguishes an edit from a new post on

--- a/docs/v0-vs-v1.md
+++ b/docs/v0-vs-v1.md
@@ -125,8 +125,9 @@ v1: `{pub|priv}/social/v1/posts/{id}/{editId}.json`, referenced versionlessly as
   instead of a hand-rolled convention. All seven concrete kinds survive (each has a live
   creation path in pubky-app); `Link` deliberately stays untyped because the URL lives inside the
   content text, so there is no per-kind shape decision being missed.
-- **`embed` collapses from `{kind, uri}` to a plain URI string, and accepts external
-  http/https targets.** Why: the embedded target's kind is derivable by resolving the target;
+- **`embed` collapses from `{kind, uri}` to a plain URI string, and accepts ANY external
+  target (the universal tier: http/https strictly gated, any other scheme via a pinned opaque
+  gate).** Why: the embedded target's kind is derivable by resolving the target;
   storing it duplicates state that can go stale. External embeds make quoting a web resource
   first-class (the indexer reuses the External Resource nodes it already builds for external tag
   targets), and they keep migration total: v0's `Url::parse` gate accepted arbitrary embed URLs,

--- a/docs/v0-vs-v1.md
+++ b/docs/v0-vs-v1.md
@@ -67,6 +67,13 @@ These are listed once here; the per-model sections below only add what is specif
   private objects may reference both roots. Why: such a reference dangles for every reader but
   the owner and leaks the existence of a private path via the 401-vs-404 oracle. This is the one
   now-or-never piece of the private tier: tightening validation later is epoch-class.
+- **Folder ownership (the composition law).** The specification that defines an object
+  determines its storage namespace, never the application that writes it; apps compose spec
+  packages (each bringing capability scopes and path builders). App namespaces SHOULD carry an
+  epoch (`pub/<app>/v1/...`): unenforceable for foreign namespaces, but the parser already
+  extracts a version from conforming Foreign paths, so the convention buys version-routing for
+  free. `social/vN` itself is governed by the spec repo: a resource type exists exactly when the
+  released crate parses it.
 - **No silent sanitize-rewrites.** v0 silently rewrote `[DELETED]` names to "anonymous",
   truncated-then-blanked over-long `file.src`, and passed unparseable URLs through
   `sanitize_url`. v1 makes invalid input a validation error. Why: silent rewrites hide bugs and
@@ -163,7 +170,7 @@ v1: `{pub|priv}/social/v1/posts/{id}/{editId}.json`, referenced versionlessly as
   synthesizing its own tombstones from DELETE events and real deletion state, never from content
   strings (the same required flag upgrade as the user model).
 
-## 3. ArticleContent (new model, 4.4a)
+## 3. ArticleContent (new model)
 
 v0: none. pubky-app hand-rolls `JSON.stringify({title, body})` into `long` posts, unspecified,
 with the cover image smuggled as `attachments[0]` (both verified in the client).
@@ -226,6 +233,12 @@ v1: `pub/social/v1/tags/{id}.json`, same fields.
   across epochs by construction; nexus dedups on `(author, normalized target, label)` with an
   id-SET per edge so cross-epoch un-tagging works. Why: without this, dual-read double-counts
   every tag and a "like" placed before migration can never be removed after it.
+- **One write location, any target.** Every app writes tags at the author's
+  `pub/social/v1/tags/` (folder ownership above); the target may be any public pubky resource or
+  ANY external URI (the universal tier: http/https via the strict web gate, other schemes like
+  `nostr:`/`geo:`/`ipfs:` via the pinned opaque gate). One logical tag has exactly one address,
+  so re-tags self-overwrite and the indexer drops the writing-app dimension for v1 data; tag
+  files under other app namespaces survive as a legacy READ rule only.
 - Tags stay public-only in v1; tagging private objects is deferred (dual-rooting a resource
   later is additive).
 
@@ -235,6 +248,8 @@ v0: `pub/pubky.app/bookmarks/{HashId(raw uri)}`, content `{uri, created_at}`: wo
 and the filename is one-way, so listing your bookmarks costs one GET per bookmark.
 v1: `priv/social/v1/bookmarks/{filename}.json`.
 
+- **Targets take the universal tier** (any public pubky resource or any external URI), same
+  domain as tags; over-cap and exotic targets all representable (overflow form below).
 - **Moves to `/priv/`.** Why: what you saved is personal state with zero cross-user readers
   (verified: even pubky-app reads bookmark state via nexus, which only surfaces it to the owner);
   world-readable bookmarks are a privacy leak.
@@ -249,8 +264,9 @@ v1: `priv/social/v1/bookmarks/{filename}.json`.
   overflow they could not be represented at all under the reversible form. `~` is outside the
   base64url alphabet, so the two forms are unambiguous.
 - **Content shrinks to `{created_at}`** (plus `target` only in overflow). Why: the target lives
-  in the filename; duplicating it invites mismatch. Recency SORT still costs GETs (created_at is
-  in content), stated honestly.
+  in the filename; duplicating it invites mismatch. Stated honestly: recency SORT still costs
+  GETs (created_at is in content), and each OVERFLOW entry costs one GET to recover its target;
+  primary-form listing is zero GETs.
 - **The hash/encoding input is the canonicalizer's output, never the raw spelling.** Why: v0
   hashed the raw string, so two spellings of one URL made two bookmarks.
 - **Read-side rules are pinned:** decode-then-re-encode must reproduce the filename
@@ -351,7 +367,7 @@ v1: `{priv|pub}/social/v1/feeds/{id}.json`.
   re-publish if desired); pubky-app's v0 flow already works exactly this way, including the
   known orphan-file behavior, now documented instead of accidental.
 
-## 12. Settings (new model, 4.12)
+## 12. Settings (new model)
 
 v0: none in the spec. pubky-app hand-rolls `pub/pubky.app/settings.json`: WORLD-READABLE, exposing
 `require_pin`, `sign_out_inactive`, and the rest of the user's privacy posture to anyone, read
@@ -384,7 +400,8 @@ v1: one closed grammar (normative form: Appendix A of `rfc-v1-social-specs.md`).
   as "upgrade me", not garbage.
 - **Failed id or format validation yields `Unknown`, never an error; every access is
   bounds-safe.** Why: the parser's consumers run unattended over hostile input forever; the two
-  hard errors that remain (invalid host, unknown root) exist only because no `ParsedUri` can be
+  hard errors that remain (an uncanonicalizable URI: bad scheme case, bad host, userinfo,
+  dot-dot, or an unknown root) exist only because no `ParsedUri` can be
   constructed, and callers treat them as skips.
 - **Wrong-root parses to `Unknown` for single-root resources; `visibility` carries the root for
   the dual-root three.** Why: "private object at a public path" becomes unrepresentable at the

--- a/docs/v0-vs-v1.md
+++ b/docs/v0-vs-v1.md
@@ -50,7 +50,7 @@ These are listed once here; the per-model sections below only add what is specif
   them; and the indexer carries unknown members verbatim in its views (readable by any client)
   while indexing only adopted projections. Deliberate extensions SHOULD nest under the reserved `ext` member, defined once
   as unvalidated third-party data: hostile input until an extension's own rules validate it.
-- **Canonical-encoding id validation.** An encoded id is valid iff re-encoding its decoded
+- **Canonical-encoding id validation.** An encoded id is valid if and only if re-encoding its decoded
   bytes reproduces the input, with closed-form regexes and final-char sets. Why: v0's validators
   decode Crockford aliases (`O` as `0`, lowercase, a dangling final bit) and z-base32 dangling
   bits, so one logical id has dozens of accepted spellings, each a DISTINCT homeserver key:

--- a/docs/v0-vs-v1.md
+++ b/docs/v0-vs-v1.md
@@ -71,8 +71,8 @@ These are listed once here; the per-model sections below only add what is specif
   determines its storage namespace, never the application that writes it; apps compose spec
   packages (each bringing capability scopes and path builders). App namespaces SHOULD carry an
   epoch (`pub/<app>/v1/...`): unenforceable for foreign namespaces, but the parser already
-  extracts a version from conforming Foreign paths, so the convention buys version-routing for
-  free. `social/vN` itself is governed by the spec repo: a resource type exists exactly when the
+  surfaces the post-namespace segment from Foreign paths, so for conforming apps that segment IS
+  the version and the convention buys version-routing for free. `social/vN` itself is governed by the spec repo: a resource type exists exactly when the
   released crate parses it.
 - **No silent sanitize-rewrites.** v0 silently rewrote `[DELETED]` names to "anonymous",
   truncated-then-blanked over-long `file.src`, and passed unparseable URLs through
@@ -260,7 +260,7 @@ v1: `priv/social/v1/bookmarks/{filename}.json`.
   encoding that fits at all. base64url is also `/`-free, `%`-free, JS-decodable natively, and
   already in the SDK dependency stack.
 - **An overflow form for long targets:** `~ + HashId(target)` with the target kept in content,
-  up to 1024 bytes. Why: real bookmarks exceed 187 bytes (maps and shop URLs); without an
+  from 188 bytes up to the shared 1024 code-point reference cap. Why: real bookmarks exceed 187 bytes (maps and shop URLs); without an
   overflow they could not be represented at all under the reversible form. `~` is outside the
   base64url alphabet, so the two forms are unambiguous.
 - **Content shrinks to `{created_at}`** (plus `target` only in overflow). Why: the target lives

--- a/docs/v0-vs-v1.md
+++ b/docs/v0-vs-v1.md
@@ -1,0 +1,413 @@
+# v0 vs v1, model by model
+
+> Companion to `rfc-v1-social-specs.md`: the same design, expanded. This document walks every
+> model and explains each change: what it was in v0 (`pubky-app-specs` 0.6.0, verified against
+> the July 2026 main), what it becomes in v1 (`pubky-social-specs` 1.0.0, epoch `social/v1`),
+> and why the change is an improvement: which problem or requirement it tackles.
+
+---
+
+## 0. Cross-cutting changes (apply to every model)
+
+These are listed once here; the per-model sections below only add what is specific to them.
+
+- **Namespace and epoch: `pub/pubky.app/<res>` becomes `{pub|priv}/social/v1/<res>`.**
+  Why: v0 hard-codes one app's domain as the location of SHARED social data and the parser
+  rejects every other app's path, contradicting multi-app interop, the project's first-class
+  goal. And v0 has no version signal at all, while the path is the only channel that survives
+  the events feed, LIST, and anonymous GET. Epochs in the path also make old and new data
+  physically coexist in disjoint subtrees, which is what makes non-destructive client-side
+  migration possible at all. A third, practical reason the new segment is a bare word: dotted
+  directory names are a filesystem hazard. Back up or export a homeserver tree to disk (pubky-app's
+  data-export ZIP preserves paths) and you get a folder literally named `pubky.app`, which macOS
+  treats as an application bundle: contents hidden behind an app icon, double-click tries to
+  launch it. `social` carries no extension, and no directory in the social tree ever will; only
+  leaf files carry extensions.
+- **`.json` on every JSON leaf.** Why: the homeserver derives the served Content-Type from
+  magic bytes and then the path extension; extensionless JSON (everything in v0 except
+  `profile.json`) serves as `application/octet-stream`/plaintext. The extension fixes serving
+  and downloads for free, using machinery the server already has.
+- **A privacy tier.** Why: v0 stores mutes, bookmarks, saved feeds, and the client's
+  settings world-readable and on the public events feed although their verified reader set is
+  exactly one, the owner's own client. `/priv/` (owner-only, excluded from public events,
+  shipped on pubky-core main) is their correct home. The rule that decides placement is the
+  ACTUAL reader set, not aspiration.
+- **Type rename `PubkyApp*` to `PubkySocial*`, wire-invariant.** Why: the crate name and type
+  prefixes teach every integrator that one app owns shared data. Serde field names and enum
+  strings stay byte-identical: this break costs a compile, not a migration.
+- **Forward-compat contract.** Every wire enum gains `#[serde(other)] Unknown`; no model
+  may ever use `deny_unknown_fields`; every future field must be optional, defaulted, and
+  skip-if-none. Unknown members are tolerated on read AND preserved on rewrite: every wire model
+  carries an opaque flattened catch-all map, so a rewriting client round-trips members it does
+  not understand (tolerating without preserving would let any older client silently destroy
+  every field added after it shipped). Why: v0 has exactly one `Unknown` catch-all (`PostKind`); adding a value to any
+  feed enum hard-crashes every old client on deserialize. This contract is what turns "break
+  once, then grow additively" from an aspiration into a property.
+- **Canonical-encoding id validation.** An encoded id is valid iff re-encoding its decoded
+  bytes reproduces the input, with closed-form regexes and final-char sets. Why: v0's validators
+  decode Crockford aliases (`O` as `0`, lowercase, a dangling final bit) and z-base32 dangling
+  bits, so one logical id has dozens of accepted spellings, each a DISTINCT homeserver key:
+  identity forks, dedup splits, and broken bytewise ordering. Verified empirically. The ed25519
+  point check also leaves PubkyId validation: v0 ran it native-only, which made Rust and JS
+  disagree by construction.
+- **Pinned text operations.** Trim uses a frozen whitespace table (a DATA asset); tag-label
+  lowercasing is ASCII-only; lengths are code points; all wire i64s must fit in 53 bits. Why:
+  engine trim/lowercase/Unicode tables differ between Rust and JS and across browser versions
+  (verified divergences on U+FEFF, U+0085, full-Unicode case mapping, i64 rounding), and
+  content-addressed ids freeze whatever functions feed them. Changing these later re-ids data,
+  an epoch-class break, so they are pinned now, engine-free.
+- **One URI grammar.** All `pubky://` validation goes through one raw-string
+  canonicalizer (accepts the SDK short form, #120; rejects userinfo, `..`, `%`, query, fragment,
+  whitespace, control, #141); web references are gated by a pinned regex; `url::Url` and WHATWG
+  `new URL()` leave the normative surface entirely. Why: v0's `url::Url` normalizes junk into
+  acceptance and rejects valid short forms, and two independent validation surfaces (parser vs
+  field validators) had already drifted; engine URL parsers cannot be version-pinned across
+  browsers.
+- **The root rule.** A public-rooted object must never reference a priv-root pubky URI;
+  private objects may reference both roots. Why: such a reference dangles for every reader but
+  the owner and leaks the existence of a private path via the 401-vs-404 oracle. This is the one
+  now-or-never piece of the private tier: tightening validation later is epoch-class.
+- **No silent sanitize-rewrites.** v0 silently rewrote `[DELETED]` names to "anonymous",
+  truncated-then-blanked over-long `file.src`, and passed unparseable URLs through
+  `sanitize_url`. v1 makes invalid input a validation error. Why: silent rewrites hide bugs and
+  make two implementations disagree about what was stored.
+
+---
+
+## 1. User (profile)
+
+v0: `pub/pubky.app/profile.json`, `{name, bio?, image?, links?, status?}`.
+v1: `pub/social/v1/profile.json`, same fields.
+
+- **`image` explicitly allows `pubky`, `http`, `https` and uses the one shared image validator,
+  cap 300.** Why: pubky-app avatars ARE pubky URIs today (`pubky://<pk>/pub/.../files/<id>` is what
+  the client writes into `image`, verified end-to-end); an http-only rule, which one design
+  draft proposed, would have invalidated every real avatar. One validator now covers
+  `user.image` and both `cover_image` fields, one rule for one kind of value.
+- **The `[DELETED]` name rule becomes an honest rejection.** v0 silently rewrote a user named
+  `[DELETED]` to "anonymous"; v1 REJECTS the exact literal as a validation error instead (and
+  likewise for `post.content`). Why the rule must exist at all: nexus keys its internal
+  tombstones on that literal and its queries exclude `[DELETED]`-named users (verified), so a
+  user carrying the name would be treated as deleted by the index. Why rejection beats rewrite:
+  no silent mutation, and the reservation can be RETIRED additively once nexus keys tombstones
+  on a real flag (loosening validation is non-breaking). Substring occurrences are fine; only
+  the exact value is reserved.
+- **`links[].url` validated by the pinned web gate instead of `Url::parse` + `sanitize_url`.**
+  Why: cross-implementation determinism (cross-cutting rationale above); v0's `sanitize_url`
+  passed invalid URLs through unchanged.
+- Unchanged: field set, caps (name 3..50, bio 160, links 5 x {100, 300}, status 50), and wire
+  field names. The profile stays public: identity is the one thing that must be readable.
+
+## 2. Post
+
+v0: `pub/pubky.app/posts/{id}`, one flat file, overwritten on edit;
+`{content, kind, parent?, embed?: {kind, uri}, attachments?: [String], lock?}`.
+v1: `{pub|priv}/social/v1/posts/{id}/{editId}.json`, referenced versionlessly as
+`posts/{id}`.
+
+- **Per-edit path versioning.** Storage is one file per edit; the first version reuses the
+  post id; every reference (reply, embed, tag, bookmark, collection item) uses the versionless
+  form. Why: v0 edits overwrite in place, so nothing distinguishes an edit from a new post on
+  the events feed, and there is no history. A counter-based scheme was rejected because the
+  substrate has no compare-and-swap: counters race across the owner's devices. TimestampId
+  editIds mint with no prior read, sort chronologically under bytewise LIST order, and
+  `decode(editId)` doubles as an approximate edit timestamp. Versionless references mean edits
+  never orphan replies or re-key tags. This is now-or-never: a `posts/{id}` file and a
+  `posts/{id}/` directory are mutually exclusive on the homeserver, so the layout cannot be
+  retrofitted.
+- **Dual-root: private posts.** Drafts, personal notes, and private collections live under
+  `/priv/` with identical shapes and ids; publish is a deterministic root migration; unpublish
+  deletes the public copies. Why: drafts and private collections are committed
+  product needs, and the Locks flow independently demonstrates the value of post-shaped private
+  content. Public stays the default root, so this adds capability without changing anyone's
+  existing mental model.
+- **Kinds renamed: `short` to `note`, `long` to `article`.** Why: the old names describe length,
+  not nature; `article` is what the thing actually is, and it now has a typed envelope (model 3)
+  instead of a hand-rolled convention. All seven concrete kinds survive (each has a live
+  creation path in pubky-app); `Link` deliberately stays untyped because the URL lives inside the
+  content text, so there is no per-kind shape decision being missed.
+- **`embed` collapses from `{kind, uri}` to a plain URI string.** Why: the embedded target's
+  kind is derivable by resolving the target; storing it duplicates state that can go stale. (The
+  often-cited "casing bug" was a wasm getter wart, not a wire bug; it dies with the wasm
+  surface.)
+- **`attachments` becomes `Vec<{uri, alt?, name?}>`, always present, default `[]` (#48).** Why: v0's
+  `Option<Vec<String>>` made every consumer branch on null-vs-empty; and a bare string array can
+  never grow per-item metadata without a breaking change. The object form makes alt text (a
+  committed accessibility need) and `name` (the display filename, relocated from the deleted v0
+  File object by the media collapse) ship now, and every future per-attachment field (hash,
+  blurhash, dimensions, `content_type`/`size`) additive. Exactly two optional fields ship;
+  nothing speculative.
+- **`lock` is kept with corrected semantics.** The value is the lock FILE URI
+  (`pubky://<creator>/pub/locks.app/<lock_id>.json`), pubky-only; presence means "locked
+  content" regardless of kind. Why: this matches the resolved Locks design (pubky-app #2029);
+  earlier drafts (including v0 doc comments) mis-described it as a lock-server URI. The teaser
+  envelope inside a locked post's `content` stays deliberately client-owned, per the Locks
+  team's own recorded decision.
+- **Reference fields get one shared cap (1024) and canonicalization.** Why: v0 was a mix
+  (attachment URI 200, src 1024, parent/embed/lock effectively uncapped or 200); one
+  `reference_uri_max_length` replaces four inconsistent rules.
+- **The `[DELETED]` content sentinel is removed; absence is the tombstone.** Why: a
+  magic content string must not survive the one clean break; deletion is now defined honestly as
+  "delete every version in every epoch and both roots, retry to completion", with nexus
+  synthesizing its own tombstones from DELETE events.
+
+## 3. ArticleContent (new model, 4.4a)
+
+v0: none. pubky-app hand-rolls `JSON.stringify({title, body})` into `long` posts, unspecified,
+with the cover image smuggled as `attachments[0]` (both verified in the client).
+v1: `PubkySocialArticleContent {title, body, cover_image?}`, a typed envelope in `content` when
+`kind == article`.
+
+- **The envelope exists at all.** Why: an unspec'd JSON convention inside a spec'd field is
+  interop debt; any other client rendering articles must reverse-engineer pubky-app. Per-kind
+  content shapes are now-or-never (changing what `content` means for a kind is a break), so this
+  is exactly what the one break budget is for.
+- **`cover_image` moves INTO the envelope.** Why: `attachments[0]`-as-cover is positional
+  convention, invisible in the type system; the field is explicit, validated by the shared image
+  validator, and composes with real attachments. Migration maps the old convention in.
+- **Articles may carry `parent`, `embed`, and `attachments`.** Why: an article can legitimately
+  be a reply or a quote and carry media; and a forbid rule would have made any v0 long post
+  holding more than the single mapped cover attachment FAIL migration. Composability plus
+  migration totality.
+- **Caps: title 100 code points, body 50000 (renamed from `post_long_content_max_length`), raw
+  envelope 52000.** Why: the title cap formalizes what pubky-app's UI already enforces; the raw cap
+  is a cheap pre-parse bound. pubky-app's brittle "body budget = long cap minus 100 minus 22 bytes
+  of JSON skeleton" arithmetic dies because validation is field-level now.
+
+## 4. CollectionContent
+
+v0: `PubkyAppCollectionContent {name, description?, items[], cover_image?}` in `content` when
+`kind == collection` (shipped shortly before v1).
+v1: same shape, three rule changes.
+
+- **`items` accept any reference-tier pubky URI (any resource, any app).** Why: v0's item check
+  hard-restricted items to `posts/` under `pubky.app`, contradicting the interop goal; a curated
+  list may legitimately include files, profiles, or another app's resources. Items stay
+  pubky-only (a web link belongs in a post) and stay plain strings (per-item annotation is
+  speculative, recorded as an accepted low-probability future break).
+- **`cover_image` uses the shared image validator (cap 300).** Why: one rule for one kind of
+  value, aligned with Article and `user.image`.
+- **Private collections come free.** A collection post under `/priv/` is a private
+  curation list, a requested future feature that costs zero extra spec surface because
+  collections are posts.
+- Unchanged: the v0 guards (collections carry no parent, embed, or attachments) because they are
+  live in v0 and cost migration nothing.
+
+## 5. Tag
+
+v0: `pub/pubky.app/tags/{id}`, `{uri, label, created_at}`, id = `HashId("{uri}:{label}")` where
+the uri was normalized by `Url::parse(...).to_string()` and the label by full-Unicode lowercase.
+v1: `pub/social/v1/tags/{id}.json`, same fields.
+
+- **The hash input is pinned: canonicalized target + frozen-trim + ASCII-folded label.** Why:
+  v0's normalization was engine-dependent twice over (`url` crate re-serialization and ICU case
+  tables), and content-addressed ids freeze their input functions forever; an engine-skew fork
+  in a tag id never heals. The ASCII-only fold trades non-Latin case-insensitive dedup (bounded
+  regression, documented) for permanent cross-implementation determinism.
+- **The injectivity invariant is stated:** `"{uri}:{label}"` is unambiguous only because labels
+  reject `:`; that restriction may never be lifted while the id format stands. Why: implicit
+  invariants get broken by well-meaning future edits.
+- **`uri` gains the shared 1024 cap** (was uncapped) **and hash inputs always use the
+  canonicalizer's output** (v0's bookmark hashed the RAW string while tag hashed a normalized
+  one, two different identity rules for the same kind of value).
+- **Migration non-invariance is documented:** a tag id embedding a social target changes
+  across epochs by construction; nexus dedups on `(author, normalized target, label)` with an
+  id-SET per edge so cross-epoch un-tagging works. Why: without this, dual-read double-counts
+  every tag and a "like" placed before migration can never be removed after it.
+- Tags stay public-only in v1; tagging private objects is deferred (dual-rooting a resource
+  later is additive).
+
+## 6. Bookmark
+
+v0: `pub/pubky.app/bookmarks/{HashId(raw uri)}`, content `{uri, created_at}`: world-readable,
+and the filename is one-way, so listing your bookmarks costs one GET per bookmark.
+v1: `priv/social/v1/bookmarks/{filename}.json`.
+
+- **Moves to `/priv/`.** Why: what you saved is personal state with zero cross-user readers
+  (verified: even pubky-app reads bookmark state via nexus, which only surfaces it to the owner);
+  world-readable bookmarks are a privacy leak.
+- **The target moves into the filename, reversibly:** `base64url_nopad(canonical target)` for
+  targets up to 187 bytes. Why: LIST returns keys only, so a reversible filename makes "list all
+  my bookmarks" ZERO GETs (v0's defining defect, #47's sibling). 187 bytes is the exact
+  substrate maximum (250 chars + `.json` = 255), and at that cap base64url is the ONLY standard
+  encoding that fits at all. base64url is also `/`-free, `%`-free, JS-decodable natively, and
+  already in the SDK dependency stack.
+- **An overflow form for long targets:** `~ + HashId(target)` with the target kept in content,
+  up to 1024 bytes. Why: real bookmarks exceed 187 bytes (maps and shop URLs); without an
+  overflow they could not be represented at all under the reversible form. `~` is outside the
+  base64url alphabet, so the two forms are unambiguous.
+- **Content shrinks to `{created_at}`** (plus `target` only in overflow). Why: the target lives
+  in the filename; duplicating it invites mismatch. Recency SORT still costs GETs (created_at is
+  in content), stated honestly.
+- **The hash/encoding input is the canonicalizer's output, never the raw spelling.** Why: v0
+  hashed the raw string, so two spellings of one URL made two bookmarks.
+- **Read-side rules are pinned:** decode-then-re-encode must reproduce the filename
+  byte-for-byte, UTF-8 decode is fatal, failures are skipped entries. Why: JS base64 decoding is
+  catastrophically lenient (verified: it accepts padding, aliases, and garbage the Rust crate
+  rejects), and a hostile filename must not fork implementations.
+
+## 7. Follow
+
+v0: `pub/pubky.app/follows/{followeePk}`, `{created_at}`.
+v1: `pub/social/v1/follows/{followeePk}.json`. Shape unchanged.
+
+- Only the cross-cutting changes apply (path, `.json`, canonical PubkyId spelling). Follows stay
+  public: they are the social graph, nexus's core input. The filename-is-the-target pattern
+  (one LIST answers "who do I follow") was already right in v0 and is kept.
+
+## 8. Mute
+
+v0: `pub/pubky.app/mutes/{muteePk}`, `{created_at}`, world-readable.
+v1: `priv/social/v1/mutes/{muteePk}.json`. Shape unchanged.
+
+- **Moves to `/priv/`.** Why: who you muted is among the most sensitive social data there is,
+  and its verified reader set is the owner alone: nexus main has ZERO mute consumers (the
+  watcher no-ops mute events), and pubky-app already reads mutes by LISTing its own directory. The
+  move costs nexus nothing and the client a path change.
+
+## 9. LastRead
+
+v0: `pub/pubky.app/last_read` (no extension), `{timestamp}` in MILLISECONDS, world-readable.
+v1: `priv/social/v1/last_read.json`, microseconds.
+
+- **Moves to `/priv/`.** Why: pure reading-activity metadata, no cross-user reader.
+- **Milliseconds become microseconds.** Why: it was the lone unit outlier in a spec where every
+  other timestamp is microseconds; a unit change is only fixable at a break, so this is the
+  window. Migration multiplies by 1000, the only unit change in the shared transform table
+  (the pubky-app-owned settings import performs the same ms-to-µs conversion on its side).
+
+## 10. File (media), the v0 File + Blob pair collapsed
+
+v0: TWO objects per upload: `files/{id}` metadata (`{name, created_at, src, content_type,
+size}`, with a HARD 21-entry MIME whitelist gate and a silent truncate-then-blank sanitize on
+`src`) pointing at `blobs/{HashId(bytes)}`, extensionless raw bytes.
+v1: ONE object: `{pub|priv}/social/v1/files/{hash}.{ext}`, the raw bytes, content-addressed.
+The metadata sidecar is deleted.
+
+- **The collapse itself.** Why: both premises of the v0 split died. `name` now has a better home,
+  the attachment object's optional `name` field (per-reference, so two posts can attach the same
+  bytes under different names, which one-name-per-File could not express); authoring time is
+  carried by the referencing post's own id; `size` and the served type come free from the bytes
+  and headers (nexus downloads the bytes anyway to build CDN variants); and the v1 nexus adapter
+  is new code regardless, so "nexus is event-driven off the File PUT" stopped being an argument.
+  Deleted with it: the `src` indirection, the two-PUT upload dance, the several-metadata-objects-
+  per-blob extension ambiguity, and the word "blob" (a backup now shows a `files/` folder holding
+  openable `{hash}.jpg` files). Honest costs, accepted: renaming an upload means editing the
+  referencing post; the same bytes declared under two MIMEs duplicate storage instead of sharing
+  one blob (rare, documented fork); an uploaded-but-never-referenced file carries no metadata.
+- **A canonical, path-only extension from a frozen MIME-to-ext map.** Why: the homeserver ignores
+  the PUT Content-Type and derives the stored type from magic bytes, then the path extension
+  (verified, `file_metadata.rs`); sniff-miss text types (svg, csv, txt, json, html, xml) served
+  wrong in v0. The declared type is consumed exactly once, at upload, to derive `{ext}` via a
+  pinned essence regex + single-valued map; it is never stored. The ext is NEVER part of the
+  hash, so the content address and dedup are untouched; `.bin` is the total fallback.
+- **The MIME whitelist gate is removed.** Why: a closed list on world-readable content is a
+  forward-compat trap (it already rejected avif, heic, webm audio, opus, wasm); and the Rust
+  `mime` crate could not stay the judge because its verdicts are not reproducible in JS and it
+  accepts the malformed `"image/"` (verified). The old list survives as an advisory hint.
+- **The parser strips exactly one known-map extension before id validation.** Why: without the
+  strip, recompute-and-compare id validation would reject every single media file.
+- **Dual-root.** Why: a private draft whose images sat in public `files/` would leak (media
+  directories are anonymously LISTable). Publish copies bytes across roots identically (the hash,
+  and therefore the id, is root-independent).
+
+## 11. Feed
+
+v0: `pub/pubky.app/feeds/{HashId(serde_json(config))}`, `{feed: config, name, created_at}`,
+public, enums crash on unknown values.
+v1: `{priv|pub}/social/v1/feeds/{id}.json`.
+
+- **Private by default, published by choice (dual-root).** Why: a saved feed is a personal
+  config whose verified reader set is the owner (pubky-app only ever LISTs its own feeds dir; no
+  share or subscribe feature exists); public-by-default was aspiration, not fact. Publishing is
+  a deliberate act: copy the same bytes to `/pub/`, unpublish deletes the copy.
+- **The id stays content-addressed but the hash input is a pinned canonical string, never serde
+  output.** Why the content-addressing: identical configs self-overwrite
+  (natural dedup), migration re-derives ids purely, and two users publishing the same config
+  share an id, so public-feed identity is readable from `/events/` paths alone, which makes a
+  future cross-homeserver popularity ranking purely additive indexer work. Why the pinned
+  string: v0 hashed `serde_json::to_string(config)`, which silently re-ids every feed on any
+  struct reshuffle and is not byte-reproducible in JS. `name` and `created_at` stay outside the
+  hash: personal labels on a shared identity. Tags sort inside the input so `[a,b]` and `[b,a]`
+  are one filter; the format is injective because `:` and `,` are invalid in labels.
+- **All three enums gain `Unknown`; an unknown `content` filter degrades to "no filter".** Why:
+  the highest value-per-byte fix in v1. In v0, the day a new reach/layout/sort value ships,
+  every old client hard-crashes on deserialize; this is the one guarantee only a version
+  boundary can make.
+- **`name` gains a cap (100).** Why: it was the only unbounded display name.
+- **Edit semantics stated honestly:** a config change derives a new id (write new, delete old,
+  re-publish if desired); pubky-app's v0 flow already works exactly this way, including the
+  known orphan-file behavior, now documented instead of accidental.
+
+## 12. Settings (new model, 4.12)
+
+v0: none in the spec. pubky-app hand-rolls `pub/pubky.app/settings.json`: WORLD-READABLE, exposing
+`require_pin`, `sign_out_inactive`, and the rest of the user's privacy posture to anyone, read
+by nobody but the owner's client (verified: the only unspec'd homeserver artifact in the app).
+v1: `PubkySocialSettings` at `priv/social/v1/settings.json`.
+
+- **It exists, and it is private.** Why: the strongest reader-set case in the audit; a security
+  posture file must not be public. Spec'd because its content (notification, content-filter,
+  and language preferences) is client-portable social state any client benefits from sharing.
+- **Every section is optional.** Why: a client writes only what it uses; other clients' unknown
+  sections and fields survive a rewrite via the preservation rule (cross-cutting above), not
+  merely deserialization tolerance, which alone would drop them on the next whole-file write.
+- **Whole-file last-write-wins on `updated_at` (now microseconds).** Why: it formalizes exactly
+  what pubky-app already does at bootstrap; anything cleverer (field-wise merge) is machinery
+  without a demonstrated need.
+- **The per-file `version` field is dropped.** Why: verified dead, pubky-app checks it but never
+  bumps it; schema evolution is governed by the path epoch and crate semver like every other
+  model, so a second, parallel versioning channel is a contradiction waiting to happen.
+
+## 13. Parser and `Resource` (the read side of every model)
+
+v0: `url::Url`-based, hard-rejects any app path that is not `pubky.app`, silently accepts
+userinfo/`..`/query/fragment/extra segments, never validates ids, never panics, but errors on
+all foreign data.
+v1: one closed grammar (normative form: Appendix A of `rfc-v1-social-specs.md`).
+
+- **`Foreign` and `UnsupportedVersion` are first-class handled categories, never errors.** Why:
+  v0's defining interop failure was erroring on other apps' data; an indexer iterating the
+  events feed must classify and skip, not crash or log-spam. A future `social/v2` object reads
+  as "upgrade me", not garbage.
+- **Failed id or format validation yields `Unknown`, never an error; every access is
+  bounds-safe.** Why: the parser's consumers run unattended over hostile input forever; the two
+  hard errors that remain (invalid host, unknown root) exist only because no `ParsedUri` can be
+  constructed, and callers treat them as skips.
+- **Wrong-root parses to `Unknown` for single-root resources; `visibility` carries the root for
+  the dual-root three.** Why: "private object at a public path" becomes unrepresentable at the
+  type level, the one structural guard the homeserver cannot give.
+- **Reserved names: `^v[0-9]+$` epoch segments, `_`-prefixed private filenames, the `ext`
+  field.** Why: reserving names is free; colliding with them later is not.
+
+## 14. IDs (the identity layer under every model)
+
+- **TimestampId: unchanged format, monotonic mint guard in BOTH implementations.** Why:
+  the JS runtime mints at millisecond resolution, so same-ms writes collide on path, which
+  under path-versioning is silent data loss; the guard is three lines. The JS codec uses BigInt,
+  byte-for-byte equal to Rust (verified including `i64::MAX`).
+- **HashId: unchanged format (blake3, first 16 bytes, Crockford, 26 chars), kept at 128 bits.**
+  Why: under owner-only-write, pubkey-namespaced paths, a collision cannot substitute content at
+  someone else's path, and per-user counts are nowhere near the birthday bound; widening buys
+  nothing and costs every path 13 chars.
+- **Canonical spellings enforced everywhere** (cross-cutting above), and the stale "z-base32"
+  doc comments on Crockford code die.
+
+---
+
+## The deltas at a glance
+
+| Model | v0 path | v1 path | Headline change |
+|---|---|---|---|
+| User | `pub/pubky.app/profile.json` | `pub/social/v1/profile.json` | pubky avatars legal; `[DELETED]` sanitize gone |
+| Post | `posts/{id}` flat file | `{root}/.../posts/{id}/{editId}.json` | edit versioning; dual-root drafts; kinds renamed; attachments become objects |
+| Article | (hand-rolled JSON) | typed envelope | formalized; cover in envelope |
+| Collection | envelope, posts-only items | envelope, reference-tier items | interop items; private collections free |
+| Tag | `tags/{id}` | `tags/{id}.json` | engine-free pinned hash input |
+| Bookmark | `bookmarks/{HashId}` public, GET-per-file | `priv/.../bookmarks/{b64u\|~hash}.json` | private, reversible filename, overflow form |
+| Follow | `follows/{pk}` | `follows/{pk}.json` | unchanged shape |
+| Mute | `mutes/{pk}` public | `priv/.../mutes/{pk}.json` | private |
+| LastRead | `last_read` ms, public | `priv/.../last_read.json` µs | private; unit fixed |
+| File (media) | `files/{id}` meta + `blobs/{hash}` bytes | `{root}/.../files/{hash}.{ext}` | ONE object (collapse); canonical extension; dual-root |
+| Feed | `feeds/{HashId(serde_json)}` public | `{priv\|pub}/.../feeds/{id}.json` | private default + publish; pinned hash string; enums get Unknown |
+| Settings | (unspec'd, public) | `priv/.../settings.json` | spec'd, private, version field dropped |

--- a/docs/v0-vs-v1.md
+++ b/docs/v0-vs-v1.md
@@ -46,7 +46,8 @@ These are listed once here; the per-model sections below only add what is specif
   needs: TOTAL object size is capped (posts 512 KiB, other resources 64 KiB, on stored bytes),
   rewrites fetch from the homeserver rather than indexer views, and the indexer carries unknown
   members verbatim in its views (readable by any client) while indexing only adopted
-  projections.
+  projections. Deliberate extensions SHOULD nest under the reserved `ext` member, defined once
+  as unvalidated third-party data: hostile input until an extension's own rules validate it.
 - **Canonical-encoding id validation.** An encoded id is valid iff re-encoding its decoded
   bytes reproduces the input, with closed-form regexes and final-char sets. Why: v0's validators
   decode Crockford aliases (`O` as `0`, lowercase, a dangling final bit) and z-base32 dangling

--- a/docs/v0-vs-v1.md
+++ b/docs/v0-vs-v1.md
@@ -84,14 +84,13 @@ v1: `pub/social/v1/profile.json`, same fields.
   the client writes into `image`, verified end-to-end); an http-only rule, which one design
   draft proposed, would have invalidated every real avatar. One validator now covers
   `user.image` and both `cover_image` fields, one rule for one kind of value.
-- **The `[DELETED]` name rule becomes an honest rejection.** v0 silently rewrote a user named
-  `[DELETED]` to "anonymous"; v1 REJECTS the exact literal as a validation error instead (and
-  likewise for `post.content`). Why the rule must exist at all: nexus keys its internal
-  tombstones on that literal and its queries exclude `[DELETED]`-named users (verified), so a
-  user carrying the name would be treated as deleted by the index. Why rejection beats rewrite:
-  no silent mutation, and the reservation can be RETIRED additively once nexus keys tombstones
-  on a real flag (loosening validation is non-breaking). Substring occurrences are fine; only
-  the exact value is reserved.
+- **The `[DELETED]` magic string dies entirely.** v0 silently rewrote a user named `[DELETED]`
+  to "anonymous" because the indexer keys its deletion handling on that literal (verified), so a
+  user carrying the name would be treated as deleted. v1 removes the rewrite with NO replacement
+  rule: `[DELETED]` is an ordinary legal name. The load-bearing requirement moves to the indexer
+  contract instead: **nexus must key deletion on a real flag** (`deleted` on the indexed row)
+  before indexing v1 data, and display of deleted accounts becomes pure client presentation. A
+  magic string survives nowhere in the v1 wire rules.
 - **`links[].url` validated by the pinned web gate instead of `Url::parse` + `sanitize_url`.**
   Why: cross-implementation determinism (cross-cutting rationale above); v0's `sanitize_url`
   passed invalid URLs through unchanged.
@@ -149,7 +148,8 @@ v1: `{pub|priv}/social/v1/posts/{id}/{editId}.json`, referenced versionlessly as
 - **The `[DELETED]` content sentinel is removed; absence is the tombstone.** Why: a
   magic content string must not survive the one clean break; deletion is now defined honestly as
   "delete every version in every epoch and both roots, retry to completion", with nexus
-  synthesizing its own tombstones from DELETE events.
+  synthesizing its own tombstones from DELETE events and real deletion state, never from content
+  strings (the same required flag upgrade as the user model).
 
 ## 3. ArticleContent (new model, 4.4a)
 

--- a/docs/v0-vs-v1.md
+++ b/docs/v0-vs-v1.md
@@ -27,11 +27,14 @@ These are listed once here; the per-model sections below only add what is specif
   magic bytes and then the path extension; extensionless JSON (everything in v0 except
   `profile.json`) serves as `application/octet-stream`/plaintext. The extension fixes serving
   and downloads for free, using machinery the server already has.
-- **A privacy tier.** Why: v0 stores mutes, bookmarks, saved feeds, and the client's
-  settings world-readable and on the public events feed although their verified reader set is
-  exactly one, the owner's own client. `/priv/` (owner-only, excluded from public events,
-  shipped on pubky-core main) is their correct home. The rule that decides placement is the
-  ACTUAL reader set, not aspiration.
+- **A privacy tier.** Why: v0 stores mutes, bookmarks and saved feeds world-readable and on the
+  public events feed although their verified reader set is exactly one, the owner's own client.
+  `/priv/` (owner-only, excluded from public events, shipped on pubky-core main) is their correct
+  home. The rule that decides VISIBILITY is the ACTUAL reader set, not aspiration.
+  A second rule decides OWNERSHIP, and it outranks the first: whose specification defines the
+  object. `settings.json` and `last_read` pass the reader-set test and still leave this spec
+  (sections 9 and 12), because preferences general to any application are not social data however
+  portable they are. Reader set tells you which root; the defining spec tells you which namespace.
 - **Type rename `PubkyApp*` to `PubkySocial*`, wire-invariant.** Why: the crate name and type
   prefixes teach every integrator that one app owns shared data. Serde field names and enum
   strings stay byte-identical: this break costs a compile, not a migration.
@@ -208,11 +211,18 @@ v0: `PubkyAppCollectionContent {name, description?, items[], cover_image?}` in `
 `kind == collection` (shipped shortly before v1).
 v1: same shape, three rule changes.
 
-- **`items` accept any reference-tier pubky URI (any resource, any app).** Why: v0's item check
-  hard-restricted items to `posts/` under `pubky.app`, contradicting the interop goal; a curated
-  list may legitimately include files, profiles, or another app's resources. Items stay
-  pubky-only (a web link belongs in a post) and stay plain strings (per-item annotation is
-  speculative, recorded as an accepted low-probability future break).
+- **`items` accept ANY scheme-shaped URI, on the universal tier.** Why: v0's item check
+  hard-restricted items to `posts/` under `pubky.app`, contradicting the interop goal. The first
+  draft relaxed that to any pubky URI while keeping items pubky-only, on the reasoning that "a web
+  link belongs in a post". That reasoning does not survive the obvious case: a collection of OSM
+  locations or Spotify tracks is a collection of those resources, not a collection of posts about
+  them. Tags, bookmarks and `post.embed` were already universal, so collections were the last
+  field narrowed for no reason that held.
+- **`items` become objects, `{uri, note?}`, not plain strings.** Why: the earlier draft kept plain
+  strings and recorded per-item annotation as an accepted future break. It is not worth accepting.
+  `attachments` makes exactly this move in v1 (section 2) because per-item metadata is additive
+  once the element is an object and a wire break once it is not. Doing it now costs one level of
+  nesting; doing it later costs an epoch.
 - **`cover_image` uses the shared image validator (cap 300).** Why: one rule for one kind of
   value, aligned with Article and `user.image`.
 - **Private collections come free.** A collection post under `/priv/` is a private
@@ -305,16 +315,29 @@ v1: `priv/social/v1/mutes/{muteePk}.json`. Shape unchanged.
   watcher no-ops mute events), and pubky-app already reads mutes by LISTing its own directory. The
   move costs nexus nothing and the client a path change.
 
-## 9. LastRead
+## 9. LastRead, and 12. Settings: both leave this spec
 
-v0: `pub/pubky.app/last_read` (no extension), `{timestamp}` in MILLISECONDS, world-readable.
-v1: `priv/social/v1/last_read.json`, microseconds.
+v0: `pub/pubky.app/last_read` (no extension, MILLISECONDS) and `pub/pubky.app/settings.json`, both
+WORLD-READABLE. `settings.json` was the only unspec'd homeserver artifact in the app, exposing
+`require_pin`, `sign_out_inactive` and the rest of the user's privacy posture to anyone, read by
+nobody but the owner's client.
+v1: both move to the writing app's namespace, `priv/app.pubky/v1/` for pubky-app, and leave this
+library entirely: no shared model, no validation, no builders.
 
-- **Moves to `/priv/`.** Why: pure reading-activity metadata, no cross-user reader.
-- **Milliseconds become microseconds.** Why: it was the lone unit outlier in a spec where every
-  other timestamp is microseconds; a unit change is only fixable at a break, so this is the
-  window. Migration multiplies by 1000, the only unit change in the shared transform table
-  (the pubky-app-owned settings import performs the same ms-to-µs conversion on its side).
+- **Why they leave rather than move to `priv/social/v1/`.** Device state (`require_pin`,
+  `sign_out_inactive`) is not social by any reading. `language` is the interesting case: it is
+  genuinely portable, so it passes the reader-set test, and it still leaves, because it is general
+  to ANY application rather than to social ones. A spec that defines social objects does not get to
+  own general preferences by virtue of having noticed them first. The earlier draft argued the
+  opposite, that portability alone justified adopting them; that argument is withdrawn.
+- **Consequence, accepted.** A second social client starts your unread count from scratch, and
+  neither file is validated by anything shared. That is the correct trade for state whose only
+  reader is one app, and it is precisely why they are leaving.
+- **Migration still carries them.** The v0 values are imported into the new location by the
+  pubky-app `/migrate` route, including the `last_read` millisecond-to-microsecond conversion.
+  That conversion is now app-owned; the shared transform table has no unit changes at all.
+- **Not a precedent for stripping the spec.** Mutes and bookmarks stay, because a different social
+  client reading them gets value: they shape what you see in a shared social graph.
 
 ## 10. File (media), the v0 File + Blob pair collapsed
 
@@ -382,26 +405,6 @@ v1: `{priv|pub}/social/v1/feeds/{id}.json`.
   re-publish if desired); pubky-app's v0 flow already works exactly this way, including the
   known orphan-file behavior, now documented instead of accidental.
 
-## 12. Settings (new model)
-
-v0: none in the spec. pubky-app hand-rolls `pub/pubky.app/settings.json`: WORLD-READABLE, exposing
-`require_pin`, `sign_out_inactive`, and the rest of the user's privacy posture to anyone, read
-by nobody but the owner's client (verified: the only unspec'd homeserver artifact in the app).
-v1: `PubkySocialSettings` at `priv/social/v1/settings.json`.
-
-- **It exists, and it is private.** Why: the strongest reader-set case in the audit; a security
-  posture file must not be public. Spec'd because its content (notification, content-filter,
-  and language preferences) is client-portable social state any client benefits from sharing.
-- **Every section is optional.** Why: a client writes only what it uses; other clients' unknown
-  sections and fields survive a rewrite via the preservation rule (cross-cutting above), not
-  merely deserialization tolerance, which alone would drop them on the next whole-file write.
-- **Whole-file last-write-wins on `updated_at` (now microseconds).** Why: it formalizes exactly
-  what pubky-app already does at bootstrap; anything cleverer (field-wise merge) is machinery
-  without a demonstrated need.
-- **The per-file `version` field is dropped.** Why: verified dead, pubky-app checks it but never
-  bumps it; schema evolution is governed by the path epoch and crate semver like every other
-  model, so a second, parallel versioning channel is a contradiction waiting to happen.
-
 ## 13. Parser and `Resource` (the read side of every model)
 
 v0: `url::Url`-based, hard-rejects any app path that is not `pubky.app`, silently accepts
@@ -449,9 +452,8 @@ v1: one closed grammar (normative form: Appendix A of `rfc-v1-social-specs.md`).
 | Collection | envelope, posts-only items | envelope, reference-tier items | interop items; private collections free |
 | Tag | `tags/{id}` | `tags/{id}.json` | engine-free pinned hash input |
 | Bookmark | `bookmarks/{HashId}` public, GET-per-file | `priv/.../bookmarks/{b64u\|~hash}.json` | private, reversible filename, overflow form |
+| LastRead, Settings | `pub/pubky.app/...`, public | `priv/app.pubky/v1/...` | leave this spec entirely |
 | Follow | `follows/{pk}` | `follows/{pk}.json` | unchanged shape |
 | Mute | `mutes/{pk}` public | `priv/.../mutes/{pk}.json` | private |
-| LastRead | `last_read` ms, public | `priv/.../last_read.json` µs | private; unit fixed |
 | File (media) | `files/{id}` meta + `blobs/{hash}` bytes | `{root}/.../files/{hash}.{ext}` | ONE object (collapse); canonical extension; dual-root |
 | Feed | `feeds/{HashId(serde_json)}` public | `{priv\|pub}/.../feeds/{id}.json` | private default + publish; pinned hash string; enums get Unknown |
-| Settings | (unspec'd, public) | `priv/.../settings.json` | spec'd, private, version field dropped |

--- a/docs/v0-vs-v1.md
+++ b/docs/v0-vs-v1.md
@@ -125,8 +125,13 @@ v1: `{pub|priv}/social/v1/posts/{id}/{editId}.json`, referenced versionlessly as
   instead of a hand-rolled convention. All seven concrete kinds survive (each has a live
   creation path in pubky-app); `Link` deliberately stays untyped because the URL lives inside the
   content text, so there is no per-kind shape decision being missed.
-- **`embed` collapses from `{kind, uri}` to a plain URI string.** Why: the embedded target's
-  kind is derivable by resolving the target; storing it duplicates state that can go stale. (The
+- **`embed` collapses from `{kind, uri}` to a plain URI string, and accepts external
+  http/https targets.** Why: the embedded target's kind is derivable by resolving the target;
+  storing it duplicates state that can go stale. External embeds make quoting a web resource
+  first-class (the indexer reuses the External Resource nodes it already builds for external tag
+  targets), and they keep migration total: v0's `Url::parse` gate accepted arbitrary embed URLs,
+  so real v0 posts can carry them. `parent` stays pubky-only: reply threads are social-graph
+  edges between posts. (The
   often-cited "casing bug" was a wasm getter wart, not a wire bug; it dies with the wasm
   surface.)
 - **`attachments` becomes `Vec<{uri, alt?, name?}>`, always present, default `[]` (#48).** Why: v0's

--- a/docs/v0-vs-v1.md
+++ b/docs/v0-vs-v1.md
@@ -104,6 +104,12 @@ v0: `pub/pubky.app/posts/{id}`, one flat file, overwritten on edit;
 v1: `{pub|priv}/social/v1/posts/{id}/{editId}.json`, referenced versionlessly as
 `posts/{id}`.
 
+- **The post becomes a reusable envelope.** The shared mechanics (versioned storage, ids,
+  references, attachments, lock, preservation) ship as a generic crate layer that app specs
+  specialize with their own kinds in their own namespaces; the social post is the first
+  specialization, wire-identical to the shape described here. Why: the consumers are real
+  (Mapky, Eventky), the layer costs no wire change, and it turns the governance incubation path
+  into something usable at launch.
 - **Per-edit path versioning.** Storage is one file per edit; the first version reuses the
   post id; every reference (reply, embed, tag, bookmark, collection item) uses the versionless
   form. Why: v0 edits overwrite in place, so nothing distinguishes an edit from a new post on

--- a/docs/v0-vs-v1.md
+++ b/docs/v0-vs-v1.md
@@ -43,10 +43,12 @@ These are listed once here; the per-model sections below only add what is specif
   every field added after it shipped). Why: v0 has exactly one `Unknown` catch-all (`PostKind`); adding a value to any
   feed enum hard-crashes every old client on deserialize. This contract is what turns "break
   once, then grow additively" from an aspiration into a property. The bound extensibility
-  needs: TOTAL object size is capped (posts 512 KiB, other resources 64 KiB, on stored bytes),
-  rewrites fetch from the homeserver rather than indexer views, and the indexer carries unknown
-  members verbatim in its views (readable by any client) while indexing only adopted
-  projections. Deliberate extensions SHOULD nest under the reserved `ext` member, defined once
+  needs: TOTAL object size is capped (posts 512 KiB, every other JSON resource 64 KiB; media
+  bytes keep their own media-size bound), checked before parsing on read and after building on
+  write; rewrites fetch from the homeserver rather than indexer views; a rewrite that cannot fit
+  the cap while preserving unknown members fails and surfaces rather than silently dropping
+  them; and the indexer carries unknown members verbatim in its views (readable by any client)
+  while indexing only adopted projections. Deliberate extensions SHOULD nest under the reserved `ext` member, defined once
   as unvalidated third-party data: hostile input until an extension's own rules validate it.
 - **Canonical-encoding id validation.** An encoded id is valid iff re-encoding its decoded
   bytes reproduces the input, with closed-form regexes and final-char sets. Why: v0's validators
@@ -243,7 +245,10 @@ v1: `pub/social/v1/tags/{id}.json`, same fields.
   ANY external URI (the universal tier: http/https via the strict web gate, other schemes like
   `nostr:`/`geo:`/`ipfs:` via the pinned opaque gate). One logical tag has exactly one address,
   so re-tags self-overwrite and the indexer drops the writing-app dimension for v1 data; tag
-  files under other app namespaces survive as a legacy READ rule only.
+  files under other app namespaces survive as a legacy READ rule only. Because addresses
+  converge, a tag writer SHOULD GET the address first and preserve unknown members if a file
+  exists: a blind PUT would destroy another app's enrichment (e.g. `ext.badge`) of the same
+  statement.
 - Tags stay public-only in v1; tagging private objects is deferred (dual-rooting a resource
   later is additive).
 


### PR DESCRIPTION
Draft for design review, not for merge as-is.

This PR adds the complete v1 design and rollout as `docs/rfc-v1-social-specs.md`, so reviewers can comment inline on each decision. The doc is self-contained: it needs no other reading. The first stable and first breaking release renames the crate to `pubky-social-specs` (`1.0.0`) and moves all data from `/pub/pubky.app/<res>` to a versioned, app-neutral epoch `/{pub|priv}/social/v1/<res>`, with a permanent forward-compat contract so this is the last path break.

## How to review

The design is written model by model (v0 shape, v1 shape, and the reason for each change), then migration, then the subtask rollout. Comment on the specific line you agree or disagree with.

The highest-value places to push back:
- Per-edit path versioning (Post) and whether edit history earns its permanent cost.
- The dual-root content family and the private-posts lifecycle.
- The hand-written pure-JS second implementation gated by differential tests.
- Content-addressed feed ids and the private-by-default feed placement.

## Scope

Supersedes the v1 roadmap #12. Folds in and resolves #47, #48, #55 (deferred to v1.x with the shape pinned), #120, #141. No open design decisions remain; the destructive migration carve-out was considered and rejected in favor of strictly non-destructive migration.

Once the design is accepted, the subtasks in Part D become the tracked implementation issues.
