### PR TITLE
icons for custom feeds

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -286,6 +286,7 @@ For `kind = collection`, `parent`, `embed`, and `post.attachments` must be unset
 | -------------- | --------- | --------------------------- | --------------------------------------- |
 | `feed`         | Object    | Feed filter/sort settings.  | Required. See `feed` object below.      |
 | `name`         | String    | Display name of the feed.   | Required. Non-empty after trim.         |
+| `icon`         | String    | Lucide icon name.           | Required on new feeds; may be missing or `null` on older ones. Max 50 chars. Only `a-z`, `0-9`, `-`. |
 | `created_at`   | Integer   | Unix timestamp of creation. | Required.                               |
 
 #### `feed` object (`PubkyAppFeedConfig`)
@@ -301,8 +302,10 @@ For `kind = collection`, `parent`, `embed`, and `post.attachments` must be unset
 
 **Validation Notes:**
 
-- The `feed_id` is a **Hash ID** derived from the serialized `feed` object.
+- The `feed_id` is a **Hash ID** derived from the serialized `feed` object. `name` and `icon` are not part of it, so both can change without recreating the feed.
 - Tags and domain tags are trimmed, lowercased, and empty entries are removed on sanitize.
+- `icon` names a [Lucide](https://lucide.dev/icons) icon; the spec does not enumerate the allowed names, and clients fall back to their default icon for names they do not know. It is trimmed and lowercased on sanitize.
+- Every newly created feed must carry an `icon`. It stays optional in the schema only so that feeds written before the field existed remain valid when the field is missing or `null`; an `icon` that is present but empty is rejected.
 
 **Example: Valid Feed**
 
@@ -317,6 +320,7 @@ For `kind = collection`, `parent`, `embed`, and `post.attachments` must be unset
     "content": "video"
   },
   "name": "My Feed",
+  "icon": "bitcoin",
   "created_at": 1700000000
 }
 ```

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -69,11 +69,20 @@ const { bookmark, meta } = specs.createBookmark(uri);
 const { tag, meta } = specs.createTag(uri, label);
 const { follow, meta } = specs.createFollow(pubkyId);
 const { mute, meta } = specs.createMute(pubkyId);
-const { feed, meta } = specs.createFeed(tags, reach, layout, sort, content, name, domainTags);
+const { feed, meta } = specs.createFeed({
+  tags,
+  reach,
+  layout,
+  sort,
+  content,
+  name,
+  domainTags,
+  icon,
+});
 const { last_read, meta } = specs.createLastRead();
 ```
 
-`domainTags` is optional — omit it or pass `null`/`undefined` when unused. Reach accepts `wot` and `me` in addition to `following`, `followers`, `friends`, and `all`.
+`domainTags` is optional and can be omitted. `icon` is required and is a [Lucide](https://lucide.dev/icons) icon name (max 50 chars, `a-z`, `0-9`, `-`); legacy feeds may have a missing or `null` icon. Reach accepts `wot` and `me` in addition to `following`, `followers`, `friends`, and `all`.
 
 For runnable examples covering posts, embeds, files, feeds, URI helpers, and MIME type validation, see [`example.js`](https://github.com/pubky/pubky-app-specs/blob/main/pkg/example.js).
 

--- a/pkg/example.js
+++ b/pkg/example.js
@@ -224,16 +224,18 @@ header("FEEDS & LAST READ");
 
 // Feed
 console.log(`  ${c.yellow}▸ Custom Feed${c.reset}`);
-const { feed, meta: feedMeta } = specsBuilder.createFeed(
-  ["mountain", "hiking", "nature"],
-  "all",
-  "columns",
-  "recent",
-  "image",
-  "Outdoor Adventures"
-);
+const { feed, meta: feedMeta } = specsBuilder.createFeed({
+  tags: ["mountain", "hiking", "nature"],
+  reach: "all",
+  layout: "columns",
+  sort: "recent",
+  content: "image",
+  name: "Outdoor Adventures",
+  icon: "mountain",
+});
 field("ID", feedMeta.id);
 field("Name", feed.toJson().name);
+field("Icon", feed.toJson().icon);
 field("Tags", feed.toJson().feed.tags.join(", "));
 field("Layout", feed.toJson().feed.layout);
 field("Sort", feed.toJson().feed.sort);
@@ -241,15 +243,16 @@ console.log();
 
 // WoT feed with domain tags
 console.log(`  ${c.yellow}▸ WoT Feed with Domain Tags${c.reset}`);
-const { feed: wotFeed, meta: wotFeedMeta } = specsBuilder.createFeed(
-  ["rust"],
-  "wot",
-  "columns",
-  "recent",
-  "image",
-  "Rust WoT",
-  ["synonym"]
-);
+const { feed: wotFeed, meta: wotFeedMeta } = specsBuilder.createFeed({
+  tags: ["rust"],
+  reach: "wot",
+  layout: "columns",
+  sort: "recent",
+  content: "image",
+  name: "Rust WoT",
+  domainTags: ["synonym"],
+  icon: "users",
+});
 field("ID", wotFeedMeta.id);
 field("Reach", wotFeed.toJson().feed.reach);
 field("Domain Tags", wotFeed.toJson().feed.domain_tags.join(", "));

--- a/pkg/test.js
+++ b/pkg/test.js
@@ -521,14 +521,15 @@ describe("PubkySpecs Example Objects Tests", () => {
 
   describe("Feed Pubky-app-specs", () => {
     it("should create feed with correct properties", () => {
-      const { feed, meta: feedMeta } = specsBuilder.createFeed(
-        ["mountain","hike"], 
-        "all", 
-        "columns", 
-        "recent", 
-        "image", 
-        "nature"
-      );
+      const { feed, meta: feedMeta } = specsBuilder.createFeed({
+        tags: ["mountain", "hike"],
+        reach: "all",
+        layout: "columns",
+        sort: "recent",
+        content: "image",
+        name: "nature",
+        icon: "mountain",
+      });
 
       // Test meta properties
       assert.ok(feedMeta.id, "Feed should have an ID");
@@ -547,20 +548,22 @@ describe("PubkySpecs Example Objects Tests", () => {
       assert.strictEqual(feedJson.feed.sort, "recent", "Feed sort should match");
       assert.strictEqual(feedJson.feed.content, "image", "Feed content should match");
       assert.strictEqual(feedJson.name, "nature", "Feed name should match");
+      assert.strictEqual(feedJson.icon, "mountain", "Feed icon should match");
       assert.ok(feedJson.created_at, "Feed should have created_at timestamp");
       assert.ok(typeof feedJson.created_at === "number", "created_at should be a number");
     });
 
     it("should create feed with wot reach and domain_tags", () => {
-      const { feed } = specsBuilder.createFeed(
-        ["rust"],
-        "wot",
-        "columns",
-        "recent",
-        "image",
-        "WoT Feed",
-        ["synonym"]
-      );
+      const { feed } = specsBuilder.createFeed({
+        tags: ["rust"],
+        reach: "wot",
+        layout: "columns",
+        sort: "recent",
+        content: "image",
+        name: "WoT Feed",
+        domainTags: ["synonym"],
+        icon: "users",
+      });
 
       const feedJson = feed.toJson();
       assert.strictEqual(feedJson.feed.reach, "wot", "Feed reach should be wot");
@@ -572,20 +575,45 @@ describe("PubkySpecs Example Objects Tests", () => {
     });
 
     it("should create feed with me reach without domain_tags", () => {
-      const { feed } = specsBuilder.createFeed(
-        null,
-        "me",
-        "list",
-        "popularity",
-        null,
-        "My Posts"
-      );
+      const { feed } = specsBuilder.createFeed({
+        reach: "me",
+        layout: "list",
+        sort: "popularity",
+        name: "My Posts",
+        icon: "user",
+      });
 
       const feedJson = feed.toJson();
       assert.strictEqual(feedJson.feed.reach, "me", "Feed reach should be me");
       assert.ok(
         feedJson.feed.domain_tags == null,
         "Feed domain_tags should be absent or null when not provided"
+      );
+      assert.strictEqual(feedJson.icon, "user", "Feed icon should match");
+    });
+
+    it("should reject icons outside a-z, 0-9 and -", () => {
+      for (const icon of ["bad icon", "bad_icon"]) {
+        assert.throws(() =>
+          specsBuilder.createFeed({
+            reach: "all",
+            layout: "columns",
+            sort: "recent",
+            name: "Bad Icon",
+            icon,
+          })
+        );
+      }
+    });
+
+    it("should require an icon when creating a feed", () => {
+      assert.throws(() =>
+        specsBuilder.createFeed({
+          reach: "all",
+          layout: "columns",
+          sort: "recent",
+          name: "Missing Icon",
+        })
       );
     });
   });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,9 @@ pub use limits::*;
 // Re-export domain types
 pub use models::blob::PubkyAppBlob;
 pub use models::bookmark::PubkyAppBookmark;
-pub use models::feed::{PubkyAppFeed, PubkyAppFeedLayout, PubkyAppFeedReach, PubkyAppFeedSort};
+pub use models::feed::{
+    PubkyAppFeed, PubkyAppFeedConfig, PubkyAppFeedLayout, PubkyAppFeedReach, PubkyAppFeedSort,
+};
 pub use models::file::{PubkyAppFile, VALID_MIME_TYPES};
 pub use models::follow::PubkyAppFollow;
 pub use models::last_read::PubkyAppLastRead;

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -81,6 +81,8 @@ pub struct ValidationLimits {
     pub file_src_max_length: usize,
     /// Maximum number of tags allowed in a feed.
     pub feed_tags_max_count: usize,
+    /// Maximum length of a feed icon name in characters.
+    pub feed_icon_max_length: usize,
 }
 
 /// All validation limits in a single bundle.
@@ -112,4 +114,5 @@ pub const VALIDATION_LIMITS: ValidationLimits = ValidationLimits {
     file_name_max_length: 255,
     file_src_max_length: 1024,
     feed_tags_max_count: 5,
+    feed_icon_max_length: 50,
 };

--- a/src/models/feed.rs
+++ b/src/models/feed.rs
@@ -943,6 +943,47 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_icon_at_max_length() {
+        let feed = PubkyAppFeed::new(
+            feed_config(
+                None,
+                None,
+                PubkyAppFeedReach::All,
+                PubkyAppFeedLayout::Columns,
+                PubkyAppFeedSort::Recent,
+                None,
+            ),
+            "Test Feed".to_string(),
+            "a".repeat(VALIDATION_LIMITS.feed_icon_max_length),
+        );
+        let feed_id = feed.create_id();
+
+        assert!(feed.validate(Some(&feed_id)).is_ok());
+    }
+
+    #[test]
+    fn test_validate_accepts_unknown_icon_name() {
+        // Only the shape is validated; clients fall back to their default icon
+        // for names outside their set.
+        let feed = PubkyAppFeed::new(
+            feed_config(
+                None,
+                None,
+                PubkyAppFeedReach::All,
+                PubkyAppFeedLayout::Columns,
+                PubkyAppFeedSort::Recent,
+                None,
+            ),
+            "Test Feed".to_string(),
+            "no-such-icon-42".to_string(),
+        );
+        let feed_id = feed.create_id();
+
+        assert!(feed.validate(Some(&feed_id)).is_ok());
+        assert_eq!(feed.icon, Some("no-such-icon-42".to_string()));
+    }
+
+    #[test]
     fn test_icon_does_not_change_feed_id() {
         let make_feed = |icon: &str| {
             PubkyAppFeed::new(

--- a/src/models/feed.rs
+++ b/src/models/feed.rs
@@ -131,6 +131,45 @@ fn sanitize_tag_list(tags: Option<Vec<String>>) -> Option<Vec<String>> {
     })
 }
 
+fn sanitize_feed_icon(icon: Option<String>) -> Option<String> {
+    icon.map(|icon| icon.trim().to_lowercase())
+}
+
+/// Only the shape of the name is validated, not whether the icon exists: the
+/// icon set is curated by the client.
+///
+/// `None` is accepted for feeds created before the field existed; new feeds
+/// always carry one, since [`PubkyAppFeed::new`] requires it.
+fn validate_feed_icon(icon: &Option<String>) -> Result<(), String> {
+    let Some(icon) = icon else {
+        return Ok(());
+    };
+
+    if icon.trim().is_empty() {
+        return Err("Validation Error: Feed icon cannot be empty".into());
+    }
+
+    let icon_len = icon.chars().count();
+    if icon_len > VALIDATION_LIMITS.feed_icon_max_length {
+        return Err(format!(
+            "Validation Error: Feed icon '{}' exceeds maximum length of {} characters",
+            icon, VALIDATION_LIMITS.feed_icon_max_length
+        ));
+    }
+
+    if let Some(c) = icon
+        .chars()
+        .find(|c| !c.is_ascii_lowercase() && !c.is_ascii_digit() && *c != '-')
+    {
+        return Err(format!(
+            "Validation Error: Feed icon '{}' contains invalid character: {}",
+            icon, c
+        ));
+    }
+
+    Ok(())
+}
+
 fn validate_tag_list(tags: &Option<Vec<String>>, field_name: &str) -> Result<(), String> {
     if let Some(tags) = tags {
         if tags.len() > VALIDATION_LIMITS.feed_tags_max_count {
@@ -180,32 +219,24 @@ pub struct PubkyAppFeed {
     pub feed: PubkyAppFeedConfig,
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
     pub name: String,
+    /// Lucide icon name, e.g. `"bitcoin"`. Required on new feeds, but optional
+    /// on the wire: feeds created before this field existed have none, and
+    /// clients render their default icon for those. Not part of the `feed_id`,
+    /// so the icon can change without recreating the feed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
+    pub icon: Option<String>,
     pub created_at: i64,
 }
 
 impl PubkyAppFeed {
     /// Creates a new `PubkyAppFeed` instance and sanitizes it.
-    pub fn new(
-        tags: Option<Vec<String>>,
-        domain_tags: Option<Vec<String>>,
-        reach: PubkyAppFeedReach,
-        layout: PubkyAppFeedLayout,
-        sort: PubkyAppFeedSort,
-        content: Option<PubkyAppPostKind>,
-        name: String,
-    ) -> Self {
+    pub fn new(feed: PubkyAppFeedConfig, name: String, icon: String) -> Self {
         let created_at = timestamp();
-        let feed = PubkyAppFeedConfig {
-            tags,
-            domain_tags,
-            reach,
-            layout,
-            sort,
-            content,
-        };
         Self {
             feed,
             name,
+            icon: Some(icon),
             created_at,
         }
         .sanitize()
@@ -236,6 +267,12 @@ impl PubkyAppFeed {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
     pub fn name(&self) -> String {
         self.name.clone()
+    }
+
+    /// Getter for `icon`.
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
+    pub fn icon(&self) -> Option<String> {
+        self.icon.clone()
     }
 }
 
@@ -269,21 +306,19 @@ impl Validatable for PubkyAppFeed {
             return Err("Validation Error: Feed name cannot be empty".into());
         }
 
+        validate_feed_icon(&self.icon)?;
+
         self.feed.validate(None)?;
 
         Ok(())
     }
 
     fn sanitize(self) -> Self {
-        // Sanitize name
-        let name = self.name.trim().to_string();
-
-        let feed = self.feed.sanitize();
-
         PubkyAppFeed {
-            feed,
-            name,
-            created_at: self.created_at,
+            feed: self.feed.sanitize(),
+            name: self.name.trim().to_string(),
+            icon: sanitize_feed_icon(self.icon),
+            ..self
         }
     }
 }
@@ -335,16 +370,37 @@ mod tests {
     use super::*;
     use crate::{limits::VALIDATION_LIMITS, traits::Validatable};
 
+    fn feed_config(
+        tags: Option<Vec<String>>,
+        domain_tags: Option<Vec<String>>,
+        reach: PubkyAppFeedReach,
+        layout: PubkyAppFeedLayout,
+        sort: PubkyAppFeedSort,
+        content: Option<PubkyAppPostKind>,
+    ) -> PubkyAppFeedConfig {
+        PubkyAppFeedConfig {
+            tags,
+            domain_tags,
+            reach,
+            layout,
+            sort,
+            content,
+        }
+    }
+
     #[test]
     fn test_new() {
         let feed = PubkyAppFeed::new(
-            Some(vec!["bitcoin".to_string(), "rust".to_string()]),
-            None,
-            PubkyAppFeedReach::Following,
-            PubkyAppFeedLayout::Columns,
-            PubkyAppFeedSort::Recent,
-            Some(PubkyAppPostKind::Image),
+            feed_config(
+                Some(vec!["bitcoin".to_string(), "rust".to_string()]),
+                None,
+                PubkyAppFeedReach::Following,
+                PubkyAppFeedLayout::Columns,
+                PubkyAppFeedSort::Recent,
+                Some(PubkyAppPostKind::Image),
+            ),
             "Rust Bitcoiners".to_string(),
+            "bitcoin".to_string(),
         );
 
         let feed_config = PubkyAppFeedConfig {
@@ -357,6 +413,7 @@ mod tests {
         };
         assert_eq!(feed.feed, feed_config);
         assert_eq!(feed.name, "Rust Bitcoiners");
+        assert_eq!(feed.icon, Some("bitcoin".to_string()));
         // Check that created_at is recent
         let now = timestamp();
         assert!(feed.created_at <= now && feed.created_at >= now - 1_000_000);
@@ -365,13 +422,16 @@ mod tests {
     #[test]
     fn test_create_id() {
         let feed = PubkyAppFeed::new(
-            Some(vec!["bitcoin".to_string(), "rust".to_string()]),
-            None,
-            PubkyAppFeedReach::Following,
-            PubkyAppFeedLayout::Columns,
-            PubkyAppFeedSort::Recent,
-            None,
+            feed_config(
+                Some(vec!["bitcoin".to_string(), "rust".to_string()]),
+                None,
+                PubkyAppFeedReach::Following,
+                PubkyAppFeedLayout::Columns,
+                PubkyAppFeedSort::Recent,
+                None,
+            ),
             "Rust Bitcoiners".to_string(),
+            "bitcoin".to_string(),
         );
 
         let feed_id = feed.create_id();
@@ -383,13 +443,16 @@ mod tests {
     #[test]
     fn test_validate() {
         let feed = PubkyAppFeed::new(
-            Some(vec!["bitcoin".to_string(), "rust".to_string()]),
-            None,
-            PubkyAppFeedReach::Following,
-            PubkyAppFeedLayout::Columns,
-            PubkyAppFeedSort::Recent,
-            None,
+            feed_config(
+                Some(vec!["bitcoin".to_string(), "rust".to_string()]),
+                None,
+                PubkyAppFeedReach::Following,
+                PubkyAppFeedLayout::Columns,
+                PubkyAppFeedSort::Recent,
+                None,
+            ),
             "Rust Bitcoiners".to_string(),
+            "bitcoin".to_string(),
         );
         let feed_id = feed.create_id();
 
@@ -400,13 +463,16 @@ mod tests {
     #[test]
     fn test_validate_invalid_id() {
         let feed = PubkyAppFeed::new(
-            Some(vec!["bitcoin".to_string(), "rust".to_string()]),
-            None,
-            PubkyAppFeedReach::Following,
-            PubkyAppFeedLayout::Columns,
-            PubkyAppFeedSort::Recent,
-            None,
+            feed_config(
+                Some(vec!["bitcoin".to_string(), "rust".to_string()]),
+                None,
+                PubkyAppFeedReach::Following,
+                PubkyAppFeedLayout::Columns,
+                PubkyAppFeedSort::Recent,
+                None,
+            ),
             "Rust Bitcoiners".to_string(),
+            "bitcoin".to_string(),
         );
         let invalid_id = "INVALIDID";
         let result = feed.validate(Some(invalid_id));
@@ -416,15 +482,19 @@ mod tests {
     #[test]
     fn test_sanitize() {
         let feed = PubkyAppFeed::new(
-            Some(vec!["  BiTcoin  ".to_string(), " RUST   ".to_string()]),
-            None,
-            PubkyAppFeedReach::Following,
-            PubkyAppFeedLayout::Columns,
-            PubkyAppFeedSort::Recent,
-            None,
+            feed_config(
+                Some(vec!["  BiTcoin  ".to_string(), " RUST   ".to_string()]),
+                None,
+                PubkyAppFeedReach::Following,
+                PubkyAppFeedLayout::Columns,
+                PubkyAppFeedSort::Recent,
+                None,
+            ),
             "  Rust Bitcoiners".to_string(),
+            "  BitCoin  ".to_string(),
         );
         assert_eq!(feed.name, "Rust Bitcoiners");
+        assert_eq!(feed.icon, Some("bitcoin".to_string()));
         assert_eq!(
             feed.feed.tags,
             Some(vec!["bitcoin".to_string(), "rust".to_string()])
@@ -485,13 +555,16 @@ mod tests {
     #[test]
     fn test_sanitize_domain_tags() {
         let feed = PubkyAppFeed::new(
-            None,
-            Some(vec!["  Synonym  ".to_string(), "  ".to_string()]),
-            PubkyAppFeedReach::Wot,
-            PubkyAppFeedLayout::Columns,
-            PubkyAppFeedSort::Recent,
-            None,
+            feed_config(
+                None,
+                Some(vec!["  Synonym  ".to_string(), "  ".to_string()]),
+                PubkyAppFeedReach::Wot,
+                PubkyAppFeedLayout::Columns,
+                PubkyAppFeedSort::Recent,
+                None,
+            ),
             "Test Feed".to_string(),
+            "rss".to_string(),
         );
 
         assert_eq!(feed.feed.domain_tags, Some(vec!["synonym".to_string()]));
@@ -500,20 +573,23 @@ mod tests {
     #[test]
     fn test_validate_too_many_domain_tags() {
         let feed = PubkyAppFeed::new(
-            None,
-            Some(vec![
-                "tag1".to_string(),
-                "tag2".to_string(),
-                "tag3".to_string(),
-                "tag4".to_string(),
-                "tag5".to_string(),
-                "tag6".to_string(),
-            ]),
-            PubkyAppFeedReach::Me,
-            PubkyAppFeedLayout::Columns,
-            PubkyAppFeedSort::Recent,
-            None,
+            feed_config(
+                None,
+                Some(vec![
+                    "tag1".to_string(),
+                    "tag2".to_string(),
+                    "tag3".to_string(),
+                    "tag4".to_string(),
+                    "tag5".to_string(),
+                    "tag6".to_string(),
+                ]),
+                PubkyAppFeedReach::Me,
+                PubkyAppFeedLayout::Columns,
+                PubkyAppFeedSort::Recent,
+                None,
+            ),
             "Test Feed".to_string(),
+            "rss".to_string(),
         );
         let feed_id = feed.create_id();
 
@@ -525,13 +601,16 @@ mod tests {
     #[test]
     fn test_validate_domain_tag_with_invalid_char() {
         let feed = PubkyAppFeed::new(
-            None,
-            Some(vec!["synonym,to".to_string()]),
-            PubkyAppFeedReach::Wot,
-            PubkyAppFeedLayout::Columns,
-            PubkyAppFeedSort::Recent,
-            None,
+            feed_config(
+                None,
+                Some(vec!["synonym,to".to_string()]),
+                PubkyAppFeedReach::Wot,
+                PubkyAppFeedLayout::Columns,
+                PubkyAppFeedSort::Recent,
+                None,
+            ),
             "Test Feed".to_string(),
+            "rss".to_string(),
         );
         let feed_id = feed.create_id();
 
@@ -543,20 +622,23 @@ mod tests {
     #[test]
     fn test_validate_too_many_tags() {
         let feed = PubkyAppFeed::new(
-            Some(vec![
-                "tag1".to_string(),
-                "tag2".to_string(),
-                "tag3".to_string(),
-                "tag4".to_string(),
-                "tag5".to_string(),
-                "tag6".to_string(), // This exceeds feed_tags_max_count
-            ]),
-            None,
-            PubkyAppFeedReach::Following,
-            PubkyAppFeedLayout::Columns,
-            PubkyAppFeedSort::Recent,
-            None,
+            feed_config(
+                Some(vec![
+                    "tag1".to_string(),
+                    "tag2".to_string(),
+                    "tag3".to_string(),
+                    "tag4".to_string(),
+                    "tag5".to_string(),
+                    "tag6".to_string(), // This exceeds feed_tags_max_count
+                ]),
+                None,
+                PubkyAppFeedReach::Following,
+                PubkyAppFeedLayout::Columns,
+                PubkyAppFeedSort::Recent,
+                None,
+            ),
             "Test Feed".to_string(),
+            "rss".to_string(),
         );
         let feed_id = feed.create_id();
 
@@ -571,13 +653,16 @@ mod tests {
     #[test]
     fn test_validate_tag_too_long() {
         let feed = PubkyAppFeed::new(
-            Some(vec!["a".repeat(VALIDATION_LIMITS.tag_label_max_length + 1)]),
-            None,
-            PubkyAppFeedReach::Following,
-            PubkyAppFeedLayout::Columns,
-            PubkyAppFeedSort::Recent,
-            None,
+            feed_config(
+                Some(vec!["a".repeat(VALIDATION_LIMITS.tag_label_max_length + 1)]),
+                None,
+                PubkyAppFeedReach::Following,
+                PubkyAppFeedLayout::Columns,
+                PubkyAppFeedSort::Recent,
+                None,
+            ),
             "Test Feed".to_string(),
+            "rss".to_string(),
         );
         let feed_id = feed.create_id();
 
@@ -589,13 +674,16 @@ mod tests {
     #[test]
     fn test_validate_tag_with_whitespace() {
         let feed = PubkyAppFeed::new(
-            Some(vec!["bit coin".to_string()]),
-            None,
-            PubkyAppFeedReach::Following,
-            PubkyAppFeedLayout::Columns,
-            PubkyAppFeedSort::Recent,
-            None,
+            feed_config(
+                Some(vec!["bit coin".to_string()]),
+                None,
+                PubkyAppFeedReach::Following,
+                PubkyAppFeedLayout::Columns,
+                PubkyAppFeedSort::Recent,
+                None,
+            ),
             "Test Feed".to_string(),
+            "rss".to_string(),
         );
         let feed_id = feed.create_id();
 
@@ -607,13 +695,16 @@ mod tests {
     #[test]
     fn test_validate_tag_with_invalid_char() {
         let feed = PubkyAppFeed::new(
-            Some(vec!["bitcoin,rust".to_string()]),
-            None,
-            PubkyAppFeedReach::Following,
-            PubkyAppFeedLayout::Columns,
-            PubkyAppFeedSort::Recent,
-            None,
+            feed_config(
+                Some(vec!["bitcoin,rust".to_string()]),
+                None,
+                PubkyAppFeedReach::Following,
+                PubkyAppFeedLayout::Columns,
+                PubkyAppFeedSort::Recent,
+                None,
+            ),
             "Test Feed".to_string(),
+            "rss".to_string(),
         );
         let feed_id = feed.create_id();
 
@@ -625,19 +716,22 @@ mod tests {
     #[test]
     fn test_validate_max_tags() {
         let feed = PubkyAppFeed::new(
-            Some(vec![
-                "tag1".to_string(),
-                "tag2".to_string(),
-                "tag3".to_string(),
-                "tag4".to_string(),
-                "tag5".to_string(),
-            ]),
-            None,
-            PubkyAppFeedReach::Following,
-            PubkyAppFeedLayout::Columns,
-            PubkyAppFeedSort::Recent,
-            None,
+            feed_config(
+                Some(vec![
+                    "tag1".to_string(),
+                    "tag2".to_string(),
+                    "tag3".to_string(),
+                    "tag4".to_string(),
+                    "tag5".to_string(),
+                ]),
+                None,
+                PubkyAppFeedReach::Following,
+                PubkyAppFeedLayout::Columns,
+                PubkyAppFeedSort::Recent,
+                None,
+            ),
             "Test Feed".to_string(),
+            "rss".to_string(),
         );
         let feed_id = feed.create_id();
 
@@ -648,17 +742,20 @@ mod tests {
     #[test]
     fn test_sanitize_filters_empty_tags() {
         let feed = PubkyAppFeed::new(
-            Some(vec![
-                "bitcoin".to_string(),
-                "  ".to_string(), // Empty after trim
-                "rust".to_string(),
-            ]),
-            None,
-            PubkyAppFeedReach::Following,
-            PubkyAppFeedLayout::Columns,
-            PubkyAppFeedSort::Recent,
-            None,
+            feed_config(
+                Some(vec![
+                    "bitcoin".to_string(),
+                    "  ".to_string(), // Empty after trim
+                    "rust".to_string(),
+                ]),
+                None,
+                PubkyAppFeedReach::Following,
+                PubkyAppFeedLayout::Columns,
+                PubkyAppFeedSort::Recent,
+                None,
+            ),
             "Test Feed".to_string(),
+            "rss".to_string(),
         );
 
         assert_eq!(
@@ -681,13 +778,16 @@ mod tests {
 
         for (invalid_tag, expected_error) in invalid_cases {
             let feed = PubkyAppFeed::new(
-                Some(vec![invalid_tag.clone()]),
-                None,
-                PubkyAppFeedReach::Following,
-                PubkyAppFeedLayout::Columns,
-                PubkyAppFeedSort::Recent,
-                None,
+                feed_config(
+                    Some(vec![invalid_tag.clone()]),
+                    None,
+                    PubkyAppFeedReach::Following,
+                    PubkyAppFeedLayout::Columns,
+                    PubkyAppFeedSort::Recent,
+                    None,
+                ),
                 "Test Feed".to_string(),
+                "rss".to_string(),
             );
             let feed_id = feed.create_id();
 
@@ -700,6 +800,169 @@ mod tests {
                 invalid_tag
             );
         }
+    }
+
+    #[test]
+    fn test_icon_json_roundtrip() {
+        let feed_json = r#"
+        {
+            "feed": {
+                "tags": ["rust"],
+                "reach": "all",
+                "layout": "columns",
+                "sort": "recent"
+            },
+            "name": "Rust",
+            "icon": "code-2",
+            "created_at": 1700000000
+        }
+        "#;
+
+        let feed: PubkyAppFeed = serde_json::from_str(feed_json).unwrap();
+        let feed_id = feed.create_id();
+
+        let feed_parsed =
+            <PubkyAppFeed as Validatable>::try_from(feed_json.as_bytes(), &feed_id).unwrap();
+        assert_eq!(feed_parsed.icon, Some("code-2".to_string()));
+
+        let serialized = serde_json::to_value(&feed_parsed).unwrap();
+        assert_eq!(serialized["icon"], "code-2");
+    }
+
+    #[test]
+    fn test_feed_without_icon_stays_valid() {
+        // Feeds stored before `icon` existed carry no icon and must keep
+        // parsing, validating and serializing without one.
+        let feed_json = r#"
+        {
+            "feed": {
+                "tags": ["rust"],
+                "reach": "all",
+                "layout": "columns",
+                "sort": "recent"
+            },
+            "name": "Legacy Feed",
+            "created_at": 1700000000
+        }
+        "#;
+
+        let feed: PubkyAppFeed = serde_json::from_str(feed_json).unwrap();
+        let feed_id = feed.create_id();
+
+        let feed_parsed =
+            <PubkyAppFeed as Validatable>::try_from(feed_json.as_bytes(), &feed_id).unwrap();
+        assert_eq!(feed_parsed.icon, None);
+
+        let serialized = serde_json::to_value(&feed_parsed).unwrap();
+        assert!(serialized.get("icon").is_none());
+    }
+
+    #[test]
+    fn test_feed_with_null_icon_stays_valid() {
+        let feed_json = r#"
+        {
+            "feed": {
+                "tags": ["rust"],
+                "reach": "all",
+                "layout": "columns",
+                "sort": "recent"
+            },
+            "name": "Legacy Feed",
+            "icon": null,
+            "created_at": 1700000000
+        }
+        "#;
+
+        let feed: PubkyAppFeed = serde_json::from_str(feed_json).unwrap();
+        let feed_id = feed.create_id();
+        let feed_parsed =
+            <PubkyAppFeed as Validatable>::try_from(feed_json.as_bytes(), &feed_id).unwrap();
+
+        assert_eq!(feed_parsed.icon, None);
+        let serialized = serde_json::to_value(&feed_parsed).unwrap();
+        assert!(serialized.get("icon").is_none());
+    }
+
+    #[test]
+    fn test_sanitize_icon_lowercases() {
+        let feed = PubkyAppFeed::new(
+            feed_config(
+                None,
+                None,
+                PubkyAppFeedReach::All,
+                PubkyAppFeedLayout::Columns,
+                PubkyAppFeedSort::Recent,
+                None,
+            ),
+            "Mixed Case Icon".to_string(),
+            "  Code-2  ".to_string(),
+        );
+
+        assert_eq!(feed.icon, Some("code-2".to_string()));
+        let feed_id = feed.create_id();
+        assert!(feed.validate(Some(&feed_id)).is_ok());
+    }
+
+    #[test]
+    fn test_validate_icon_errors() {
+        let invalid_cases = vec![
+            ("   ".to_string(), "cannot be empty"),
+            (
+                "a".repeat(VALIDATION_LIMITS.feed_icon_max_length + 1),
+                "exceeds maximum length",
+            ),
+            ("bit coin".to_string(), "invalid character"),
+            ("bitcoin,rust".to_string(), "invalid character"),
+            ("bitcoin_rust".to_string(), "invalid character"),
+        ];
+
+        for (invalid_icon, expected_error) in invalid_cases {
+            let feed = PubkyAppFeed::new(
+                feed_config(
+                    None,
+                    None,
+                    PubkyAppFeedReach::All,
+                    PubkyAppFeedLayout::Columns,
+                    PubkyAppFeedSort::Recent,
+                    None,
+                ),
+                "Test Feed".to_string(),
+                invalid_icon.clone(),
+            );
+            let feed_id = feed.create_id();
+
+            let result = feed.validate(Some(&feed_id));
+            assert!(result.is_err(), "Should reject icon: {}", invalid_icon);
+            assert!(
+                result.unwrap_err().contains(expected_error),
+                "Expected error containing '{}' for icon: {}",
+                expected_error,
+                invalid_icon
+            );
+        }
+    }
+
+    #[test]
+    fn test_icon_does_not_change_feed_id() {
+        let make_feed = |icon: &str| {
+            PubkyAppFeed::new(
+                feed_config(
+                    Some(vec!["rust".to_string()]),
+                    None,
+                    PubkyAppFeedReach::All,
+                    PubkyAppFeedLayout::Columns,
+                    PubkyAppFeedSort::Recent,
+                    None,
+                ),
+                "Rust".to_string(),
+                icon.to_string(),
+            )
+        };
+
+        assert_eq!(
+            make_feed("bitcoin").create_id(),
+            make_feed("rss").create_id()
+        );
     }
 
     #[test]

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,8 +1,10 @@
 use crate::limits::VALIDATION_LIMITS;
 use crate::traits::{HasIdPath, HasPath, HashId, TimestampId, Validatable};
 use crate::*;
+use serde::{Deserialize, Serialize};
 use serde_wasm_bindgen::{from_value, to_value};
 use std::str::FromStr;
+use tsify_next::Tsify;
 use wasm_bindgen::prelude::*;
 
 /// Each FFI function:
@@ -70,6 +72,25 @@ impl Meta {
 pub struct PubkySpecsBuilder {
     #[wasm_bindgen(skip)]
     pubky_id: PubkyId,
+}
+
+/// Creation-only input for a feed. Unlike the stored feed model, `icon` is
+/// required because only legacy stored feeds may omit it.
+#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateFeedInput {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tags: Option<Vec<String>>,
+    reach: String,
+    layout: String,
+    sort: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    content: Option<String>,
+    name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    domain_tags: Option<Vec<String>>,
+    icon: String,
 }
 
 /// A macro to generate result structs and `wasm_bindgen`-exposed getters.
@@ -190,48 +211,26 @@ impl PubkySpecsBuilder {
     // -----------------------------------------------------------------------------
 
     #[wasm_bindgen(js_name = createFeed)]
-    pub fn create_feed(
-        &self,
-        tags: JsValue,
-        reach: String,
-        layout: String,
-        sort: String,
-        content: Option<String>,
-        name: String,
-        domain_tags: JsValue,
-    ) -> Result<FeedResult, String> {
-        let tags_vec: Option<Vec<String>> = if tags.is_null() || tags.is_undefined() {
-            None
-        } else {
-            from_value(tags).map_err(|e| e.to_string())?
-        };
-
-        let domain_tags_vec: Option<Vec<String>> =
-            if domain_tags.is_null() || domain_tags.is_undefined() {
-                None
-            } else {
-                from_value(domain_tags).map_err(|e| e.to_string())?
-            };
-
+    pub fn create_feed(&self, input: CreateFeedInput) -> Result<FeedResult, String> {
         // Use `FromStr` to parse enums
-        let reach = PubkyAppFeedReach::from_str(&reach)?;
-        let layout = PubkyAppFeedLayout::from_str(&layout)?;
-        let sort = PubkyAppFeedSort::from_str(&sort)?;
-        let content = match content {
+        let reach = PubkyAppFeedReach::from_str(&input.reach)?;
+        let layout = PubkyAppFeedLayout::from_str(&input.layout)?;
+        let sort = PubkyAppFeedSort::from_str(&input.sort)?;
+        let content = match input.content {
             Some(val) => Some(PubkyAppPostKind::from_str(&val)?),
             None => None,
         };
 
         // Create the feed
-        let feed = PubkyAppFeed::new(
-            tags_vec,
-            domain_tags_vec,
+        let config = PubkyAppFeedConfig {
+            tags: input.tags,
+            domain_tags: input.domain_tags,
             reach,
             layout,
             sort,
             content,
-            name,
-        );
+        };
+        let feed = PubkyAppFeed::new(config, input.name, input.icon);
 
         let feed_id = feed.create_id();
         feed.validate(Some(&feed_id))?;


### PR DESCRIPTION
* Introduced `icon` as a required field for new feeds, allowing only valid Lucide icon names.
* Updated feed creation methods and examples to include the `icon` parameter.
* Enhanced validation to ensure icons meet specified criteria (length and character restrictions).
* Adjusted documentation to reflect the new requirements and examples.
