### PR TITLE
chore: bump version to 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-app-specs"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky-app-specs"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 rust-version = "1.89"
 description = "Pubky.app data models with validation, sanitization, and URI helpers"

--- a/pkg/package.json
+++ b/pkg/package.json
@@ -55,5 +55,5 @@
   "sideEffects": false,
   "type": "module",
   "types": "pubky_app_specs.d.ts",
-  "version": "0.6.1"
+  "version": "0.6.2"
 }


### PR DESCRIPTION
Patch bump for the new optional collection `layout` field (#147).