### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-app-specs"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky-app-specs"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.89"
 description = "Pubky.app data models with validation, sanitization, and URI helpers"

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For a full homeserver flow, see [`examples/create_user.rs`](https://github.com/p
 | `openapi` | OpenAPI schemas via `utoipa`   |
 
 ```toml
-pubky-app-specs = { version = "0.6", features = ["openapi"] }
+pubky-app-specs = { version = "0.7", features = ["openapi"] }
 ```
 
 - **MSRV:** 1.89 (see `rust-version` in `Cargo.toml`)

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # Data model specification
 
-_Version 0.6.0_
+_Version 0.7.0_
 
 ## Table of Contents
 

--- a/pkg/package.json
+++ b/pkg/package.json
@@ -55,5 +55,5 @@
   "sideEffects": false,
   "type": "module",
   "types": "pubky_app_specs.d.ts",
-  "version": "0.6.2"
+  "version": "0.7.0"
 }


### PR DESCRIPTION
Minor bump instead of patch because #149 changed the signatures of `PubkyAppFeed::new` and the JS `createFeed`, so 0.6.x consumers need code changes when upgrading.

Also fixed the `_Version_` line in SPEC.md, it was stuck at 0.6.0.

Ran locally: clippy, nextest, wasm-pack firefox tests, npm build + mocha, locked checks on native and wasm32, and `cargo publish --dry-run`. All green.