### PR TITLE
feat: add wot/me feed reach and optional domain_tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-app-specs"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky-app-specs"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.89"
 description = "Pubky.app data models with validation, sanitization, and URI helpers"

--- a/SPEC.md
+++ b/SPEC.md
@@ -291,7 +291,8 @@ For `kind = collection`, `parent`, `embed`, and `post.attachments` must be unset
 | **Field**   | **Type** | **Description**                    | **Validation Rules**                                      |
 | ----------- | -------- | ---------------------------------- | --------------------------------------------------------- |
 | `tags`      | Array    | Tags for filtering.                | Optional. Max 5 tags. Each tag follows tag label rules.     |
-| `reach`     | String   | Feed visibility scope.             | Required. One of: `following`, `followers`, `friends`, `all`. |
+| `domain_tags` | Array  | Domain tags for filtering.         | Optional. Max 5 tags. Each tag follows tag label rules.   |
+| `reach`     | String   | Feed visibility scope.             | Required. One of: `following`, `followers`, `friends`, `all`, `wot`, `me`. |
 | `layout`    | String   | Feed layout style.                 | Required. One of: `columns`, `wide`, `visual`, `list`.    |
 | `sort`      | String   | Sort order.                        | Required. One of: `recent`, `popularity`.                   |
 | `content`   | String   | Post kind to filter by.            | Optional. A valid `PubkyAppPostKind` value.               |
@@ -299,7 +300,7 @@ For `kind = collection`, `parent`, `embed`, and `post.attachments` must be unset
 **Validation Notes:**
 
 - The `feed_id` is a **Hash ID** derived from the serialized `feed` object.
-- Tags are trimmed, lowercased, and empty entries are removed on sanitize.
+- Tags and domain tags are trimmed, lowercased, and empty entries are removed on sanitize.
 
 **Example: Valid Feed**
 
@@ -307,7 +308,8 @@ For `kind = collection`, `parent`, `embed`, and `post.attachments` must be unset
 {
   "feed": {
     "tags": ["crab", "rust"],
-    "reach": "following",
+    "domain_tags": ["synonym"],
+    "reach": "wot",
     "layout": "columns",
     "sort": "recent",
     "content": "video"

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -69,9 +69,11 @@ const { bookmark, meta } = specs.createBookmark(uri);
 const { tag, meta } = specs.createTag(uri, label);
 const { follow, meta } = specs.createFollow(pubkyId);
 const { mute, meta } = specs.createMute(pubkyId);
-const { feed, meta } = specs.createFeed(tags, reach, layout, sort, content, name);
+const { feed, meta } = specs.createFeed(tags, reach, layout, sort, content, name, domainTags);
 const { last_read, meta } = specs.createLastRead();
 ```
+
+`domainTags` is optional — omit it or pass `null`/`undefined` when unused. Reach accepts `wot` and `me` in addition to `following`, `followers`, `friends`, and `all`.
 
 For runnable examples covering posts, embeds, files, feeds, URI helpers, and MIME type validation, see [`example.js`](https://github.com/pubky/pubky-app-specs/blob/main/pkg/example.js).
 

--- a/pkg/example.js
+++ b/pkg/example.js
@@ -239,6 +239,22 @@ field("Layout", feed.toJson().feed.layout);
 field("Sort", feed.toJson().feed.sort);
 console.log();
 
+// WoT feed with domain tags
+console.log(`  ${c.yellow}▸ WoT Feed with Domain Tags${c.reset}`);
+const { feed: wotFeed, meta: wotFeedMeta } = specsBuilder.createFeed(
+  ["rust"],
+  "wot",
+  "columns",
+  "recent",
+  "image",
+  "Rust WoT",
+  ["synonym"]
+);
+field("ID", wotFeedMeta.id);
+field("Reach", wotFeed.toJson().feed.reach);
+field("Domain Tags", wotFeed.toJson().feed.domain_tags.join(", "));
+console.log();
+
 // LastRead
 console.log(`  ${c.yellow}▸ Last Read Marker${c.reset}`);
 const { last_read, meta: lastReadMeta } = specsBuilder.createLastRead();

--- a/pkg/package.json
+++ b/pkg/package.json
@@ -55,5 +55,5 @@
   "sideEffects": false,
   "type": "module",
   "types": "pubky_app_specs.d.ts",
-  "version": "0.6.0"
+  "version": "0.6.1"
 }

--- a/pkg/test.js
+++ b/pkg/test.js
@@ -550,6 +550,44 @@ describe("PubkySpecs Example Objects Tests", () => {
       assert.ok(feedJson.created_at, "Feed should have created_at timestamp");
       assert.ok(typeof feedJson.created_at === "number", "created_at should be a number");
     });
+
+    it("should create feed with wot reach and domain_tags", () => {
+      const { feed } = specsBuilder.createFeed(
+        ["rust"],
+        "wot",
+        "columns",
+        "recent",
+        "image",
+        "WoT Feed",
+        ["synonym"]
+      );
+
+      const feedJson = feed.toJson();
+      assert.strictEqual(feedJson.feed.reach, "wot", "Feed reach should be wot");
+      assert.deepStrictEqual(
+        feedJson.feed.domain_tags,
+        ["synonym"],
+        "Feed domain_tags should match"
+      );
+    });
+
+    it("should create feed with me reach without domain_tags", () => {
+      const { feed } = specsBuilder.createFeed(
+        null,
+        "me",
+        "list",
+        "popularity",
+        null,
+        "My Posts"
+      );
+
+      const feedJson = feed.toJson();
+      assert.strictEqual(feedJson.feed.reach, "me", "Feed reach should be me");
+      assert.ok(
+        feedJson.feed.domain_tags == null,
+        "Feed domain_tags should be absent or null when not provided"
+      );
+    });
   });
 
   describe("Valid MIME Types", () => {

--- a/src/models/feed.rs
+++ b/src/models/feed.rs
@@ -59,6 +59,7 @@ pub enum PubkyAppFeedSort {
 pub struct PubkyAppFeedConfig {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
     pub tags: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
     pub domain_tags: Option<Vec<String>>,
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
@@ -478,10 +479,7 @@ mod tests {
 
         let feed: PubkyAppFeed = serde_json::from_str(feed_json).unwrap();
         assert_eq!(feed.feed.reach, PubkyAppFeedReach::Wot);
-        assert_eq!(
-            feed.feed.domain_tags,
-            Some(vec!["synonym".to_string()])
-        );
+        assert_eq!(feed.feed.domain_tags, Some(vec!["synonym".to_string()]));
     }
 
     #[test]
@@ -496,10 +494,7 @@ mod tests {
             "Test Feed".to_string(),
         );
 
-        assert_eq!(
-            feed.feed.domain_tags,
-            Some(vec!["synonym".to_string()])
-        );
+        assert_eq!(feed.feed.domain_tags, Some(vec!["synonym".to_string()]));
     }
 
     #[test]

--- a/src/models/feed.rs
+++ b/src/models/feed.rs
@@ -26,6 +26,8 @@ pub enum PubkyAppFeedReach {
     Followers,
     Friends,
     All,
+    Wot,
+    Me,
 }
 
 /// Enum representing the layout of the feed.
@@ -58,6 +60,8 @@ pub struct PubkyAppFeedConfig {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
     pub tags: Option<Vec<String>>,
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    pub domain_tags: Option<Vec<String>>,
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
     pub reach: PubkyAppFeedReach,
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
     pub layout: PubkyAppFeedLayout,
@@ -86,6 +90,12 @@ impl PubkyAppFeedConfig {
         self.tags.clone()
     }
 
+    /// Getter for `domain_tags`.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
+    pub fn domain_tags(&self) -> Option<Vec<String>> {
+        self.domain_tags.clone()
+    }
+
     /// Getter for `name`.
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
     pub fn reach(&self) -> PubkyAppFeedReach {
@@ -111,35 +121,47 @@ impl PubkyAppFeedConfig {
     }
 }
 
+fn sanitize_tag_list(tags: Option<Vec<String>>) -> Option<Vec<String>> {
+    tags.map(|tags| {
+        tags.into_iter()
+            .map(|tag| sanitize_tag_label(&tag))
+            .filter(|tag| !tag.is_empty())
+            .collect()
+    })
+}
+
+fn validate_tag_list(tags: &Option<Vec<String>>, field_name: &str) -> Result<(), String> {
+    if let Some(tags) = tags {
+        if tags.len() > VALIDATION_LIMITS.feed_tags_max_count {
+            return Err(format!(
+                "Validation Error: Feed config cannot have more than {} {}",
+                VALIDATION_LIMITS.feed_tags_max_count, field_name
+            ));
+        }
+
+        for tag in tags {
+            validate_tag_label(tag)?;
+        }
+    }
+
+    Ok(())
+}
+
 impl Validatable for PubkyAppFeedConfig {
     fn sanitize(self) -> Self {
-        // Sanitize tags: trim, lowercase, and filter out empty tags
-        let tags = self.tags.map(|tags| {
-            tags.into_iter()
-                .map(|tag| sanitize_tag_label(&tag))
-                .filter(|tag| !tag.is_empty())
-                .collect()
-        });
+        let tags = sanitize_tag_list(self.tags);
+        let domain_tags = sanitize_tag_list(self.domain_tags);
 
-        PubkyAppFeedConfig { tags, ..self }
+        PubkyAppFeedConfig {
+            tags,
+            domain_tags,
+            ..self
+        }
     }
 
     fn validate(&self, _id: Option<&str>) -> Result<(), String> {
-        // Validate tags
-        if let Some(tags) = &self.tags {
-            // Validate maximum number of tags
-            if tags.len() > VALIDATION_LIMITS.feed_tags_max_count {
-                return Err(format!(
-                    "Validation Error: Feed config cannot have more than {} tags",
-                    VALIDATION_LIMITS.feed_tags_max_count
-                ));
-            }
-
-            // Validate each tag using shared validation function
-            for tag in tags {
-                validate_tag_label(tag)?;
-            }
-        }
+        validate_tag_list(&self.tags, "tags")?;
+        validate_tag_list(&self.domain_tags, "domain_tags")?;
 
         Ok(())
     }
@@ -164,6 +186,7 @@ impl PubkyAppFeed {
     /// Creates a new `PubkyAppFeed` instance and sanitizes it.
     pub fn new(
         tags: Option<Vec<String>>,
+        domain_tags: Option<Vec<String>>,
         reach: PubkyAppFeedReach,
         layout: PubkyAppFeedLayout,
         sort: PubkyAppFeedSort,
@@ -173,6 +196,7 @@ impl PubkyAppFeed {
         let created_at = timestamp();
         let feed = PubkyAppFeedConfig {
             tags,
+            domain_tags,
             reach,
             layout,
             sort,
@@ -272,6 +296,8 @@ impl FromStr for PubkyAppFeedReach {
             "followers" => Ok(PubkyAppFeedReach::Followers),
             "friends" => Ok(PubkyAppFeedReach::Friends),
             "all" => Ok(PubkyAppFeedReach::All),
+            "wot" => Ok(PubkyAppFeedReach::Wot),
+            "me" => Ok(PubkyAppFeedReach::Me),
             _ => Err(format!("Invalid feed reach: {}", s)),
         }
     }
@@ -312,6 +338,7 @@ mod tests {
     fn test_new() {
         let feed = PubkyAppFeed::new(
             Some(vec!["bitcoin".to_string(), "rust".to_string()]),
+            None,
             PubkyAppFeedReach::Following,
             PubkyAppFeedLayout::Columns,
             PubkyAppFeedSort::Recent,
@@ -321,6 +348,7 @@ mod tests {
 
         let feed_config = PubkyAppFeedConfig {
             tags: Some(vec!["bitcoin".to_string(), "rust".to_string()]),
+            domain_tags: None,
             reach: PubkyAppFeedReach::Following,
             layout: PubkyAppFeedLayout::Columns,
             sort: PubkyAppFeedSort::Recent,
@@ -337,6 +365,7 @@ mod tests {
     fn test_create_id() {
         let feed = PubkyAppFeed::new(
             Some(vec!["bitcoin".to_string(), "rust".to_string()]),
+            None,
             PubkyAppFeedReach::Following,
             PubkyAppFeedLayout::Columns,
             PubkyAppFeedSort::Recent,
@@ -354,6 +383,7 @@ mod tests {
     fn test_validate() {
         let feed = PubkyAppFeed::new(
             Some(vec!["bitcoin".to_string(), "rust".to_string()]),
+            None,
             PubkyAppFeedReach::Following,
             PubkyAppFeedLayout::Columns,
             PubkyAppFeedSort::Recent,
@@ -370,6 +400,7 @@ mod tests {
     fn test_validate_invalid_id() {
         let feed = PubkyAppFeed::new(
             Some(vec!["bitcoin".to_string(), "rust".to_string()]),
+            None,
             PubkyAppFeedReach::Following,
             PubkyAppFeedLayout::Columns,
             PubkyAppFeedSort::Recent,
@@ -385,6 +416,7 @@ mod tests {
     fn test_sanitize() {
         let feed = PubkyAppFeed::new(
             Some(vec!["  BiTcoin  ".to_string(), " RUST   ".to_string()]),
+            None,
             PubkyAppFeedReach::Following,
             PubkyAppFeedLayout::Columns,
             PubkyAppFeedSort::Recent,
@@ -425,6 +457,92 @@ mod tests {
             feed_parsed.feed.tags,
             Some(vec!["bitcoin".to_string(), "rust".to_string()])
         );
+        assert_eq!(feed_parsed.feed.domain_tags, None);
+    }
+
+    #[test]
+    fn test_domain_tags_json_roundtrip() {
+        let feed_json = r#"
+        {
+            "feed": {
+                "tags": ["rust"],
+                "domain_tags": ["synonym"],
+                "reach": "wot",
+                "layout": "columns",
+                "sort": "recent"
+            },
+            "name": "WoT Feed",
+            "created_at": 1700000000
+        }
+        "#;
+
+        let feed: PubkyAppFeed = serde_json::from_str(feed_json).unwrap();
+        assert_eq!(feed.feed.reach, PubkyAppFeedReach::Wot);
+        assert_eq!(
+            feed.feed.domain_tags,
+            Some(vec!["synonym".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_sanitize_domain_tags() {
+        let feed = PubkyAppFeed::new(
+            None,
+            Some(vec!["  Synonym  ".to_string(), "  ".to_string()]),
+            PubkyAppFeedReach::Wot,
+            PubkyAppFeedLayout::Columns,
+            PubkyAppFeedSort::Recent,
+            None,
+            "Test Feed".to_string(),
+        );
+
+        assert_eq!(
+            feed.feed.domain_tags,
+            Some(vec!["synonym".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_validate_too_many_domain_tags() {
+        let feed = PubkyAppFeed::new(
+            None,
+            Some(vec![
+                "tag1".to_string(),
+                "tag2".to_string(),
+                "tag3".to_string(),
+                "tag4".to_string(),
+                "tag5".to_string(),
+                "tag6".to_string(),
+            ]),
+            PubkyAppFeedReach::Me,
+            PubkyAppFeedLayout::Columns,
+            PubkyAppFeedSort::Recent,
+            None,
+            "Test Feed".to_string(),
+        );
+        let feed_id = feed.create_id();
+
+        let result = feed.validate(Some(&feed_id));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("domain_tags"));
+    }
+
+    #[test]
+    fn test_validate_domain_tag_with_invalid_char() {
+        let feed = PubkyAppFeed::new(
+            None,
+            Some(vec!["synonym,to".to_string()]),
+            PubkyAppFeedReach::Wot,
+            PubkyAppFeedLayout::Columns,
+            PubkyAppFeedSort::Recent,
+            None,
+            "Test Feed".to_string(),
+        );
+        let feed_id = feed.create_id();
+
+        let result = feed.validate(Some(&feed_id));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("invalid character"));
     }
 
     #[test]
@@ -438,6 +556,7 @@ mod tests {
                 "tag5".to_string(),
                 "tag6".to_string(), // This exceeds feed_tags_max_count
             ]),
+            None,
             PubkyAppFeedReach::Following,
             PubkyAppFeedLayout::Columns,
             PubkyAppFeedSort::Recent,
@@ -458,6 +577,7 @@ mod tests {
     fn test_validate_tag_too_long() {
         let feed = PubkyAppFeed::new(
             Some(vec!["a".repeat(VALIDATION_LIMITS.tag_label_max_length + 1)]),
+            None,
             PubkyAppFeedReach::Following,
             PubkyAppFeedLayout::Columns,
             PubkyAppFeedSort::Recent,
@@ -475,6 +595,7 @@ mod tests {
     fn test_validate_tag_with_whitespace() {
         let feed = PubkyAppFeed::new(
             Some(vec!["bit coin".to_string()]),
+            None,
             PubkyAppFeedReach::Following,
             PubkyAppFeedLayout::Columns,
             PubkyAppFeedSort::Recent,
@@ -492,6 +613,7 @@ mod tests {
     fn test_validate_tag_with_invalid_char() {
         let feed = PubkyAppFeed::new(
             Some(vec!["bitcoin,rust".to_string()]),
+            None,
             PubkyAppFeedReach::Following,
             PubkyAppFeedLayout::Columns,
             PubkyAppFeedSort::Recent,
@@ -515,6 +637,7 @@ mod tests {
                 "tag4".to_string(),
                 "tag5".to_string(),
             ]),
+            None,
             PubkyAppFeedReach::Following,
             PubkyAppFeedLayout::Columns,
             PubkyAppFeedSort::Recent,
@@ -535,6 +658,7 @@ mod tests {
                 "  ".to_string(), // Empty after trim
                 "rust".to_string(),
             ]),
+            None,
             PubkyAppFeedReach::Following,
             PubkyAppFeedLayout::Columns,
             PubkyAppFeedSort::Recent,
@@ -563,6 +687,7 @@ mod tests {
         for (invalid_tag, expected_error) in invalid_cases {
             let feed = PubkyAppFeed::new(
                 Some(vec![invalid_tag.clone()]),
+                None,
                 PubkyAppFeedReach::Following,
                 PubkyAppFeedLayout::Columns,
                 PubkyAppFeedSort::Recent,
@@ -600,6 +725,14 @@ mod tests {
         assert_eq!(
             "all".parse::<PubkyAppFeedReach>().unwrap(),
             PubkyAppFeedReach::All
+        );
+        assert_eq!(
+            "wot".parse::<PubkyAppFeedReach>().unwrap(),
+            PubkyAppFeedReach::Wot
+        );
+        assert_eq!(
+            "me".parse::<PubkyAppFeedReach>().unwrap(),
+            PubkyAppFeedReach::Me
         );
 
         // Invalid case

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -198,12 +198,20 @@ impl PubkySpecsBuilder {
         sort: String,
         content: Option<String>,
         name: String,
+        domain_tags: JsValue,
     ) -> Result<FeedResult, String> {
         let tags_vec: Option<Vec<String>> = if tags.is_null() || tags.is_undefined() {
             None
         } else {
             from_value(tags).map_err(|e| e.to_string())?
         };
+
+        let domain_tags_vec: Option<Vec<String>> =
+            if domain_tags.is_null() || domain_tags.is_undefined() {
+                None
+            } else {
+                from_value(domain_tags).map_err(|e| e.to_string())?
+            };
 
         // Use `FromStr` to parse enums
         let reach = PubkyAppFeedReach::from_str(&reach)?;
@@ -215,7 +223,15 @@ impl PubkySpecsBuilder {
         };
 
         // Create the feed
-        let feed = PubkyAppFeed::new(tags_vec, reach, layout, sort, content, name);
+        let feed = PubkyAppFeed::new(
+            tags_vec,
+            domain_tags_vec,
+            reach,
+            layout,
+            sort,
+            content,
+            name,
+        );
 
         let feed_id = feed.create_id();
         feed.validate(Some(&feed_id))?;


### PR DESCRIPTION
Extends feed config with two new reach scopes (`wot`, `me`) and an optional `domain_tags` array (same validation as tags). Updates Rust/WASM