### PR TITLE
feat: add optional collection layout field

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -161,6 +161,7 @@ Collection posts use a typed JSON envelope as their `content`. The envelope shap
   "name": "AI papers",
   "description": "Best stuff",
   "cover_image": "pubky://userA/pub/pubky.app/files/0034A0X7NJ52C",
+  "layout": "visual",
   "items": [
     "pubky://userA/pub/pubky.app/posts/0034A0X7NJ52A",
     "pubky://userB/pub/pubky.app/posts/0034A0X7NJ52B"
@@ -171,6 +172,7 @@ Collection posts use a typed JSON envelope as their `content`. The envelope shap
 - `name`: required, 1 to 100 unicode scalars, non-whitespace-only.
 - `description`: optional, max 500 scalars.
 - `cover_image`: optional hero/cover image URL (max 200 chars). Validated as a general attachment URL — protocol must be `pubky`, `http`, or `https`.
+- `layout`: optional, one of `grid`, `list`, `visual`; the creator's default layout for experiencing the collection. Absent = `grid`. Consumers must treat unrecognized values as `grid`.
 - `items`: ordered list of pubky.app post URIs (max 100). Each URI must be in exact canonical form `pubky://<pubky-id>/pub/pubky.app/posts/<post-id>` (94 chars); any deviation (extra path segments, query, fragment, userinfo, etc.) is rejected.
 
 For `kind = collection`, `parent`, `embed`, and `post.attachments` must be unset. The `content` field is bounded by 40000 scalars instead of the regular short/long caps.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,8 @@ pub use models::follow::PubkyAppFollow;
 pub use models::last_read::PubkyAppLastRead;
 pub use models::mute::PubkyAppMute;
 pub use models::post::{
-    PubkyAppCollectionContent, PubkyAppPost, PubkyAppPostEmbed, PubkyAppPostKind,
+    PubkyAppCollectionContent, PubkyAppCollectionLayout, PubkyAppPost, PubkyAppPostEmbed,
+    PubkyAppPostKind,
 };
 pub use models::tag::PubkyAppTag;
 pub use models::user::{PubkyAppUser, PubkyAppUserLink};

--- a/src/models/post/content/collection.rs
+++ b/src/models/post/content/collection.rs
@@ -13,9 +13,8 @@ use super::super::PubkyAppPost;
 
 /// Creator-chosen default layout for experiencing a collection.
 ///
-/// Absent means `grid`. Unknown values deserialize as `Unknown` so future
-/// layouts never invalidate the whole post (same policy as `PubkyAppPostKind`);
-/// clients must treat `Unknown` as `grid`.
+/// Unrecognized values deserialize as `Unknown` so future layouts never
+/// invalidate the whole post (same policy as `PubkyAppPostKind`).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
@@ -81,7 +80,7 @@ pub struct PubkyAppCollectionContent {
     /// `VALIDATION_LIMITS.post_allowed_attachment_protocols`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cover_image: Option<String>,
-    /// Creator's preferred default layout. Absent = grid.
+    /// Creator's preferred default layout.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub layout: Option<PubkyAppCollectionLayout>,
 }
@@ -523,7 +522,7 @@ mod tests {
     #[test]
     fn test_collection_post_unknown_layout_tolerated() {
         // Forward-compat: a layout variant from a future spec version must not
-        // invalidate the whole post; it degrades to Unknown (rendered as grid).
+        // invalidate the whole post; it degrades to Unknown.
         let envelope_json = r#"{"name":"X","layout":"spiral"}"#;
         let post = PubkyAppPost::new(
             envelope_json.to_string(),

--- a/src/models/post/content/collection.rs
+++ b/src/models/post/content/collection.rs
@@ -1,5 +1,6 @@
 use crate::{common::validate_crockford_id, limits::VALIDATION_LIMITS, types::PubkyId};
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 use url::Url;
 
 #[cfg(target_arch = "wasm32")]
@@ -9,6 +10,36 @@ use tsify_next::Tsify;
 use utoipa::ToSchema;
 
 use super::super::PubkyAppPost;
+
+/// Creator-chosen default layout for experiencing a collection.
+///
+/// Absent means `grid`. Unknown values deserialize as `Unknown` so future
+/// layouts never invalidate the whole post (same policy as `PubkyAppPostKind`);
+/// clients must treat `Unknown` as `grid`.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(target_arch = "wasm32", derive(Tsify))]
+#[serde(rename_all = "snake_case")]
+pub enum PubkyAppCollectionLayout {
+    Grid,
+    List,
+    Visual,
+    #[serde(other)]
+    Unknown,
+}
+
+impl FromStr for PubkyAppCollectionLayout {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "grid" => Ok(Self::Grid),
+            "list" => Ok(Self::List),
+            "visual" => Ok(Self::Visual),
+            _ => Err(format!("Invalid collection layout: {}", s)),
+        }
+    }
+}
 
 /// Typed JSON envelope stored in `PubkyAppPost::content` when `kind == Collection`.
 ///
@@ -50,6 +81,9 @@ pub struct PubkyAppCollectionContent {
     /// `VALIDATION_LIMITS.post_allowed_attachment_protocols`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cover_image: Option<String>,
+    /// Creator's preferred default layout. Absent = grid.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub layout: Option<PubkyAppCollectionLayout>,
 }
 
 /// Validates a `kind = Collection` post, including its JSON content envelope.
@@ -176,7 +210,7 @@ mod tests {
             name: name.to_string(),
             description: description.map(|d| d.to_string()),
             items: items.to_vec(),
-            cover_image: None,
+            ..Default::default()
         })
         .unwrap()
     }
@@ -199,9 +233,8 @@ mod tests {
     fn make_collection_post_with_cover(cover_image: Option<&str>) -> PubkyAppPost {
         let envelope = PubkyAppCollectionContent {
             name: "X".to_string(),
-            description: None,
-            items: vec![],
             cover_image: cover_image.map(|s| s.to_string()),
+            ..Default::default()
         };
         let content = serde_json::to_string(&envelope).expect("envelope serialization");
         PubkyAppPost::new(content, PubkyAppPostKind::Collection, None, None, None)
@@ -472,6 +505,40 @@ mod tests {
     }
 
     #[test]
+    fn test_collection_post_roundtrip_layout() {
+        let envelope_json = r#"{"name":"Photos","layout":"visual"}"#;
+        let post = PubkyAppPost::new(
+            envelope_json.to_string(),
+            PubkyAppPostKind::Collection,
+            None,
+            None,
+            None,
+        );
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+        let envelope: PubkyAppCollectionContent = serde_json::from_str(&post.content).unwrap();
+        assert_eq!(envelope.layout, Some(PubkyAppCollectionLayout::Visual));
+    }
+
+    #[test]
+    fn test_collection_post_unknown_layout_tolerated() {
+        // Forward-compat: a layout variant from a future spec version must not
+        // invalidate the whole post; it degrades to Unknown (rendered as grid).
+        let envelope_json = r#"{"name":"X","layout":"spiral"}"#;
+        let post = PubkyAppPost::new(
+            envelope_json.to_string(),
+            PubkyAppPostKind::Collection,
+            None,
+            None,
+            None,
+        );
+        let id = post.create_id();
+        assert!(post.validate(Some(&id)).is_ok());
+        let envelope: PubkyAppCollectionContent = serde_json::from_str(&post.content).unwrap();
+        assert_eq!(envelope.layout, Some(PubkyAppCollectionLayout::Unknown));
+    }
+
+    #[test]
     fn test_collection_envelope_tolerates_extra_fields() {
         // Forward-compat: the envelope intentionally does NOT use deny_unknown_fields,
         // so future minor versions can add fields without breaking older parsers.
@@ -697,7 +764,7 @@ mod tests {
     #[wasm_bindgen_test::wasm_bindgen_test]
     fn test_create_collection_post_wasm_builder() {
         // End-to-end via the JS-facing builder:
-        //   PubkySpecsBuilder.createCollectionPost(name, description?, items?, cover_image?)
+        //   PubkySpecsBuilder.createCollectionPost(name, description?, items?, cover_image?, layout?)
         // builds the {name, description} envelope internally, packages it
         // into a kind=Collection PubkyAppPost, and returns a PostResult
         // ready to ship to the homeserver. JS callers don't have to
@@ -713,6 +780,7 @@ mod tests {
                     "pubky://operrr8wsbpr3ue9d4qj41ge1kcc6r7fdiy6o3ugjrrhi4y77rdo/pub/pubky.app/posts/0034A0X7NJ52A".to_string(),
                 ]),
                 Some("https://example.com/cover.png".to_string()),
+                Some("list".to_string()),
             )
             .expect("createCollectionPost should succeed");
 
@@ -728,5 +796,6 @@ mod tests {
             envelope.cover_image.as_deref(),
             Some("https://example.com/cover.png")
         );
+        assert_eq!(envelope.layout, Some(PubkyAppCollectionLayout::List));
     }
 }

--- a/src/models/post/content/mod.rs
+++ b/src/models/post/content/mod.rs
@@ -1,3 +1,3 @@
 pub mod collection;
 
-pub use collection::PubkyAppCollectionContent;
+pub use collection::{PubkyAppCollectionContent, PubkyAppCollectionLayout};

--- a/src/models/post/mod.rs
+++ b/src/models/post/mod.rs
@@ -8,7 +8,7 @@ use crate::{
 
 pub mod content;
 
-pub use content::PubkyAppCollectionContent;
+pub use content::{PubkyAppCollectionContent, PubkyAppCollectionLayout};
 use serde::{Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 use url::Url;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -320,7 +320,7 @@ impl PubkySpecsBuilder {
     /// cover_image, layout }`) and JSON-serializes it into `content` internally,
     /// so JS callers don't have to stringify the envelope themselves.
     ///
-    /// `layout` is one of `"grid" | "list" | "visual"` (absent = grid).
+    /// `layout` is one of `"grid" | "list" | "visual"`.
     ///
     /// `parent` and `embed` are not supported for Collection posts — the
     /// validator rejects them — so this helper omits those arguments.

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -317,8 +317,10 @@ impl PubkySpecsBuilder {
     ///
     /// Convenience wrapper around `createPost` that builds the
     /// `PubkyAppCollectionContent` envelope (`{ name, description, items,
-    /// cover_image }`) and JSON-serializes it into `content` internally, so
-    /// JS callers don't have to stringify the envelope themselves.
+    /// cover_image, layout }`) and JSON-serializes it into `content` internally,
+    /// so JS callers don't have to stringify the envelope themselves.
+    ///
+    /// `layout` is one of `"grid" | "list" | "visual"` (absent = grid).
     ///
     /// `parent` and `embed` are not supported for Collection posts — the
     /// validator rejects them — so this helper omits those arguments.
@@ -329,12 +331,17 @@ impl PubkySpecsBuilder {
         description: Option<String>,
         items: Option<Vec<String>>,
         cover_image: Option<String>,
+        layout: Option<String>,
     ) -> Result<PostResult, String> {
+        let layout = layout
+            .map(|s| PubkyAppCollectionLayout::from_str(&s))
+            .transpose()?;
         let envelope = PubkyAppCollectionContent {
             name,
             description,
             items: items.unwrap_or_default(),
             cover_image,
+            layout,
         };
         let content = serde_json::to_string(&envelope)
             .map_err(|e| format!("Failed to serialize Collection envelope: {e}"))?;


### PR DESCRIPTION
Adds an optional `layout` field to the collection content envelope: `grid` | `list` | `visual`. The idea is the creator defines the default way the collection is experienced (context in pubky/pubky-app#2207 and pubky/pubky-app#2208, and the slack thread).

If absent, default is grid. Unknown values don't invalidate the post, they just fall back to grid (same policy we already use for post kinds), so adding more layouts later is not breaking.

Also added the `layout` param to `createCollectionPost` in the wasm builder, is a trailing optional so existing callers are fine. wdyt?