### PR TITLE
chore: bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base32"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.5"
+version = "1.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+checksum = "76ae7bad254120e9e4c63bafc385310756f90c484eac0e36b8317cf09cb92a77"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -448,12 +454,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.6"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto",
@@ -562,20 +568,20 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ed25519"
-version = "3.0.0-rc.4"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e914c7c52decb085cea910552e24c63ac019e3ab8bf001ff736da9a9d9d890"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
  "pkcs8",
- "serde",
+ "serdect",
  "signature",
 ]
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.6"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053618a4c3d3bc24f188aa660ae75a46eeab74ef07fb415c61431e5e7cd4749b"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -1355,12 +1361,11 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mainline"
-version = "6.1.2"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578beb3b6dcbe6f3f60a89547a13b34d36bda41dc056540bac5f4e4340ebf25c"
+checksum = "6dfad9601b9117218868271c05403853593d4817e7abeab5c95e11eee16382bb"
 dependencies = [
  "crc",
- "digest 0.11.3",
  "document-features",
  "dyn-clone",
  "ed25519-dalek",
@@ -1610,9 +1615,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkarr"
-version = "6.0.1"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51c6a54ffd41eaecab1c5736251f48f229638430939fcf1e02a22ddc632471be"
+checksum = "0b8d06aecdd0cb2166c14af7abf72a8e2f125e04071bbed81b69c9b802c2a50a"
 dependencies = [
  "async-compat",
  "base32",
@@ -1621,7 +1626,6 @@ dependencies = [
  "cfg_aliases",
  "document-features",
  "dyn-clone",
- "ed25519",
  "ed25519-dalek",
  "futures-buffered",
  "futures-lite",
@@ -1633,7 +1637,6 @@ dependencies = [
  "mainline",
  "ntimestamp",
  "page_size",
- "pkcs8",
  "reqwest",
  "rustls",
  "rustls-webpki",
@@ -1645,14 +1648,13 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.11"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der",
  "spki",
@@ -1733,10 +1735,11 @@ checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "pubky"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dabfa82f58ad04e2b65fcecc02ca953dec608533dfa820b03ee174b2593e8af"
+checksum = "773c09666db817b1d2cf13866e053b790e95ec99c78385b86fa848d23bb36e70"
 dependencies = [
+ "async-trait",
  "base64",
  "cookie",
  "eventsource-stream",
@@ -1745,10 +1748,13 @@ dependencies = [
  "futures-util",
  "httpdate",
  "log",
+ "percent-encoding",
  "pkarr",
  "pubky-common",
  "reqwest",
  "rustls",
+ "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1760,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-app-specs"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "base32",
@@ -1782,22 +1788,22 @@ dependencies = [
 
 [[package]]
 name = "pubky-common"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7115f4177712ffb1d261e93a9a4992ef12da80c4b70decb1395bf8ac919c24c"
+checksum = "e772ea228e1d7be7590c7a15ce975605df30e257ddeb272be8d6c0c23c98f57c"
 dependencies = [
  "argon2",
- "base32",
+ "base64",
  "blake3",
  "crypto_secretbox",
  "ed25519-dalek",
- "js-sys",
- "once_cell",
+ "percent-encoding",
  "pkarr",
  "postcard",
  "pubky-timestamp",
  "rand 0.10.1",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "url",
 ]
@@ -2308,6 +2314,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct",
+ "serde",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,9 +2367,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.10"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "simple-dns"
@@ -2409,9 +2425,9 @@ checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
-version = "0.8.0-rc.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8baeff88f34ed0691978ec34440140e1572b68c7dd4a495fd14a3dc1944daa80"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
  "der",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-app-specs"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky-app-specs"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 rust-version = "1.89"
 description = "Pubky.app data models with validation, sanitization, and URI helpers"
@@ -30,7 +30,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 url = "2.5.8"
 base32 = "0.5.1"
-blake3 = "1.8.5"
+blake3 = "1.8.6"
 mime = "0.3"
 utoipa = { version = "5.5.0", optional = true }
 
@@ -45,7 +45,7 @@ tsify-next = { version = "0.5.6", default-features = false, features = ["js"] }
 wasm-bindgen-test = "0.3.68"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-pubky = "0.9.1"
+pubky = "0.10.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tokio = { version = "1.52.3", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky-app-specs"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.89"
 description = "Pubky.app data models with validation, sanitization, and URI helpers"

--- a/examples/create_user.rs
+++ b/examples/create_user.rs
@@ -8,7 +8,7 @@ fn main() {
 #[cfg(not(target_arch = "wasm32"))]
 use {
     anyhow::Result,
-    pubky::{Keypair, Pubky, PublicKey},
+    pubky::{ClientId, Keypair, Pubky, PublicKey},
     pubky_app_specs::{traits::HasPath, traits::Validatable, PubkyAppUser},
     serde_json::to_vec,
 };
@@ -45,10 +45,14 @@ async fn main() -> Result<()> {
     // This step will likely fail "as is" as homeservers are now requiring sign up tokens.
     // Here we provide `None` signup token.
     let signer = pubky.signer(keypair);
-    let session = signer
+    signer
         .signup(&homeserver, None)
         .await
         .expect("Failed to sign up the user on the homeserver.");
+    let session = signer
+        .signin(ClientId::new("pubky.app").expect("Invalid client id."))
+        .await
+        .expect("Failed to sign in after signup.");
 
     println!("User signed up successfully!");
 
@@ -86,10 +90,9 @@ async fn main() -> Result<()> {
     // Step 6: Retrieve the user profile from the homeserver
     println!("\nStep 6: Retrieving the user profile from the homeserver...");
 
-    let addr = format!("{}{}", user_id, path);
-    let response = pubky
-        .public_storage()
-        .get(&addr)
+    let response = session
+        .storage()
+        .get(&path)
         .await
         .expect("Failed to retrieve the user profile from the homeserver.");
 

--- a/pkg/package.json
+++ b/pkg/package.json
@@ -55,5 +55,5 @@
   "sideEffects": false,
   "type": "module",
   "types": "pubky_app_specs.d.ts",
-  "version": "0.7.1"
+  "version": "0.8.0"
 }

--- a/pkg/package.json
+++ b/pkg/package.json
@@ -55,5 +55,5 @@
   "sideEffects": false,
   "type": "module",
   "types": "pubky_app_specs.d.ts",
-  "version": "0.7.0"
+  "version": "0.7.1"
 }


### PR DESCRIPTION
## Summary
- Release **0.8.0** (Cargo.toml + pkg/package.json).
- Bump native `pubky` dependency _0.9_ → _0.10_ (and related lockfile deps, including `blake3` 1.8.6).
- Update _examples/create_user.rs_ for the _0.10_ auth flow: `signup` then `signin(ClientId)`, and read the profile back via `session.storage()`.